### PR TITLE
Add conversions to and from bytes

### DIFF
--- a/src/request.rs
+++ b/src/request.rs
@@ -226,6 +226,31 @@ impl Request {
         self.body.into_string().await
     }
 
+    /// Read the body as bytes.
+    ///
+    /// This consumes the `Request`. If you want to read the body without
+    /// consuming the request, consider using the `take_body` method and
+    /// then calling `Body::into_bytes` or using the Request's AsyncRead
+    /// implementation to read the body.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # fn main() -> Result<(), http_types::Error> { async_std::task::block_on(async {
+    /// use http_types::{Body, Url, Method, Request};
+    ///
+    /// let bytes = vec![1, 2, 3];
+    /// let mut req = Request::new(Method::Get, Url::parse("https://example.com").unwrap());
+    /// req.set_body(Body::from_bytes(bytes));
+    ///
+    /// let bytes = req.body_bytes().await?;
+    /// assert_eq!(bytes, vec![1, 2, 3]);
+    /// # Ok(()) }) }
+    /// ```
+    pub async fn body_bytes(self) -> crate::Result<Vec<u8>> {
+        self.body.into_bytes().await
+    }
+
     /// Get an HTTP header.
     pub fn header(&self, name: &HeaderName) -> Option<&Vec<HeaderValue>> {
         self.headers.get(name)

--- a/src/response.rs
+++ b/src/response.rs
@@ -254,6 +254,32 @@ impl Response {
         self.body.into_string().await
     }
 
+    /// Read the body as bytes.
+    ///
+    /// This consumes the `Response`. If you want to read the body without
+    /// consuming the response, consider using the `take_body` method and
+    /// then calling `Body::into_bytes` or using the Response's AsyncRead
+    /// implementation to read the body.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # fn main() -> Result<(), http_types::Error> { async_std::task::block_on(async {
+    ///
+    /// use http_types::{Body, Url, Method, Response, StatusCode};
+    ///
+    /// let bytes = vec![1, 2, 3];
+    /// let mut res = Response::new(StatusCode::Ok);
+    /// res.set_body(Body::from_bytes(bytes));
+    ///
+    /// let bytes = res.body_bytes().await?;
+    /// assert_eq!(bytes, vec![1, 2, 3]);
+    /// # Ok(()) }) }
+    /// ```
+    pub async fn body_bytes(self) -> crate::Result<Vec<u8>> {
+        self.body.into_bytes().await
+    }
+
     /// Set the response MIME.
     pub fn set_content_type(&mut self, mime: Mime) -> Option<Vec<HeaderValue>> {
         let value: HeaderValue = mime.into();


### PR DESCRIPTION
This adds `Body::from_bytes`, `Body.into_bytes`, `Response.body_bytes` and `Request.body_bytes` to make it easier for users to work with bytes directly.

cc https://github.com/http-rs/tide/pull/436#issuecomment-616435815