### PR TITLE
Satisfy Clippy where ever possible

### DIFF
--- a/src/body.rs
+++ b/src/body.rs
@@ -126,6 +126,11 @@ impl Body {
         self.length
     }
 
+    /// Returns `true` if the body has a length of zero, and `false` otherwise.
+    pub fn is_empty(&self) -> Option<bool> {
+        self.length.map(|length| length == 0)
+    }
+
     /// Get the inner reader from the `Body`
     ///
     /// # Examples

--- a/src/headers/header_name.rs
+++ b/src/headers/header_name.rs
@@ -74,7 +74,7 @@ impl<'a> std::convert::TryFrom<&'a str> for HeaderName {
 impl PartialEq<str> for HeaderName {
     fn eq(&self, other: &str) -> bool {
         match HeaderName::from_str(other) {
-            Err(_) => return false,
+            Err(_) => false,
             Ok(other) => self == &other,
         }
     }
@@ -83,7 +83,7 @@ impl PartialEq<str> for HeaderName {
 impl<'a> PartialEq<&'a str> for HeaderName {
     fn eq(&self, other: &&'a str) -> bool {
         match HeaderName::from_str(other) {
-            Err(_) => return false,
+            Err(_) => false,
             Ok(other) => self == &other,
         }
     }
@@ -92,7 +92,7 @@ impl<'a> PartialEq<&'a str> for HeaderName {
 impl PartialEq<String> for HeaderName {
     fn eq(&self, other: &String) -> bool {
         match HeaderName::from_str(&other) {
-            Err(_) => return false,
+            Err(_) => false,
             Ok(other) => self == &other,
         }
     }
@@ -101,7 +101,7 @@ impl PartialEq<String> for HeaderName {
 impl<'a> PartialEq<&String> for HeaderName {
     fn eq(&self, other: &&String) -> bool {
         match HeaderName::from_str(other) {
-            Err(_) => return false,
+            Err(_) => false,
             Ok(other) => self == &other,
         }
     }

--- a/src/headers/mod.rs
+++ b/src/headers/mod.rs
@@ -95,7 +95,7 @@ impl Headers {
     }
 
     /// An iterator visiting all header pairs in arbitrary order.
-    pub fn iter<'a>(&'a self) -> Iter<'a> {
+    pub fn iter(&self) -> Iter<'_> {
         Iter {
             inner: self.headers.iter(),
         }
@@ -103,22 +103,28 @@ impl Headers {
 
     /// An iterator visiting all header pairs in arbitrary order, with mutable references to the
     /// values.
-    pub fn iter_mut<'a>(&'a mut self) -> IterMut<'a> {
+    pub fn iter_mut(&mut self) -> IterMut<'_> {
         IterMut {
             inner: self.headers.iter_mut(),
         }
     }
 
     /// An iterator visiting all header names in arbitrary order.
-    pub fn names<'a>(&'a self) -> Names<'a> {
+    pub fn names(&self) -> Names<'_> {
         Names {
             inner: self.headers.keys(),
         }
     }
 
     /// An iterator visiting all header values in arbitrary order.
-    pub fn values<'a>(&'a self) -> Values<'a> {
+    pub fn values(&self) -> Values<'_> {
         Values::new(self.headers.values())
+    }
+}
+
+impl Default for Headers {
+    fn default() -> Self {
+        Self::new()
     }
 }
 

--- a/src/headers/mod.rs
+++ b/src/headers/mod.rs
@@ -122,12 +122,6 @@ impl Headers {
     }
 }
 
-impl Default for Headers {
-    fn default() -> Self {
-        Self::new()
-    }
-}
-
 impl IntoIterator for Headers {
     type Item = (HeaderName, Vec<HeaderValue>);
     type IntoIter = IntoIter;

--- a/src/headers/values.rs
+++ b/src/headers/values.rs
@@ -27,13 +27,10 @@ impl<'a> Iterator for Values<'a> {
     fn next(&mut self) -> Option<Self::Item> {
         loop {
             // Check if we have a vec in the current slot, and if not set one.
-            if let None = self.slot {
-                let next = self.inner.next();
-                if next.is_none() {
-                    return None;
-                }
+            if self.slot.is_none() {
+                let next = self.inner.next()?;
                 self.cursor = 0;
-                self.slot = next;
+                self.slot = Some(next);
             }
 
             // Get the next item

--- a/src/mime/parse.rs
+++ b/src/mime/parse.rs
@@ -68,7 +68,7 @@ pub(crate) fn parse(s: &str) -> crate::Result<Mime> {
     // ```
     loop {
         // Stop parsing if there's no more bytes to consume.
-        if s.fill_buf().unwrap().len() == 0 {
+        if s.fill_buf().unwrap().is_empty() {
             break;
         }
 
@@ -121,9 +121,8 @@ pub(crate) fn parse(s: &str) -> crate::Result<Mime> {
         param_value.make_ascii_lowercase();
 
         // Insert attribute pair into hashmap.
-        if let None = mime.parameters {
-            mime.parameters = Some(HashMap::new());
-        }
+        mime.parameters.get_or_insert_with(HashMap::new);
+
         mime.parameters
             .as_mut()
             .unwrap()

--- a/src/request.rs
+++ b/src/request.rs
@@ -318,6 +318,11 @@ impl Request {
         self.body.len()
     }
 
+    /// Returns `true` if the request has a set body stream length of zero, `false` otherwise.
+    pub fn is_empty(&self) -> Option<bool> {
+        self.body.is_empty()
+    }
+
     /// Get the HTTP version, if one has been set.
     ///
     /// # Examples
@@ -400,7 +405,7 @@ impl Request {
     /// ```
     pub fn cookie(&self, name: &str) -> Result<Option<Cookie<'_>>, crate::Error> {
         let cookies = self.cookies()?;
-        let cookie = cookies.into_iter().filter(|c| c.name() == name).next();
+        let cookie = cookies.into_iter().find(|c| c.name() == name);
         Ok(cookie)
     }
 
@@ -440,23 +445,23 @@ impl Request {
     }
 
     /// An iterator visiting all header pairs in arbitrary order.
-    pub fn iter<'a>(&'a self) -> headers::Iter<'a> {
+    pub fn iter(&self) -> headers::Iter<'_> {
         self.headers.iter()
     }
 
     /// An iterator visiting all header pairs in arbitrary order, with mutable references to the
     /// values.
-    pub fn iter_mut<'a>(&'a mut self) -> headers::IterMut<'a> {
+    pub fn iter_mut(&mut self) -> headers::IterMut<'_> {
         self.headers.iter_mut()
     }
 
     /// An iterator visiting all header names in arbitrary order.
-    pub fn header_names<'a>(&'a self) -> Names<'a> {
+    pub fn header_names(&self) -> Names<'_> {
         self.headers.names()
     }
 
     /// An iterator visiting all header values in arbitrary order.
-    pub fn header_values<'a>(&'a self) -> Values<'a> {
+    pub fn header_values(&self) -> Values<'_> {
         self.headers.values()
     }
 

--- a/src/response.rs
+++ b/src/response.rs
@@ -278,6 +278,11 @@ impl Response {
         self.body.len()
     }
 
+    /// Returns `true` if the set length of the body stream is zero, `false` otherwise.
+    pub fn is_empty(&self) -> Option<bool> {
+        self.body.is_empty()
+    }
+
     /// Get the HTTP version, if one has been set.
     ///
     /// # Examples
@@ -365,7 +370,7 @@ impl Response {
     /// ```
     pub fn cookie(&self, name: &str) -> Result<Option<Cookie<'_>>, crate::Error> {
         let cookies = self.cookies()?;
-        let cookie = cookies.into_iter().filter(|c| c.name() == name).next();
+        let cookie = cookies.into_iter().find(|c| c.name() == name);
         Ok(cookie)
     }
 
@@ -405,23 +410,23 @@ impl Response {
     }
 
     /// An iterator visiting all header pairs in arbitrary order.
-    pub fn iter<'a>(&'a self) -> headers::Iter<'a> {
+    pub fn iter(&self) -> headers::Iter<'_> {
         self.headers.iter()
     }
 
     /// An iterator visiting all header pairs in arbitrary order, with mutable references to the
     /// values.
-    pub fn iter_mut<'a>(&'a mut self) -> headers::IterMut<'a> {
+    pub fn iter_mut(&mut self) -> headers::IterMut<'_> {
         self.headers.iter_mut()
     }
 
     /// An iterator visiting all header names in arbitrary order.
-    pub fn header_names<'a>(&'a self) -> Names<'a> {
+    pub fn header_names(&self) -> Names<'_> {
         self.headers.names()
     }
 
     /// An iterator visiting all header values in arbitrary order.
-    pub fn header_values<'a>(&'a self) -> Values<'a> {
+    pub fn header_values(&self) -> Values<'_> {
         self.headers.values()
     }
 

--- a/src/trailers.rs
+++ b/src/trailers.rs
@@ -152,12 +152,6 @@ impl Trailers {
     }
 }
 
-impl Default for Trailers {
-    fn default() -> Self {
-        Self::new()
-    }
-}
-
 impl Clone for Trailers {
     fn clone(&self) -> Self {
         Self {

--- a/src/trailers.rs
+++ b/src/trailers.rs
@@ -131,24 +131,30 @@ impl Trailers {
     }
 
     /// An iterator visiting all header pairs in arbitrary order.
-    pub fn iter<'a>(&'a self) -> Iter<'a> {
+    pub fn iter(&self) -> Iter<'_> {
         self.headers.iter()
     }
 
     /// An iterator visiting all header pairs in arbitrary order, with mutable references to the
     /// values.
-    pub fn iter_mut<'a>(&'a mut self) -> IterMut<'a> {
+    pub fn iter_mut(&mut self) -> IterMut<'_> {
         self.headers.iter_mut()
     }
 
     /// An iterator visiting all header names in arbitrary order.
-    pub fn names<'a>(&'a self) -> Names<'a> {
+    pub fn names(&self) -> Names<'_> {
         self.headers.names()
     }
 
     /// An iterator visiting all header values in arbitrary order.
-    pub fn values<'a>(&'a self) -> Values<'a> {
+    pub fn values(&self) -> Values<'_> {
         self.headers.values()
+    }
+}
+
+impl Default for Trailers {
+    fn default() -> Self {
+        Self::new()
     }
 }
 

--- a/src/type_map.rs
+++ b/src/type_map.rs
@@ -31,7 +31,7 @@ impl TypeMap {
     /// If a value of this type already exists, it will be returned.
     pub fn insert<T: Send + Sync + 'static>(&mut self, val: T) -> Option<T> {
         self.map
-            .get_or_insert_with(|| Default::default())
+            .get_or_insert_with(Default::default)
             .insert(TypeId::of::<T>(), Box::new(val))
             .and_then(|boxed| (boxed as Box<dyn Any>).downcast().ok().map(|boxed| *boxed))
     }


### PR DESCRIPTION
Changes include:
- Adding `is_empty` methods as well as `len` methods.
- Removing explicit lifetimes
- Adding `Default` impls for `Headers` and `Trailers`
- A few other minor changes that Clippy suggested.

I did not follow all the lints and make breaking changes.