### PR TITLE
Derive `Hash` on `StatusCode`

### DIFF
--- a/src/status_code.rs
+++ b/src/status_code.rs
@@ -5,7 +5,7 @@ use std::fmt::{self, Display};
 /// As defined by [rfc7231 section 6](https://tools.ietf.org/html/rfc7231#section-6).
 /// [Read more](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status)
 #[repr(u16)]
-#[derive(Debug, Clone, Copy, Eq, PartialEq)]
+#[derive(Debug, Clone, Copy, Eq, PartialEq, Hash)]
 pub enum StatusCode {
     /// 100 Continue
     ///


### PR DESCRIPTION
It's convenient for me if I can create `HashMap` or `BTreeMap` for `StatusCode` as a key.
Of course, we can express status code via u16 but it's less informative.

I feel deriving `Ord` for `StatusCode` is not appropriate but I think it's OK that deriving `Hash`.