### PR TITLE
Convert Into impls to equivalent From impls

### DIFF
--- a/src/request.rs
+++ b/src/request.rs
@@ -493,9 +493,9 @@ impl AsMut<Headers> for Request {
     }
 }
 
-impl Into<Body> for Request {
-    fn into(self) -> Body {
-        self.body
+impl From<Request> for Body {
+    fn from(req: Request) -> Body {
+        req.body
     }
 }
 

--- a/src/response.rs
+++ b/src/response.rs
@@ -459,9 +459,9 @@ impl AsMut<Headers> for Response {
     }
 }
 
-impl Into<Body> for Response {
-    fn into(self) -> Body {
-        self.body
+impl From<Response> for Body {
+    fn from(res: Response) -> Body {
+        res.body
     }
 }
 

--- a/src/status_code.rs
+++ b/src/status_code.rs
@@ -460,15 +460,9 @@ impl StatusCode {
     }
 }
 
-impl Into<u16> for StatusCode {
-    fn into(self) -> u16 {
-        self as u16
-    }
-}
-
-impl Into<u16> for &StatusCode {
-    fn into(self) -> u16 {
-        *self as u16
+impl From<StatusCode> for u16 {
+    fn from(code: StatusCode) -> u16 {
+        code as u16
     }
 }
 


### PR DESCRIPTION
To quote the `std::convert::From` doc:

> One should always prefer implementing From over Into because
> implementing From automatically provides one with an implementation of
> Into thanks to the blanket implementation in the standard library.

Given `a: A, b: B`, users will be able to use `A::from(b)` or `b.into()`.