### PR TITLE
Implement TryFrom<&'a str> for HeaderValue and Method

### DIFF
--- a/src/headers/header_value.rs
+++ b/src/headers/header_value.rs
@@ -82,6 +82,14 @@ impl FromStr for HeaderValue {
     }
 }
 
+impl<'a> std::convert::TryFrom<&'a str> for HeaderValue {
+    type Error = Error;
+
+    fn try_from(value: &'a str) -> Result<Self, Self::Error> {
+        Self::from_str(value)
+    }
+}
+
 impl Display for HeaderValue {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{}", self.inner)

--- a/src/method.rs
+++ b/src/method.rs
@@ -84,3 +84,11 @@ impl FromStr for Method {
         }
     }
 }
+
+impl<'a> std::convert::TryFrom<&'a str> for Method {
+    type Error = crate::Error;
+
+    fn try_from(value: &'a str) -> Result<Self, Self::Error> {
+        Self::from_str(value)
+    }
+}


### PR DESCRIPTION
It defers to the existing implementations of `FromStr`.
This provides symmetry with what is done for `HeaderName`.