### PR TITLE
rm set_length from req, add set_len to res

### DIFF
--- a/src/request.rs
+++ b/src/request.rs
@@ -65,12 +65,6 @@ impl Request {
         self
     }
 
-    /// Set the lengths of the body.
-    pub fn set_length(mut self, length: usize) -> Self {
-        self.length = Some(length);
-        self
-    }
-
     /// Set the body as a string.
     ///
     /// # Mime

--- a/src/response.rs
+++ b/src/response.rs
@@ -97,6 +97,12 @@ impl Response {
     pub fn len(&self) -> Option<usize> {
         self.length
     }
+
+    /// Set the length of the body stream.
+    pub fn set_len(mut self, len: usize) -> Self {
+        self.length = Some(len);
+        self
+    }
 }
 
 impl Debug for Response {


### PR DESCRIPTION
We had a duplicate method to set the length on Request, and no method to set it on Response. This
fixes both. Thanks!