### PR TITLE
init error

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -1,0 +1,192 @@
+use std::convert::From;
+use std::error;
+use std::fmt;
+use std::result;
+
+/// A specialized `Result` type for HTTP operations.
+///
+/// This type is broadly used across `http_types` for any operation which may
+/// produce an error.
+pub type Result<T> = result::Result<T, Error>;
+
+/// The error type for HTTP operations.
+pub struct Error {
+    repr: Repr,
+}
+
+impl fmt::Debug for Error {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt::Debug::fmt(&self.repr, f)
+    }
+}
+
+enum Repr {
+    Simple(ErrorKind),
+    Custom(Box<Custom>),
+}
+
+#[derive(Debug)]
+struct Custom {
+    kind: ErrorKind,
+    error: Box<dyn error::Error + Send + Sync>,
+}
+
+/// A list specifying general categories of HTTP errors.
+///
+/// This list is intended to grow over time and it is not recommended to
+/// exhaustively match against it.
+///
+/// It is used with the [`http_types::Error`] type.
+///
+/// [`http_types::Error`]: struct.Error.html
+#[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+#[non_exhaustive]
+pub enum ErrorKind {
+    /// The status code was invalid.
+    InvalidStatusCode,
+
+    /// The method was invalid.
+    InvalidMethod,
+
+    /// The url was invalid.
+    InvalidUrl,
+
+    /// The header name was invalid.
+    InvalidHeaderName,
+
+    /// The header value was invalid.
+    InvalidHeaderValue,
+
+    /// Other error.
+    Other,
+}
+
+impl ErrorKind {
+    pub(crate) fn as_str(&self) -> &'static str {
+        match *self {
+            ErrorKind::InvalidStatusCode => "The status code was invalid.",
+            ErrorKind::InvalidMethod => "The method was invalid.",
+            ErrorKind::InvalidUrl => "The url was invalid.",
+            ErrorKind::InvalidHeaderName => "The header name was invalid.",
+            ErrorKind::InvalidHeaderValue => "The header value was invalid.",
+            ErrorKind::Other => "other error",
+        }
+    }
+}
+
+/// Intended for use for errors not exposed to the user, where allocating onto
+/// the heap (for normal construction via Error::new) is too costly.
+impl From<ErrorKind> for Error {
+    /// Converts an [`ErrorKind`] into an [`Error`].
+    #[inline]
+    fn from(kind: ErrorKind) -> Error {
+        Error {
+            repr: Repr::Simple(kind),
+        }
+    }
+}
+
+impl Error {
+    /// Creates a new HTTP error from a known kind of error as well as an
+    /// arbitrary error payload.
+    ///
+    /// This function is used to generically create HTTP errors which do not
+    /// originate from the OS itself. The `error` argument is an arbitrary
+    /// payload which will be contained in this `Error`.
+    pub fn new<E>(kind: ErrorKind, error: E) -> Error
+    where
+        E: Into<Box<dyn error::Error + Send + Sync>>,
+    {
+        Self::_new(kind, error.into())
+    }
+
+    fn _new(kind: ErrorKind, error: Box<dyn error::Error + Send + Sync>) -> Error {
+        Error {
+            repr: Repr::Custom(Box::new(Custom { kind, error })),
+        }
+    }
+
+    /// Returns a reference to the inner error wrapped by this error (if any).
+    ///
+    /// If this `Error` was constructed via `new` then this function will
+    /// return `Some`, otherwise it will return `None`.
+    pub fn get_ref(&self) -> Option<&(dyn error::Error + Send + Sync + 'static)> {
+        match self.repr {
+            Repr::Simple(..) => None,
+            Repr::Custom(ref c) => Some(&*c.error),
+        }
+    }
+
+    /// Returns a mutable reference to the inner error wrapped by this error
+    /// (if any).
+    ///
+    /// If this `Error` was constructed via `new` then this function will
+    /// return `Some`, otherwise it will return `None`.
+    pub fn get_mut(&mut self) -> Option<&mut (dyn error::Error + Send + Sync + 'static)> {
+        match self.repr {
+            Repr::Simple(..) => None,
+            Repr::Custom(ref mut c) => Some(&mut *c.error),
+        }
+    }
+
+    /// Consumes the `Error`, returning its inner error (if any).
+    ///
+    /// If this `Error` was constructed via `new` then this function will
+    /// return `Some`, otherwise it will return `None`.
+    pub fn into_inner(self) -> Option<Box<dyn error::Error + Send + Sync>> {
+        match self.repr {
+            Repr::Simple(..) => None,
+            Repr::Custom(c) => Some(c.error),
+        }
+    }
+
+    /// Returns the corresponding `ErrorKind` for this error.
+    pub fn kind(&self) -> ErrorKind {
+        match self.repr {
+            Repr::Custom(ref c) => c.kind,
+            Repr::Simple(kind) => kind,
+        }
+    }
+}
+
+impl fmt::Debug for Repr {
+    fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match *self {
+            Repr::Custom(ref c) => fmt::Debug::fmt(&c, fmt),
+            Repr::Simple(kind) => fmt.debug_tuple("Kind").field(&kind).finish(),
+        }
+    }
+}
+
+impl fmt::Display for Error {
+    fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self.repr {
+            Repr::Custom(ref c) => c.error.fmt(fmt),
+            Repr::Simple(kind) => write!(fmt, "{}", kind.as_str()),
+        }
+    }
+}
+
+impl error::Error for Error {
+    fn description(&self) -> &str {
+        match self.repr {
+            Repr::Simple(..) => self.kind().as_str(),
+            Repr::Custom(ref c) => c.error.description(),
+        }
+    }
+
+    #[allow(deprecated)]
+    fn cause(&self) -> Option<&dyn error::Error> {
+        match self.repr {
+            Repr::Simple(..) => None,
+            Repr::Custom(ref c) => c.error.cause(),
+        }
+    }
+
+    fn source(&self) -> Option<&(dyn error::Error + 'static)> {
+        match self.repr {
+            Repr::Simple(..) => None,
+            Repr::Custom(ref c) => c.error.source(),
+        }
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -26,12 +26,14 @@ pub mod url {
 pub mod headers;
 pub mod mime;
 
+mod error;
 mod method;
 mod request;
 mod response;
 mod status_code;
 mod version;
 
+pub use error::{Error, ErrorKind, Result};
 pub use method::Method;
 pub use request::Request;
 pub use response::Response;


### PR DESCRIPTION
Defines our own `Error` + `ErrorKind` pairs, adapted from `std::io::{Error, ErrorKind}`. This would allow us to get rid of all the `ParseErrors` we have, and instead use a unified `http_types::Error` interface for all errors.

This is not complete yet, but should set us up to extend + expand it as time goes on. Thanks!