### PR TITLE
init http docs

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,16 +1,97 @@
-//! HTTP Types.
+//! # Common types for HTTP operations.
 //!
-//! ## Example
+//! `http-types` provides shared types for HTTP operations. It combines a performant, streaming
+//! interface with convenient methods for creating headers, urls, and other standard HTTP types.
+//!
+//! # Example
 //!
 //! ```
+//! # fn main() -> Result<(), http_types::url::ParseError> {
+//! #
 //! use http_types::{Url, Method, Request, Response, StatusCode};
 //!
-//! let mut req = Request::new(Method::Get, Url::parse("https://example.com").unwrap());
-//! req.set_body("hello world");
+//! let mut req = Request::new(Method::Get, Url::parse("https://example.com")?);
+//! req.set_body("Hello, Nori!");
 //!
 //! let mut res = Response::new(StatusCode::Ok);
-//! res.set_body("hello world");
+//! res.set_body("Hello, Chashu!");
+//! #
+//! # Ok(()) }
 //! ```
+//!
+//! # How does HTTP work?
+//!
+//! We couldn't possibly explain _all_ of HTTP here, as there's [5 versions](enum.Version.html) of
+//! the protocol now, and lots of extensions. But at its core there are only a few concepts you
+//! need to know about.
+//!
+//! ```txt
+//!          request
+//! client ----------> server
+//!        <----------
+//!          response
+//! ```
+//!
+//! HTTP is an [RPC protocol](https://en.wikipedia.org/wiki/Remote_procedure_call). A client
+//! creates a [`Request`](struct.Request.html) containing a [`Url`](struct.Url.html),
+//! [`Method`](struct.Method.html), [`Headers`](struct.Headers.html), and optional
+//! [`Body`](struct.Body.html) and sends this to a server. The server then decodes this `Request`,
+//! does some work, and sends back a [`Response`](struct.Response.html).
+//!
+//! The `Url` works as a way to subdivide an IP address/domain into further addressable resources.
+//! The `Method` indicates what kind of operation we're trying perform (get something, submit
+//! something, update something, etc.)
+//!
+//! ```txt
+//!   Request
+//! |-----------------|
+//! | Url             |
+//! | Method          |
+//! | Headers         |
+//! |-----------------|
+//! | Body (optional) |
+//! |-----------------|
+//! ```
+//!
+//! A `Response` consists of a [`StatusCode`](enum.StatusCode.html),
+//! [`Headers`](struct.Headers.html), and optional [`Body`](struct.Body.html). The client then
+//! decodes the `Response`, and can then operate on it. Usually the first thing it does is check
+//! the status code to see if it was successful or not, and then operates on the headers.
+//!
+//! ```txt
+//!      Response
+//! |-----------------|
+//! | StatusCode      |
+//! | Headers         |
+//! |-----------------|
+//! | Body (optional) |
+//! |-----------------|
+//! ```
+//!
+//! Both `Request` and `Response` include [`Headers`](struct.Headers.html). This is like key-value metadata for HTTP
+//! requests. It needs to be encoded in a specific way (all lowercase ASCII, only some special
+//! characters) so we use the [`HeaderName`](headers/struct.HeaderName.html) and
+//! [`HeaderValue`](headers/struct.HeaderValue.html) structs rather than strings to ensure that.
+//! Also another interesting thing about this is that it's valid to have multiple instances of the
+//! same header name. Which is why `Headers` allows inserting multiple values, and always returns a
+//! vector of headers for each key.
+//!
+//! When reading up on HTTP you might frequently hear a lot of jargon related to ther underlying
+//! protocols. But even newer HTTP versions (`HTTP/2`, `HTTP/3`) still fundamentally use the
+//! request/response model we've described so far.
+//!
+//! # The Body Type
+//!
+//! In HTTP [`Body`](struct.Body.html) types are optional. But funamentally they're streams of
+//! bytes with a specific encoding, also known as [`Mime` type](struct.Mime.html). The `Mime` can
+//! be set using the [`set_content_type`](struct.Request.html#method.set_content_type) method, and
+//! there are many different `Mime` types possible.
+//!
+//! `http-types`' `Body` struct can take anything that implements
+//! [`AsyncBufRead`](https://docs.rs/futures/0.3.1/futures/io/trait.AsyncBufRead.html) and stream
+//! it out. Depending on the version of HTTP used, the underlying bytes will be transmitted
+//! differently. But as a rule: if you know the size of the body, it's usually more efficient to
+//! declare it up front. But if you don't, things will still work.
 
 #![forbid(rust_2018_idioms)]
 #![deny(missing_debug_implementations, nonstandard_style)]


### PR DESCRIPTION
Adds some initial docs explaining how HTTP works. Before working on this lib I hadn't realized some of these things; but feel they're really helpful to create a mindset of how to work with HTTP.

Also realized since coming to Rust that a lot of folks don't know how HTTP works in the first place, so having a brief introduction with links to our types can go a long way I think.

Anyway, first step in creating better docs. Hope this good!