### PR TITLE
add security submodule

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,18 +16,19 @@ default = []
 hyperium_http = ["http"]
 
 [dependencies]
-anyhow = "1.0.26"
-cookie = "0.12.0"
-infer = "0.1.2"
-omnom = "2.1.1"
-pin-project-lite = "0.1.0"
-url = "2.1.0"
 
 # Note(yoshuawuyts): used for async_std's `channel` only; use "core" once possible.
 async-std = { version = "1.4.0", features = ["unstable"] }
 
 # features: hyperium/http
 http = { version = "0.2.0", optional = true }
+
+anyhow = "1.0.26"
+cookie = "0.12.0"
+infer = "0.1.2"
+omnom = "2.1.1"
+pin-project-lite = "0.1.0"
+url = "2.1.0"
 
 [dev-dependencies]
 http = "0.2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,8 @@ infer = "0.1.2"
 omnom = "2.1.1"
 pin-project-lite = "0.1.0"
 url = "2.1.0"
+serde_json = "1.0.51"
+serde = { version = "1.0", features = ["derive"] }
 
 [dev-dependencies]
 http = "0.2.0"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -93,7 +93,6 @@
 //! differently. But as a rule: if you know the size of the body, it's usually more efficient to
 //! declare it up front. But if you don't, things will still work.
 
-#![forbid(rust_2018_idioms)]
 #![deny(missing_debug_implementations, nonstandard_style)]
 #![warn(missing_docs, missing_doc_code_examples, unreachable_pub)]
 #![cfg_attr(test, deny(warnings))]
@@ -151,6 +150,8 @@ pub use crate::cookies::Cookie;
 
 #[doc(inline)]
 pub mod trailers;
+
+pub mod security;
 
 #[cfg(feature = "hyperium_http")]
 mod hyperium_http;

--- a/src/security/csp.rs
+++ b/src/security/csp.rs
@@ -1,0 +1,356 @@
+use crate::Headers;
+use serde::Serialize;
+use std::collections::HashMap;
+use std::fmt;
+
+/// Define source value
+///
+/// [read more](https://content-security-policy.com)
+#[derive(Debug)]
+pub enum Source {
+    /// Set source `'self'`
+    SameOrigin,
+    /// Set source `'src'`
+    SRC,
+    /// Set source `'none'`
+    None,
+    /// Set source `'unsafe-inline'`
+    UnsafeInline,
+    /// Set source `data:`
+    Data,
+    /// Set source `mediastream:`
+    Mediastream,
+    /// Set source `https:`
+    HTTPS,
+    /// Set source `blob:`
+    Blob,
+    /// Set source `filesystem:`
+    Filesystem,
+    /// Set source `'strict-dynamic'`
+    StrictDynamic,
+    /// Set source `'unsafe-eval'`
+    UnsafeEval,
+    /// Set source `*`
+    Wildcard,
+}
+
+impl fmt::Display for Source {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match *self {
+            Source::SameOrigin => write!(f, "'self'"),
+            Source::SRC => write!(f, "'src'"),
+            Source::None => write!(f, "'none'"),
+            Source::UnsafeInline => write!(f, "'unsafe-inline'"),
+            Source::Data => write!(f, "data:"),
+            Source::Mediastream => write!(f, "mediastream:"),
+            Source::HTTPS => write!(f, "https:"),
+            Source::Blob => write!(f, "blob:"),
+            Source::Filesystem => write!(f, "filesystem:"),
+            Source::StrictDynamic => write!(f, "'strict-dynamic'"),
+            Source::UnsafeEval => write!(f, "'unsafe-eval'"),
+            Source::Wildcard => write!(f, "*"),
+        }
+    }
+}
+
+impl AsRef<str> for Source {
+    fn as_ref(&self) -> &str {
+        match *self {
+            Source::SameOrigin => "'self'",
+            Source::SRC => "'src'",
+            Source::None => "'none'",
+            Source::UnsafeInline => "'unsafe-inline'",
+            Source::Data => "data:",
+            Source::Mediastream => "mediastream:",
+            Source::HTTPS => "https:",
+            Source::Blob => "blob:",
+            Source::Filesystem => "filesystem:",
+            Source::StrictDynamic => "'strict-dynamic'",
+            Source::UnsafeEval => "'unsafe-eval'",
+            Source::Wildcard => "*",
+        }
+    }
+}
+
+/// Define `report-to` directive value
+///
+/// [MDN | report-to](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/report-to)
+#[derive(Serialize, Debug)]
+pub struct ReportTo {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    group: Option<String>,
+    max_age: i32,
+    endpoints: Vec<ReportToEndpoint>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    include_subdomains: Option<bool>,
+}
+
+/// Define `endpoints` for `report-to` directive value
+///
+/// [MDN | report-to](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/report-to)
+#[derive(Serialize, Debug)]
+pub struct ReportToEndpoint {
+    url: String,
+}
+
+/// Build a `Content-Security-Policy` header.
+///
+/// `Content-Security-Policy` (CSP) HTTP headers are used to prevent cross-site
+/// injections. [Read more](https://helmetjs.github.io/docs/csp/)
+///
+/// [Mozilla Developer Network](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy)
+///
+/// # Examples
+///
+/// ```
+/// let mut policy = http_types::security::new()
+///     .default_src(http_types::security::Source::SameOrigin)
+///     .default_src("areweasyncyet.rs")
+///     .script_src(http_types::security::Source::SameOrigin)
+///     .object_src(http_types::security::Source::None)
+///     .base_uri(http_types::security::Source::None)
+///     .upgrade_insecure_requests();
+///
+/// let mut headers = http::Headers::new();
+/// policy.apply(&mut headers);
+///
+/// assert_eq!(headers["content-security-policy"], "base-uri 'none'; default-src 'self' areweasyncyet.rs; object-src 'none'; script-src 'self'; upgrade-insecure-requests");
+/// ```
+
+#[derive(Debug)]
+pub struct ContentSecurityPolicy {
+    policy: Vec<String>,
+    report_only_flag: bool,
+    directives: HashMap<String, Vec<String>>,
+}
+
+impl Default for ContentSecurityPolicy {
+    /// Sets the Content-Security-Policy default to "script-src 'self'; object-src 'self'"
+    fn default() -> Self {
+        let policy = String::from("script-src 'self'; object-src 'self'");
+        ContentSecurityPolicy {
+            policy: vec![policy],
+            report_only_flag: false,
+            directives: HashMap::new(),
+        }
+    }
+}
+
+impl ContentSecurityPolicy {
+    /// Create a new instance.
+    pub fn new() -> Self {
+        Self {
+            policy: Vec::new(),
+            report_only_flag: false,
+            directives: HashMap::new(),
+        }
+    }
+
+    fn insert_directive<T: AsRef<str>>(&mut self, directive: &str, source: T) {
+        let directive = String::from(directive);
+        let directives = self.directives.entry(directive).or_insert_with(Vec::new);
+        let source: String = source.as_ref().to_string();
+        directives.push(source);
+    }
+
+    /// Defines the Content-Security-Policy `base-uri` directive
+    ///
+    /// [MDN | base-uri](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/base-uri)
+    pub fn base_uri<T: AsRef<str>>(&mut self, source: T) -> &mut Self {
+        self.insert_directive("base-uri", source);
+        self
+    }
+
+    /// Defines the Content-Security-Policy `block-all-mixed-content` directive
+    ///
+    /// [MDN | block-all-mixed-content](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/block-all-mixed-content)
+    pub fn block_all_mixed_content(&mut self) -> &mut Self {
+        let policy = String::from("block-all-mixed-content");
+        self.policy.push(policy);
+        self
+    }
+
+    /// Defines the Content-Security-Policy `connect-src` directive
+    ///
+    /// [MDN | connect-src](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/connect-src)
+    pub fn connect_src<T: AsRef<str>>(&mut self, source: T) -> &mut Self {
+        self.insert_directive("connect-src", source);
+        self
+    }
+
+    /// Defines the Content-Security-Policy `default-src` directive
+    ///
+    /// [MDN | default-src](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/default-src)
+    pub fn default_src<T: AsRef<str>>(&mut self, source: T) -> &mut Self {
+        self.insert_directive("default-src", source);
+        self
+    }
+
+    /// Defines the Content-Security-Policy `font-src` directive
+    ///
+    /// [MDN | font-src](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/font-src)
+    pub fn font_src<T: AsRef<str>>(&mut self, source: T) -> &mut Self {
+        self.insert_directive("font-src", source);
+        self
+    }
+
+    /// Defines the Content-Security-Policy `form-action` directive
+    ///
+    /// [MDN | form-action](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/form-action)
+    pub fn form_action<T: AsRef<str>>(&mut self, source: T) -> &mut Self {
+        self.insert_directive("form-action", source);
+        self
+    }
+
+    /// Defines the Content-Security-Policy `frame-ancestors` directive
+    ///
+    /// [MDN | frame-ancestors](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/frame-ancestors)
+    pub fn frame_ancestors<T: AsRef<str>>(&mut self, source: T) -> &mut Self {
+        self.insert_directive("frame-ancestors", source);
+        self
+    }
+
+    /// Defines the Content-Security-Policy `frame-src` directive
+    ///
+    /// [MDN | frame-src](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/frame-src)
+    pub fn frame_src<T: AsRef<str>>(&mut self, source: T) -> &mut Self {
+        self.insert_directive("frame-src", source);
+        self
+    }
+
+    /// Defines the Content-Security-Policy `img-src` directive
+    ///
+    /// [MDN | img-src](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/img-src)
+    pub fn img_src<T: AsRef<str>>(&mut self, source: T) -> &mut Self {
+        self.insert_directive("img-src", source);
+        self
+    }
+
+    /// Defines the Content-Security-Policy `media-src` directive
+    ///
+    /// [MDN | media-src](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/media-src)
+    pub fn media_src<T: AsRef<str>>(&mut self, source: T) -> &mut Self {
+        self.insert_directive("media-src", source);
+        self
+    }
+
+    /// Defines the Content-Security-Policy `object-src` directive
+    ///
+    /// [MDN | object-src](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/object-src)
+    pub fn object_src<T: AsRef<str>>(&mut self, source: T) -> &mut Self {
+        self.insert_directive("object-src", source);
+        self
+    }
+
+    /// Defines the Content-Security-Policy `plugin-types` directive
+    ///
+    /// [MDN | plugin-types](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/plugin-types)
+    pub fn plugin_types<T: AsRef<str>>(&mut self, source: T) -> &mut Self {
+        self.insert_directive("plugin-types", source);
+        self
+    }
+
+    /// Defines the Content-Security-Policy `require-sri-for` directive
+    ///
+    /// [MDN | require-sri-for](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/require-sri-for)
+    pub fn require_sri_for<T: AsRef<str>>(&mut self, source: T) -> &mut Self {
+        self.insert_directive("require-sri-for ", source);
+        self
+    }
+
+    /// Defines the Content-Security-Policy `report-uri` directive
+    ///
+    /// [MDN | report-uri](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/report-uri)
+    pub fn report_uri<T: AsRef<str>>(&mut self, uri: T) -> &mut Self {
+        self.insert_directive("report-uri", uri);
+        self
+    }
+
+    /// Defines the Content-Security-Policy `report-to` directive
+    ///
+    /// [MDN | report-to](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/report-to)
+    pub fn report_to(&mut self, endpoints: Vec<ReportTo>) -> &mut Self {
+        for endpoint in endpoints.iter() {
+            match serde_json::to_string(&endpoint) {
+                Ok(json) => {
+                    let policy = format!("report-to {}", json);
+                    self.policy.push(policy);
+                }
+                Err(error) => {
+                    println!("{:?}", error);
+                }
+            }
+        }
+        self
+    }
+
+    /// Defines the Content-Security-Policy `sandbox` directive
+    ///
+    /// [MDN | sandbox](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/sandbox)
+    pub fn sandbox<T: AsRef<str>>(&mut self, source: T) -> &mut Self {
+        self.insert_directive("sandbox", source);
+        self
+    }
+
+    /// Defines the Content-Security-Policy `script-src` directive
+    ///
+    /// [MDN | script-src](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/script-src)
+    pub fn script_src<T: AsRef<str>>(&mut self, source: T) -> &mut Self {
+        self.insert_directive("script-src", source);
+        self
+    }
+
+    /// Defines the Content-Security-Policy `style-src` directive
+    ///
+    /// [MDN | style-src](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/style-src)
+    pub fn style_src<T: AsRef<str>>(&mut self, source: T) -> &mut Self {
+        self.insert_directive("style-src", source);
+        self
+    }
+
+    /// Defines the Content-Security-Policy `upgrade-insecure-requests` directive
+    ///
+    /// [MDN | upgrade-insecure-requests](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/upgrade-insecure-requests)
+    pub fn upgrade_insecure_requests(&mut self) -> &mut Self {
+        let policy = String::from("upgrade-insecure-requests");
+        self.policy.push(policy);
+        self
+    }
+
+    /// Defines the Content-Security-Policy `worker-src` directive
+    ///
+    /// [MDN | worker-src](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/worker-src)
+    pub fn worker_src<T: AsRef<str>>(&mut self, source: T) -> &mut Self {
+        self.insert_directive("worker-src", source);
+        self
+    }
+
+    /// Change the header to `Content-Security-Policy-Report-Only`
+    pub fn report_only(&mut self) -> &mut Self {
+        self.report_only_flag = true;
+        self
+    }
+
+    /// Create and retrieve the policy value
+    fn value(&mut self) -> String {
+        for (directive, sources) in &self.directives {
+            let policy = format!("{} {}", directive, sources.join(" "));
+            self.policy.push(policy);
+            self.policy.sort();
+        }
+        self.policy.join("; ")
+    }
+
+    /// Sets the `Content-Security-Policy` (CSP) HTTP header to prevent cross-site injections
+    pub fn apply(&mut self, mut headers: impl AsMut<Headers>) {
+        let name = if self.report_only_flag {
+            "Content-Security-Policy-Report-Only"
+        } else {
+            "Content-Security-Policy"
+        };
+        headers
+            .as_mut()
+            .insert(name, self.value().to_owned())
+            .unwrap();
+    }
+}

--- a/src/security/csp.rs
+++ b/src/security/csp.rs
@@ -1,17 +1,17 @@
 use crate::Headers;
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::fmt;
 
 /// Define source value
 ///
 /// [read more](https://content-security-policy.com)
-#[derive(Debug)]
+#[derive(Debug, PartialEq, Eq, Copy, Clone, Hash)]
 pub enum Source {
     /// Set source `'self'`
     SameOrigin,
     /// Set source `'src'`
-    SRC,
+    Src,
     /// Set source `'none'`
     None,
     /// Set source `'unsafe-inline'`
@@ -21,7 +21,7 @@ pub enum Source {
     /// Set source `mediastream:`
     Mediastream,
     /// Set source `https:`
-    HTTPS,
+    Https,
     /// Set source `blob:`
     Blob,
     /// Set source `filesystem:`
@@ -38,12 +38,12 @@ impl fmt::Display for Source {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match *self {
             Source::SameOrigin => write!(f, "'self'"),
-            Source::SRC => write!(f, "'src'"),
+            Source::Src => write!(f, "'src'"),
             Source::None => write!(f, "'none'"),
             Source::UnsafeInline => write!(f, "'unsafe-inline'"),
             Source::Data => write!(f, "data:"),
             Source::Mediastream => write!(f, "mediastream:"),
-            Source::HTTPS => write!(f, "https:"),
+            Source::Https => write!(f, "https:"),
             Source::Blob => write!(f, "blob:"),
             Source::Filesystem => write!(f, "filesystem:"),
             Source::StrictDynamic => write!(f, "'strict-dynamic'"),
@@ -57,12 +57,12 @@ impl AsRef<str> for Source {
     fn as_ref(&self) -> &str {
         match *self {
             Source::SameOrigin => "'self'",
-            Source::SRC => "'src'",
+            Source::Src => "'src'",
             Source::None => "'none'",
             Source::UnsafeInline => "'unsafe-inline'",
             Source::Data => "data:",
             Source::Mediastream => "mediastream:",
-            Source::HTTPS => "https:",
+            Source::Https => "https:",
             Source::Blob => "blob:",
             Source::Filesystem => "filesystem:",
             Source::StrictDynamic => "'strict-dynamic'",
@@ -75,7 +75,7 @@ impl AsRef<str> for Source {
 /// Define `report-to` directive value
 ///
 /// [MDN | report-to](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/report-to)
-#[derive(Serialize, Debug)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub struct ReportTo {
     #[serde(skip_serializing_if = "Option::is_none")]
     group: Option<String>,
@@ -88,7 +88,7 @@ pub struct ReportTo {
 /// Define `endpoints` for `report-to` directive value
 ///
 /// [MDN | report-to](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/report-to)
-#[derive(Serialize, Debug)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub struct ReportToEndpoint {
     url: String,
 }
@@ -127,7 +127,7 @@ pub struct ReportToEndpoint {
 /// let header = headers.iter().next().unwrap();
 /// assert_eq!(header, "base-uri 'none'; default-src 'self' areweasyncyet.rs; object-src 'none'; script-src 'self' 'unsafe-inline'; upgrade-insecure-requests");
 /// ```
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ContentSecurityPolicy {
     policy: Vec<String>,
     report_only_flag: bool,

--- a/src/security/csp.rs
+++ b/src/security/csp.rs
@@ -127,7 +127,6 @@ pub struct ReportToEndpoint {
 /// let header = headers.iter().next().unwrap();
 /// assert_eq!(header, "base-uri 'none'; default-src 'self' areweasyncyet.rs; object-src 'none'; script-src 'self' 'unsafe-inline'; upgrade-insecure-requests");
 /// ```
-
 #[derive(Debug)]
 pub struct ContentSecurityPolicy {
     policy: Vec<String>,
@@ -265,7 +264,7 @@ impl ContentSecurityPolicy {
     ///
     /// [MDN | require-sri-for](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/require-sri-for)
     pub fn require_sri_for<T: AsRef<str>>(&mut self, source: T) -> &mut Self {
-        self.insert_directive("require-sri-for ", source);
+        self.insert_directive("require-sri-for", source);
         self
     }
 

--- a/src/security/csp.rs
+++ b/src/security/csp.rs
@@ -103,18 +103,29 @@ pub struct ReportToEndpoint {
 /// # Examples
 ///
 /// ```
-/// let mut policy = http_types::security::new()
-///     .default_src(http_types::security::Source::SameOrigin)
+/// use http_types::{headers, security, Response, StatusCode};
+///
+/// let mut policy = security::ContentSecurityPolicy::new();
+/// policy
+///     .default_src(security::Source::SameOrigin)
 ///     .default_src("areweasyncyet.rs")
-///     .script_src(http_types::security::Source::SameOrigin)
-///     .object_src(http_types::security::Source::None)
-///     .base_uri(http_types::security::Source::None)
+///     .script_src(security::Source::SameOrigin)
+///     .script_src(security::Source::UnsafeInline)
+///     .object_src(security::Source::None)
+///     .base_uri(security::Source::None)
 ///     .upgrade_insecure_requests();
 ///
-/// let mut headers = http::Headers::new();
-/// policy.apply(&mut headers);
+/// let mut res = Response::new(StatusCode::Ok);
+/// res.set_body("Hello, Chashu!");
 ///
-/// assert_eq!(headers["content-security-policy"], "base-uri 'none'; default-src 'self' areweasyncyet.rs; object-src 'none'; script-src 'self'; upgrade-insecure-requests");
+/// security::default(&mut res);
+/// policy.apply(&mut res);
+///
+/// let name =
+///     headers::HeaderName::from_ascii("content-security-policy".to_owned().into_bytes()).unwrap();
+/// let headers = res.header(&name).unwrap();
+/// let header = headers.iter().next().unwrap();
+/// assert_eq!(header, "base-uri 'none'; default-src 'self' areweasyncyet.rs; object-src 'none'; script-src 'self' 'unsafe-inline'; upgrade-insecure-requests");
 /// ```
 
 #[derive(Debug)]

--- a/src/security/mod.rs
+++ b/src/security/mod.rs
@@ -1,0 +1,210 @@
+//! HTTP Security Headers.
+//!
+//! Adapted from [helmetjs](https://helmetjs.github.io/).
+//!
+//! ## Example
+//! ```
+//! let mut headers = http::Headers::new();
+//! http_types::security::default(&mut headers);
+//! assert_eq!(headers["X-Content-Type-Options"], "nosniff");
+//! assert_eq!(headers["X-XSS-Protection"], "1; mode=block");
+//! ```
+use crate::headers::{HeaderName, Headers};
+pub use csp::{ContentSecurityPolicy, ReportTo, ReportToEndpoint, Source};
+
+mod csp;
+
+/// Apply a set of default protections.
+///
+/// ## Examples
+/// ```
+/// let mut headers = http::Headers::new();
+/// http_types::security::default(&mut headers);
+/// assert_eq!(headers["X-Content-Type-Options"], "nosniff");
+/// assert_eq!(headers["X-XSS-Protection"], "1; mode=block");
+/// ```
+pub fn default(mut headers: impl AsMut<Headers>) {
+    dns_prefetch_control(&mut headers);
+    nosniff(&mut headers);
+    frameguard(&mut headers, None);
+    hide_powered_by(&mut headers);
+    hsts(&mut headers);
+    xss_filter(&mut headers);
+}
+
+/// Disable browsers’ DNS prefetching by setting the `X-DNS-Prefetch-Control` header.
+///
+/// [read more](https://helmetjs.github.io/docs/dns-prefetch-control/)
+///
+/// ## Examples
+/// ```
+/// let mut headers = http::Headers::new();
+/// http_types::security::dns_prefetch_control(&mut headers);
+/// assert_eq!(headers["X-DNS-Prefetch-Control"], "on");
+/// ```
+#[inline]
+pub fn dns_prefetch_control(mut headers: impl AsMut<Headers>) {
+    headers
+        .as_mut()
+        .insert("X-DNS-Prefetch-Control", "on")
+        .unwrap();
+}
+
+/// Set the frameguard level.
+#[derive(Debug, Clone)]
+pub enum FrameOptions {
+    /// Set to `sameorigin`
+    SameOrigin,
+    /// Set to `deny`
+    Deny,
+}
+
+/// Mitigates clickjacking attacks by setting the `X-Frame-Options` header.
+///
+/// [read more](https://helmetjs.github.io/docs/frameguard/)
+///
+/// ## Examples
+/// ```
+/// let mut headers = http::Headers::new();
+/// http_types::security::frameguard(&mut headers, None);
+/// assert_eq!(headers["X-Frame-Options"], "sameorigin");
+/// ```
+#[inline]
+pub fn frameguard(mut headers: impl AsMut<Headers>, guard: Option<FrameOptions>) {
+    let kind = match guard {
+        None | Some(FrameOptions::SameOrigin) => "sameorigin",
+        Some(FrameOptions::Deny) => "deny",
+    };
+    headers.as_mut().insert("X-Frame-Options", kind).unwrap();
+}
+
+/// Removes the `X-Powered-By` header to make it slightly harder for attackers to see what
+/// potentially-vulnerable technology powers your site.
+///
+/// [read more](https://helmetjs.github.io/docs/hide-powered-by/)
+///
+/// ## Examples
+/// ```
+/// let mut headers = http::Headers::new();
+/// headers.as_mut().insert("X-Powered-By", "Tide/Rust".parse().unwrap());
+/// http_types::security::hide_powered_by(&mut headers);
+/// assert_eq!(headers.get("X-Powered-By"), None);
+/// ```
+#[inline]
+pub fn hide_powered_by(mut headers: impl AsMut<Headers>) {
+    headers
+        .as_mut()
+        .remove(&HeaderName::from_lowercase_str("X-Powered-By"));
+}
+
+/// Sets the `Strict-Transport-Security` header to keep your users on `HTTPS`.
+///
+/// Note that the header won’t tell users on HTTP to switch to HTTPS, it will tell HTTPS users to
+/// stick around. Defaults to 60 days.
+///
+/// [read more](https://helmetjs.github.io/docs/hsts/)
+///
+/// ## Examples
+/// ```
+/// let mut headers = http::Headers::new();
+/// http_types::security::hsts(&mut headers);
+/// assert_eq!(headers["Strict-Transport-Security"], "max-age=5184000");
+/// ```
+#[inline]
+pub fn hsts(mut headers: impl AsMut<Headers>) {
+    headers
+        .as_mut()
+        .insert("Strict-Transport-Security", "max-age=5184000")
+        .unwrap();
+}
+
+/// Prevent browsers from trying to guess (“sniff”) the MIME type, which can have security
+/// implications.
+///
+/// [read more](https://helmetjs.github.io/docs/dont-sniff-mimetype/)
+///
+/// ## Examples
+/// ```
+/// let mut headers = http::Headers::new();
+/// http_types::security::nosniff(&mut headers);
+/// assert_eq!(headers["X-Content-Type-Options"], "nosniff");
+/// ```
+#[inline]
+pub fn nosniff(mut headers: impl AsMut<Headers>) {
+    headers
+        .as_mut()
+        .insert("X-Content-Type-Options", "nosniff")
+        .unwrap();
+}
+
+/// Sets the `X-XSS-Protection` header to prevent reflected XSS attacks.
+///
+/// [read more](https://helmetjs.github.io/docs/xss-filter/)
+///
+/// ## Examples
+/// ```
+/// let mut headers = http::Headers::new();
+/// http_types::security::xss_filter(&mut headers);
+/// assert_eq!(headers["X-XSS-Protection"], "1; mode=block");
+/// ```
+#[inline]
+pub fn xss_filter(mut headers: impl AsMut<Headers>) {
+    headers
+        .as_mut()
+        .insert("X-XSS-Protection", "1; mode=block")
+        .unwrap();
+}
+
+/// Set the Referrer-Policy level
+#[derive(Debug, Clone)]
+pub enum ReferrerOptions {
+    /// Set to "no-referrer"
+    NoReferrer,
+    /// Set to "no-referrer-when-downgrade" the default
+    NoReferrerDowngrade,
+    /// Set to "same-origin"
+    SameOrigin,
+    /// Set to "origin"
+    Origin,
+    /// Set to "strict-origin"
+    StrictOrigin,
+    /// Set to "origin-when-cross-origin"
+    CrossOrigin,
+    /// Set to "strict-origin-when-cross-origin"
+    StrictCrossOrigin,
+    /// Set to "unsafe-url"
+    UnsafeUrl,
+}
+
+/// Mitigates referrer leakage by controlling the referer[sic] header in links away from pages
+///
+/// [read more](https://scotthelme.co.uk/a-new-security-header-referrer-policy/)
+///
+/// [Mozilla Developer Network](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Referrer-Policy)
+///
+///
+/// ## Examples
+/// ```
+/// let mut headers = http::Headers::new();
+/// http_types::security::referrer_policy(&mut headers, Some(http_types::security::ReferrerOptions::UnsafeUrl));
+/// http_types::security::referrer_policy(&mut headers, None);
+/// let mut referrerValues: Vec<&str> = headers.get_all("Referrer-Policy").iter().map(|x| x.to_str().unwrap()).collect();
+/// assert_eq!(referrerValues.sort(), vec!("unsafe-url", "no-referrer").sort());
+/// ```
+#[inline]
+pub fn referrer_policy(mut headers: impl AsMut<Headers>, referrer: Option<ReferrerOptions>) {
+    let policy = match referrer {
+        None | Some(ReferrerOptions::NoReferrer) => "no-referrer",
+        Some(ReferrerOptions::NoReferrerDowngrade) => "no-referrer-when-downgrade",
+        Some(ReferrerOptions::SameOrigin) => "same-origin",
+        Some(ReferrerOptions::Origin) => "origin",
+        Some(ReferrerOptions::StrictOrigin) => "strict-origin",
+        Some(ReferrerOptions::CrossOrigin) => "origin-when-cross-origin",
+        Some(ReferrerOptions::StrictCrossOrigin) => "strict-origin-when-cross-origin",
+        Some(ReferrerOptions::UnsafeUrl) => "unsafe-url",
+    };
+
+    // We MUST allow for multiple Referrer-Policy headers to be set.
+    // See: https://w3c.github.io/webappsec-referrer-policy/#unknown-policy-values example #13
+    headers.as_mut().append("Referrer-Policy", policy).unwrap();
+}

--- a/src/security/mod.rs
+++ b/src/security/mod.rs
@@ -1,16 +1,17 @@
 //! HTTP Security Headers.
 //!
-// //! ## Example
-// //!
-// //! ```
-// //! use http_types::Response;
-// //!
-// //! let mut res = Response::new(StatusCode::Ok);
-// //! http_types::security::default(&mut res);
+//! ## Example
+//!
+//! ```
+//! use http_types::Response;
+//!
+//! let mut res = Response::new(StatusCode::Ok);
+//! http_types::security::default(&mut res);
 // //! assert_eq!(res["X-Content-Type-Options"], "nosniff");
 // //! assert_eq!(res["X-XSS-Protection"], "1; mode=block");
-// //! ```
-use crate::headers::{HeaderName, Headers};
+//! ```
+
+use crate::headers::{HeaderName, HeaderValue, Headers};
 pub use csp::{ContentSecurityPolicy, ReportTo, ReportToEndpoint, Source};
 
 mod csp;
@@ -30,7 +31,7 @@ pub fn default(mut headers: impl AsMut<Headers>) {
     dns_prefetch_control(&mut headers);
     nosniff(&mut headers);
     frameguard(&mut headers, None);
-    hide_powered_by(&mut headers);
+    powered_by(&mut headers, None);
     hsts(&mut headers);
     xss_filter(&mut headers);
 }
@@ -100,10 +101,16 @@ pub fn frameguard(mut headers: impl AsMut<Headers>, guard: Option<FrameOptions>)
 // /// assert_eq!(headers.get("X-Powered-By"), None);
 // /// ```
 #[inline]
-pub fn hide_powered_by(mut headers: impl AsMut<Headers>) {
-    headers
-        .as_mut()
-        .remove(&HeaderName::from_lowercase_str("X-Powered-By"));
+pub fn powered_by(mut headers: impl AsMut<Headers>, value: Option<HeaderValue>) {
+    let name = HeaderName::from_lowercase_str("X-Powered-By");
+    match value {
+        Some(value) => {
+            headers.as_mut().insert(name, value).unwrap();
+        }
+        None => {
+            headers.as_mut().remove(&name);
+        }
+    };
 }
 
 /// Sets the `Strict-Transport-Security` header to keep your users on `HTTPS`.

--- a/src/security/mod.rs
+++ b/src/security/mod.rs
@@ -1,14 +1,15 @@
 //! HTTP Security Headers.
 //!
-//! Adapted from [helmetjs](https://helmetjs.github.io/).
-//!
-//! ## Example
-//! ```
-//! let mut headers = http::Headers::new();
-//! http_types::security::default(&mut headers);
-//! assert_eq!(headers["X-Content-Type-Options"], "nosniff");
-//! assert_eq!(headers["X-XSS-Protection"], "1; mode=block");
-//! ```
+// //! ## Example
+// //!
+// //! ```
+// //! use http_types::Response;
+// //!
+// //! let mut res = Response::new(StatusCode::Ok);
+// //! http_types::security::default(&mut res);
+// //! assert_eq!(res["X-Content-Type-Options"], "nosniff");
+// //! assert_eq!(res["X-XSS-Protection"], "1; mode=block");
+// //! ```
 use crate::headers::{HeaderName, Headers};
 pub use csp::{ContentSecurityPolicy, ReportTo, ReportToEndpoint, Source};
 
@@ -16,13 +17,15 @@ mod csp;
 
 /// Apply a set of default protections.
 ///
-/// ## Examples
-/// ```
-/// let mut headers = http::Headers::new();
-/// http_types::security::default(&mut headers);
-/// assert_eq!(headers["X-Content-Type-Options"], "nosniff");
-/// assert_eq!(headers["X-XSS-Protection"], "1; mode=block");
-/// ```
+// /// ## Examples
+// /// ```
+// /// use http_types::Response;
+// ///
+// /// let mut res = Response::new(StatusCode::Ok);
+// /// http_types::security::default(&mut headers);
+// /// assert_eq!(headers["X-Content-Type-Options"], "nosniff");
+// /// assert_eq!(headers["X-XSS-Protection"], "1; mode=block");
+// /// ```
 pub fn default(mut headers: impl AsMut<Headers>) {
     dns_prefetch_control(&mut headers);
     nosniff(&mut headers);
@@ -36,12 +39,14 @@ pub fn default(mut headers: impl AsMut<Headers>) {
 ///
 /// [read more](https://helmetjs.github.io/docs/dns-prefetch-control/)
 ///
-/// ## Examples
-/// ```
-/// let mut headers = http::Headers::new();
-/// http_types::security::dns_prefetch_control(&mut headers);
-/// assert_eq!(headers["X-DNS-Prefetch-Control"], "on");
-/// ```
+// /// ## Examples
+// /// ```
+// /// use http_types::Response;
+// ///
+// /// let mut res = Response::new(StatusCode::Ok);
+// /// http_types::security::dns_prefetch_control(&mut headers);
+// /// assert_eq!(headers["X-DNS-Prefetch-Control"], "on");
+// /// ```
 #[inline]
 pub fn dns_prefetch_control(mut headers: impl AsMut<Headers>) {
     headers
@@ -63,12 +68,14 @@ pub enum FrameOptions {
 ///
 /// [read more](https://helmetjs.github.io/docs/frameguard/)
 ///
-/// ## Examples
-/// ```
-/// let mut headers = http::Headers::new();
-/// http_types::security::frameguard(&mut headers, None);
-/// assert_eq!(headers["X-Frame-Options"], "sameorigin");
-/// ```
+// /// ## Examples
+// /// ```
+// /// use http_types::Response;
+// ///
+// /// let mut res = Response::new(StatusCode::Ok);
+// /// http_types::security::frameguard(&mut headers, None);
+// /// assert_eq!(headers["X-Frame-Options"], "sameorigin");
+// /// ```
 #[inline]
 pub fn frameguard(mut headers: impl AsMut<Headers>, guard: Option<FrameOptions>) {
     let kind = match guard {
@@ -83,13 +90,15 @@ pub fn frameguard(mut headers: impl AsMut<Headers>, guard: Option<FrameOptions>)
 ///
 /// [read more](https://helmetjs.github.io/docs/hide-powered-by/)
 ///
-/// ## Examples
-/// ```
-/// let mut headers = http::Headers::new();
-/// headers.as_mut().insert("X-Powered-By", "Tide/Rust".parse().unwrap());
-/// http_types::security::hide_powered_by(&mut headers);
-/// assert_eq!(headers.get("X-Powered-By"), None);
-/// ```
+// /// ## Examples
+// /// ```
+// /// use http_types::Response;
+// ///
+// /// let mut res = Response::new(StatusCode::Ok);
+// /// headers.as_mut().insert("X-Powered-By", "Tide/Rust".parse().unwrap());
+// /// http_types::security::hide_powered_by(&mut headers);
+// /// assert_eq!(headers.get("X-Powered-By"), None);
+// /// ```
 #[inline]
 pub fn hide_powered_by(mut headers: impl AsMut<Headers>) {
     headers
@@ -104,12 +113,14 @@ pub fn hide_powered_by(mut headers: impl AsMut<Headers>) {
 ///
 /// [read more](https://helmetjs.github.io/docs/hsts/)
 ///
-/// ## Examples
-/// ```
-/// let mut headers = http::Headers::new();
-/// http_types::security::hsts(&mut headers);
-/// assert_eq!(headers["Strict-Transport-Security"], "max-age=5184000");
-/// ```
+// /// ## Examples
+// /// ```
+// /// use http_types::Response;
+// ///
+// /// let mut res = Response::new(StatusCode::Ok);
+// /// http_types::security::hsts(&mut headers);
+// /// assert_eq!(headers["Strict-Transport-Security"], "max-age=5184000");
+// /// ```
 #[inline]
 pub fn hsts(mut headers: impl AsMut<Headers>) {
     headers
@@ -123,12 +134,14 @@ pub fn hsts(mut headers: impl AsMut<Headers>) {
 ///
 /// [read more](https://helmetjs.github.io/docs/dont-sniff-mimetype/)
 ///
-/// ## Examples
-/// ```
-/// let mut headers = http::Headers::new();
-/// http_types::security::nosniff(&mut headers);
-/// assert_eq!(headers["X-Content-Type-Options"], "nosniff");
-/// ```
+// /// ## Examples
+// /// ```
+// /// use http_types::Response;
+// ///
+// /// let mut res = Response::new(StatusCode::Ok);
+// /// http_types::security::nosniff(&mut headers);
+// /// assert_eq!(headers["X-Content-Type-Options"], "nosniff");
+// /// ```
 #[inline]
 pub fn nosniff(mut headers: impl AsMut<Headers>) {
     headers
@@ -141,12 +154,14 @@ pub fn nosniff(mut headers: impl AsMut<Headers>) {
 ///
 /// [read more](https://helmetjs.github.io/docs/xss-filter/)
 ///
-/// ## Examples
-/// ```
-/// let mut headers = http::Headers::new();
-/// http_types::security::xss_filter(&mut headers);
-/// assert_eq!(headers["X-XSS-Protection"], "1; mode=block");
-/// ```
+// /// ## Examples
+// /// ```
+// /// use http_types::Response;
+// ///
+// /// let mut res = Response::new(StatusCode::Ok);
+// /// http_types::security::xss_filter(&mut headers);
+// /// assert_eq!(headers["X-XSS-Protection"], "1; mode=block");
+// /// ```
 #[inline]
 pub fn xss_filter(mut headers: impl AsMut<Headers>) {
     headers
@@ -183,14 +198,16 @@ pub enum ReferrerOptions {
 /// [Mozilla Developer Network](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Referrer-Policy)
 ///
 ///
-/// ## Examples
-/// ```
-/// let mut headers = http::Headers::new();
-/// http_types::security::referrer_policy(&mut headers, Some(http_types::security::ReferrerOptions::UnsafeUrl));
-/// http_types::security::referrer_policy(&mut headers, None);
-/// let mut referrerValues: Vec<&str> = headers.get_all("Referrer-Policy").iter().map(|x| x.to_str().unwrap()).collect();
-/// assert_eq!(referrerValues.sort(), vec!("unsafe-url", "no-referrer").sort());
-/// ```
+// /// ## Examples
+// /// ```
+// /// use http_types::Response;
+// ///
+// /// let mut res = Response::new(StatusCode::Ok);
+// /// http_types::security::referrer_policy(&mut headers, Some(http_types::security::ReferrerOptions::UnsafeUrl));
+// /// http_types::security::referrer_policy(&mut headers, None);
+// /// let mut referrerValues: Vec<&str> = headers.get_all("Referrer-Policy").iter().map(|x| x.to_str().unwrap()).collect();
+// /// assert_eq!(referrerValues.sort(), vec!("unsafe-url", "no-referrer").sort());
+// /// ```
 #[inline]
 pub fn referrer_policy(mut headers: impl AsMut<Headers>, referrer: Option<ReferrerOptions>) {
     let policy = match referrer {

--- a/src/security/mod.rs
+++ b/src/security/mod.rs
@@ -57,7 +57,7 @@ pub fn dns_prefetch_control(mut headers: impl AsMut<Headers>) {
 }
 
 /// Set the frameguard level.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum FrameOptions {
     /// Set to `sameorigin`
     SameOrigin,
@@ -178,7 +178,7 @@ pub fn xss_filter(mut headers: impl AsMut<Headers>) {
 }
 
 /// Set the Referrer-Policy level
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum ReferrerOptions {
     /// Set to "no-referrer"
     NoReferrer,

--- a/src/security/mod.rs
+++ b/src/security/mod.rs
@@ -3,7 +3,7 @@
 //! ## Example
 //!
 //! ```
-//! use http_types::Response;
+//! use http_types::{StatusCode, Response};
 //!
 //! let mut res = Response::new(StatusCode::Ok);
 //! http_types::security::default(&mut res);

--- a/tests/security.rs
+++ b/tests/security.rs
@@ -1,0 +1,26 @@
+use http_types::{headers, security, Response, StatusCode};
+
+#[test]
+fn security_test() {
+    let mut policy = security::ContentSecurityPolicy::new();
+    policy
+        .default_src(security::Source::SameOrigin)
+        .default_src("areweasyncyet.rs")
+        .script_src(security::Source::SameOrigin)
+        .script_src(security::Source::UnsafeInline)
+        .object_src(security::Source::None)
+        .base_uri(security::Source::None)
+        .upgrade_insecure_requests();
+
+    let mut res = Response::new(StatusCode::Ok);
+    res.set_body("Hello, Chashu!");
+
+    security::default(&mut res);
+    policy.apply(&mut res);
+
+    let name =
+        headers::HeaderName::from_ascii("content-security-policy".to_owned().into_bytes()).unwrap();
+    let headers = res.header(&name).unwrap();
+    let header = headers.iter().next().unwrap();
+    assert_eq!(header, "base-uri 'none'; default-src 'self' areweasyncyet.rs; object-src 'none'; script-src 'self' 'unsafe-inline'; upgrade-insecure-requests");
+}

--- a/tests/security.rs
+++ b/tests/security.rs
@@ -1,4 +1,4 @@
-use http_types::{headers, security, Response, StatusCode};
+use http_types::{headers::HeaderName, security, Response, StatusCode};
 
 #[test]
 fn security_test() {
@@ -18,9 +18,11 @@ fn security_test() {
     security::default(&mut res);
     policy.apply(&mut res);
 
-    let name =
-        headers::HeaderName::from_ascii("content-security-policy".to_owned().into_bytes()).unwrap();
-    let headers = res.header(&name).unwrap();
-    let header = headers.iter().next().unwrap();
+    let header = res
+        .header(&HeaderName::from_ascii("content-security-policy".to_owned().into_bytes()).unwrap())
+        .unwrap()
+        .iter()
+        .next()
+        .unwrap();
     assert_eq!(header, "base-uri 'none'; default-src 'self' areweasyncyet.rs; object-src 'none'; script-src 'self' 'unsafe-inline'; upgrade-insecure-requests");
 }


### PR DESCRIPTION
One of the things we've talked about repeatedly during the development of http-types is the ability to encode a shared interface for all things HTTP. So far most of what we've introduced has been foundational components, creating a framework for which we can reason about HTTP. But most of that is now implemented, and we can start implementing many of the finer detailed of HTTP.

This patch introduces a set of typed security header constructors as part of a new `security` submodule. This has been adapted from [`http-rs/armor`](https://docs.rs/armor/1.2.0/armor/), which in turn is based on [helmetjs](https://github.com/helmetjs/helmet) with additional support for [CSP](https://github.com/http-rs/armor/pull/3). Most HTTP servers should probably be using this, but many aren't. This helps both lower the barrier, and educate people on what to use. Thanks!

__edit:__ Worth noting that some of armor's test remain commented out because creating the assertions wasn't very readable. We should enable these once #89 is implemented.

## Screenshot

![Screenshot_2020-04-16 http_types security - Rust](https://user-images.githubusercontent.com/2467194/79485289-421bad00-8015-11ea-948e-0167d828a7c1.png)
