### PR TITLE
Don't move MIME out of the body

### DIFF
--- a/src/body.rs
+++ b/src/body.rs
@@ -52,7 +52,7 @@ pin_project_lite::pin_project! {
     pub struct Body {
         #[pin]
         reader: Box<dyn BufRead + Unpin + Send + Sync + 'static>,
-        mime: Option<Mime>,
+        mime: Mime,
         length: Option<usize>,
     }
 }
@@ -74,7 +74,7 @@ impl Body {
     pub fn empty() -> Self {
         Self {
             reader: Box::new(io::empty()),
-            mime: Some(mime::BYTE_STREAM),
+            mime: mime::BYTE_STREAM,
             length: Some(0),
         }
     }
@@ -104,7 +104,7 @@ impl Body {
     ) -> Self {
         Self {
             reader: Box::new(reader),
-            mime: Some(mime::BYTE_STREAM),
+            mime: mime::BYTE_STREAM,
             length: len,
         }
     }
@@ -147,9 +147,8 @@ impl Body {
         self.reader
     }
 
-    /// Return the mime type.
-    pub(crate) fn take_mime(&mut self) -> Mime {
-        self.mime.take().expect("internal error: missing mime")
+    pub(crate) fn mime(&self) -> &Mime {
+        &self.mime
     }
 }
 
@@ -167,7 +166,7 @@ impl From<String> for Body {
         Self {
             length: Some(s.len()),
             reader: Box::new(io::Cursor::new(s.into_bytes())),
-            mime: Some(string_mime()),
+            mime: string_mime(),
         }
     }
 }
@@ -177,7 +176,7 @@ impl<'a> From<&'a str> for Body {
         Self {
             length: Some(s.len()),
             reader: Box::new(io::Cursor::new(s.to_owned().into_bytes())),
-            mime: Some(string_mime()),
+            mime: string_mime(),
         }
     }
 }
@@ -195,7 +194,7 @@ impl From<Vec<u8>> for Body {
         Self {
             length: Some(b.len()),
             reader: Box::new(io::Cursor::new(b)),
-            mime: Some(mime::BYTE_STREAM),
+            mime: mime::BYTE_STREAM,
         }
     }
 }

--- a/tests/req_res_body.rs
+++ b/tests/req_res_body.rs
@@ -1,0 +1,30 @@
+use async_std::io::prelude::*;
+use http_types::{Body, Method, Request, Response, StatusCode, Url};
+
+#[test]
+fn test_req_res_set_body() {
+    let mut req = Request::new(Method::Get, Url::parse("http://example.com/").unwrap());
+    req.set_body(Body::empty());
+    let mut res = Response::new(StatusCode::Ok);
+    res.set_body(req);
+    let body = async_std::task::block_on(async move {
+        let mut body = Vec::new();
+        res.read_to_end(&mut body).await.unwrap();
+        body
+    });
+    assert!(body.is_empty());
+}
+
+#[test]
+fn test_req_res_take_replace_body() {
+    let mut req = Request::new(Method::Get, Url::parse("http://example.com/").unwrap());
+    req.take_body();
+    let mut res = Response::new(StatusCode::Ok);
+    res.replace_body(req);
+    let body = async_std::task::block_on(async move {
+        let mut body = Vec::new();
+        res.read_to_end(&mut body).await.unwrap();
+        body
+    });
+    assert!(body.is_empty());
+}


### PR DESCRIPTION
This PR fixes the panic when the same `Body` is reused on requests or responses without `Content-Type`.