### PR TITLE
partially re-export url

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,7 +17,10 @@ pub mod cookies {
 
 /// URL records.
 pub mod url {
-    pub use url::*;
+    pub use url::{
+        EncodingOverride, Host, OpaqueOrigin, Origin, ParseError, ParseOptions, PathSegmentsMut,
+        Position, SyntaxViolation, Url, UrlQuery,
+    };
 }
 
 pub mod headers;


### PR DESCRIPTION
The encoding logic felt somewhat out of place, so this patch omits that re-export in favor of the core types only. Thanks!