### PR TITLE
Implement `Clone` for `Request` and `Response`

### DIFF
--- a/src/headers/mod.rs
+++ b/src/headers/mod.rs
@@ -25,7 +25,7 @@ pub use to_header_values::ToHeaderValues;
 pub use values::Values;
 
 /// A collection of HTTP Headers.
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct Headers {
     pub(crate) headers: HashMap<HeaderName, Vec<HeaderValue>>,
 }

--- a/src/request.rs
+++ b/src/request.rs
@@ -486,6 +486,22 @@ impl Request {
     }
 }
 
+impl Clone for Request {
+    /// Clone the request, resolving the body to `Body::empty()` and removing extensions.
+    fn clone(&self) -> Self {
+        Request {
+            method: self.method.clone(),
+            url: self.url.clone(),
+            headers: self.headers.clone(),
+            version: self.version.clone(),
+            sender: self.sender.clone(),
+            receiver: self.receiver.clone(),
+            body: Body::empty(),
+            local: TypeMap::new(),
+        }
+    }
+}
+
 impl Read for Request {
     #[allow(missing_doc_code_examples)]
     fn poll_read(

--- a/src/response.rs
+++ b/src/response.rs
@@ -451,6 +451,21 @@ impl Response {
     }
 }
 
+impl Clone for Response {
+    /// Clone the response, resolving the body to `Body::empty()` and removing extensions.
+    fn clone(&self) -> Self {
+        Self {
+            status: self.status.clone(),
+            headers: self.headers.clone(),
+            version: self.version.clone(),
+            sender: self.sender.clone(),
+            receiver: self.receiver.clone(),
+            body: Body::empty(),
+            local: TypeMap::new(),
+        }
+    }
+}
+
 impl Read for Response {
     #[allow(missing_doc_code_examples)]
     fn poll_read(


### PR DESCRIPTION
 The `Clone` impl resolves the body to `Body::empty()` and removes all extensions (as they are not clonable).

I do not think that it is possible to clone the extensions, as trait objects are too limited at the moment; we can't have `dyn Any + Clone` and we can't downcast to other traits.

This closes #54.