### PR TITLE
Remove safety section from README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,10 +46,6 @@
 $ cargo add http-types
 ```
 
-## Safety
-This crate uses ``#![deny(unsafe_code)]`` to ensure everything is implemented in
-100% Safe Rust.
-
 ## Contributing
 Want to join us? Check out our ["Contributing" guide][contributing] and take a
 look at some of these issues:


### PR DESCRIPTION
There are still some uses of `unsafe` in this crate.