### PR TITLE
allow setting http version as None

### DIFF
--- a/src/hyperium_http.rs
+++ b/src/hyperium_http.rs
@@ -96,7 +96,7 @@ impl TryFrom<http::Request<Body>> for Request {
         let url = from_uri_to_url(parts.uri)?;
         let mut req = Request::new(method, url);
         req.set_body(body);
-        req.set_version(parts.version.into());
+        req.set_version(Some(parts.version.into()));
         hyperium_headers_to_headers(parts.headers, req.as_mut());
         Ok(req)
     }
@@ -121,7 +121,7 @@ impl From<http::Response<Body>> for Response {
         let status = parts.status.into();
         let mut res = Response::new(status);
         res.set_body(body);
-        res.set_version(parts.version.into());
+        res.set_version(Some(parts.version.into()));
         hyperium_headers_to_headers(parts.headers, res.as_mut());
         res
     }

--- a/src/request.rs
+++ b/src/request.rs
@@ -143,7 +143,7 @@ impl Request {
     /// let mut req = Request::new(Method::Get, Url::parse("https://example.com")?);
     /// assert_eq!(req.version(), None);
     ///
-    /// req.set_version(Version::Http2_0);
+    /// req.set_version(Some(Version::Http2_0));
     /// assert_eq!(req.version(), Some(Version::Http2_0));
     /// #
     /// # Ok(()) }
@@ -162,12 +162,12 @@ impl Request {
     /// # fn main() -> Result<(), http_types::url::ParseError> {
     /// #
     /// let mut req = Request::new(Method::Get, Url::parse("https://example.com")?);
-    /// req.set_version(Version::Http2_0);
+    /// req.set_version(Some(Version::Http2_0));
     /// #
     /// # Ok(()) }
     /// ```
-    pub fn set_version(&mut self, version: Version) {
-        self.version = Some(version);
+    pub fn set_version(&mut self, version: Option<Version>) {
+        self.version = version;
     }
 
     /// An iterator visiting all header pairs in arbitrary order.

--- a/src/response.rs
+++ b/src/response.rs
@@ -121,7 +121,7 @@ impl Response {
     /// let mut res = Response::new(StatusCode::Ok);
     /// assert_eq!(res.version(), None);
     ///
-    /// res.set_version(Version::Http2_0);
+    /// res.set_version(Some(Version::Http2_0));
     /// assert_eq!(res.version(), Some(Version::Http2_0));
     /// #
     /// # Ok(()) }
@@ -140,12 +140,12 @@ impl Response {
     /// use http_types::{Response, StatusCode, Version};
     ///
     /// let mut res = Response::new(StatusCode::Ok);
-    /// res.set_version(Version::Http2_0);
+    /// res.set_version(Some(Version::Http2_0));
     /// #
     /// # Ok(()) }
     /// ```
-    pub fn set_version(&mut self, version: Version) {
-        self.version = Some(version);
+    pub fn set_version(&mut self, version: Option<Version>) {
+        self.version = version;
     }
 
     /// An iterator visiting all header pairs in arbitrary order.


### PR DESCRIPTION
This allows passing `None` as the http version; which is in line with how many of the `Url` methods work as well. Thanks!