### PR TITLE
Match Surf's Body conversions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,13 +16,15 @@ features = ["docs"]
 rustdoc-args = ["--cfg", "feature=\"docs\""]
 
 [features]
-default = []
+default = ["async_std"]
 docs = ["unstable"]
 unstable = []
 hyperium_http = ["http"]
+async_std = [] # "async-std" when it is not default
 
 [dependencies]
 # Note(yoshuawuyts): used for async_std's `channel` only; use "core" once possible.
+# features: async_std
 async-std = { version = "1.4.0", features = ["unstable"] }
 
 # features: hyperium/http

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,6 @@ unstable = []
 hyperium_http = ["http"]
 
 [dependencies]
-
 # Note(yoshuawuyts): used for async_std's `channel` only; use "core" once possible.
 async-std = { version = "1.4.0", features = ["unstable"] }
 
@@ -36,7 +35,7 @@ omnom = "2.1.1"
 pin-project-lite = "0.1.0"
 url = "2.1.0"
 serde_json = "1.0.51"
-serde = { version = "1.0", features = ["derive"] }
+serde = { version = "1.0.106", features = ["derive"] }
 
 [dev-dependencies]
 http = "0.2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,6 +38,7 @@ pin-project-lite = "0.1.0"
 url = "2.1.0"
 serde_json = "1.0.51"
 serde = { version = "1.0.106", features = ["derive"] }
+serde_urlencoded = "0.6.1"
 
 [dev-dependencies]
 http = "0.2.0"

--- a/src/body.rs
+++ b/src/body.rs
@@ -167,7 +167,7 @@ impl Body {
     /// # Examples
     ///
     /// ```
-    /// use http_types::{Body, serde::json};
+    /// use http_types::{Body, convert::json};
     ///
     /// let body = Body::from_json(json!({ "name": "Chashu" }));
     /// # drop(body);
@@ -250,7 +250,7 @@ impl Body {
     /// ```
     /// # fn main() -> Result<(), http_types::Error> { async_std::task::block_on(async {
     /// use http_types::Body;
-    /// use http_types::serde::{Serialize, Deserialize};
+    /// use http_types::convert::{Serialize, Deserialize};
     ///
     /// #[derive(Debug, Serialize, Deserialize)]
     /// struct Cat { name: String }

--- a/src/body.rs
+++ b/src/body.rs
@@ -193,7 +193,7 @@ impl Body {
     /// let mut req = Response::new(StatusCode::Ok);
     ///
     /// let input = String::from("hello Nori!");
-    /// req.set_body(Body::from_bytes(input));
+    /// req.set_body(Body::from_string(input));
     /// ```
     pub fn from_string(s: String) -> Self {
         Self {
@@ -262,7 +262,7 @@ impl Body {
     /// struct Cat { name: String }
     ///
     /// let cat = Cat { name: String::from("chashu") };
-    /// let body = Body::from_json(cat)?;
+    /// let body = Body::from_json(&cat)?;
     ///
     /// let cat: Cat = body.into_json().await?;
     /// assert_eq!(&cat.name, "chashu");
@@ -331,7 +331,7 @@ impl Body {
     /// struct Cat { name: String }
     ///
     /// let cat = Cat { name: String::from("chashu") };
-    /// let body = Body::from_form(cat)?;
+    /// let body = Body::from_form(&cat)?;
     ///
     /// let cat: Cat = body.into_form().await?;
     /// assert_eq!(&cat.name, "chashu");

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -173,6 +173,13 @@ mod hyperium_http;
 #[doc(inline)]
 pub use crate::type_map::TypeMap;
 
+/// Generic serialization and deserialization.
+pub mod serde {
+    pub use serde::{de::DeserializeOwned, Deserialize, Serialize};
+    #[doc(inline)]
+    pub use serde_json::json;
+}
+
 // Not public API. Referenced by macro-generated code.
 #[doc(hidden)]
 pub mod private {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -173,8 +173,8 @@ mod hyperium_http;
 #[doc(inline)]
 pub use crate::type_map::TypeMap;
 
-/// Generic serialization and deserialization.
-pub mod serde {
+/// Traits for conversions between types.
+pub mod convert {
     pub use serde::{de::DeserializeOwned, Deserialize, Serialize};
     #[doc(inline)]
     pub use serde_json::json;

--- a/src/request.rs
+++ b/src/request.rs
@@ -271,7 +271,7 @@ impl Request {
     ///
     /// let cat = Cat { name: String::from("chashu") };
     /// let mut req = Request::new(Method::Get, Url::parse("https://example.com").unwrap());
-    /// req.set_body(Body::from_json(cat)?);
+    /// req.set_body(Body::from_json(&cat)?);
     ///
     /// let cat: Cat = req.body_json().await?;
     /// assert_eq!(&cat.name, "chashu");
@@ -279,6 +279,35 @@ impl Request {
     /// ```
     pub async fn body_json<T: DeserializeOwned>(self) -> crate::Result<T> {
         self.body.into_json().await
+    }
+
+    /// Read the body as `x-www-form-urlencoded`.
+    ///
+    /// This consumes the request. If you want to read the body without
+    /// consuming the request, consider using the `take_body` method and
+    /// then calling `Body::into_json` or using the Request's AsyncRead
+    /// implementation to read the body.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # fn main() -> Result<(), http_types::Error> { async_std::task::block_on(async {
+    /// use http_types::{Body, Url, Method, Request};
+    /// use http_types::convert::{Serialize, Deserialize};
+    ///
+    /// #[derive(Debug, Serialize, Deserialize)]
+    /// struct Cat { name: String }
+    ///
+    /// let cat = Cat { name: String::from("chashu") };
+    /// let mut req = Request::new(Method::Get, Url::parse("https://example.com").unwrap());
+    /// req.set_body(Body::from_form(&cat)?);
+    ///
+    /// let cat: Cat = req.body_form().await?;
+    /// assert_eq!(&cat.name, "chashu");
+    /// # Ok(()) }) }
+    /// ```
+    pub async fn body_form<T: DeserializeOwned>(self) -> crate::Result<T> {
+        self.body.into_form().await
     }
 
     /// Get an HTTP header.

--- a/src/response.rs
+++ b/src/response.rs
@@ -300,7 +300,7 @@ impl Response {
     ///
     /// let cat = Cat { name: String::from("chashu") };
     /// let mut res = Response::new(StatusCode::Ok);    
-    /// res.set_body(Body::from_json(cat)?);
+    /// res.set_body(Body::from_json(&cat)?);
     ///
     /// let cat: Cat = res.body_json().await?;
     /// assert_eq!(&cat.name, "chashu");
@@ -308,6 +308,35 @@ impl Response {
     /// ```
     pub async fn body_json<T: DeserializeOwned>(self) -> crate::Result<T> {
         self.body.into_json().await
+    }
+
+    /// Read the body as `x-www-form-urlencoded`.
+    ///
+    /// This consumes the request. If you want to read the body without
+    /// consuming the request, consider using the `take_body` method and
+    /// then calling `Body::into_json` or using the Response's AsyncRead
+    /// implementation to read the body.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # fn main() -> Result<(), http_types::Error> { async_std::task::block_on(async {
+    /// use http_types::{Body, Url, Method, Response, StatusCode};    
+    /// use http_types::convert::{Serialize, Deserialize};
+    ///
+    /// #[derive(Debug, Serialize, Deserialize)]
+    /// struct Cat { name: String }
+    ///
+    /// let cat = Cat { name: String::from("chashu") };
+    /// let mut res = Response::new(StatusCode::Ok);    
+    /// res.set_body(Body::from_form(&cat)?);
+    ///
+    /// let cat: Cat = res.body_form().await?;
+    /// assert_eq!(&cat.name, "chashu");
+    /// # Ok(()) }) }
+    /// ```
+    pub async fn body_form<T: DeserializeOwned>(self) -> crate::Result<T> {
+        self.body.into_form().await
     }
 
     /// Set the response MIME.

--- a/src/response.rs
+++ b/src/response.rs
@@ -284,7 +284,7 @@ impl Response {
     /// Read the body as JSON.
     ///
     /// This consumes the response. If you want to read the body without
-    /// consuming the request, consider using the `take_body` method and
+    /// consuming the response, consider using the `take_body` method and
     /// then calling `Body::into_json` or using the Response's AsyncRead
     /// implementation to read the body.
     ///

--- a/src/response.rs
+++ b/src/response.rs
@@ -6,6 +6,7 @@ use std::mem;
 use std::pin::Pin;
 use std::task::{Context, Poll};
 
+use crate::convert::DeserializeOwned;
 use crate::headers::{
     self, HeaderName, HeaderValue, HeaderValues, Headers, Names, ToHeaderValues, Values,
     CONTENT_TYPE,
@@ -244,11 +245,11 @@ impl Response {
     /// use http_types::{Body, Url, Method, Response, StatusCode};    
     /// use async_std::io::Cursor;
     ///
-    /// let mut resp = Response::new(StatusCode::Ok);    
+    /// let mut res = Response::new(StatusCode::Ok);    
     /// let cursor = Cursor::new("Hello Nori");
     /// let body = Body::from_reader(cursor, None);
-    /// resp.set_body(body);
-    /// assert_eq!(&resp.body_string().await.unwrap(), "Hello Nori");
+    /// res.set_body(body);
+    /// assert_eq!(&res.body_string().await.unwrap(), "Hello Nori");
     /// # Ok(()) }) }
     /// ```
     pub async fn body_string(self) -> io::Result<String> {
@@ -266,7 +267,6 @@ impl Response {
     ///
     /// ```
     /// # fn main() -> Result<(), http_types::Error> { async_std::task::block_on(async {
-    ///
     /// use http_types::{Body, Url, Method, Response, StatusCode};
     ///
     /// let bytes = vec![1, 2, 3];
@@ -279,6 +279,35 @@ impl Response {
     /// ```
     pub async fn body_bytes(self) -> crate::Result<Vec<u8>> {
         self.body.into_bytes().await
+    }
+
+    /// Read the body as JSON.
+    ///
+    /// This consumes the response. If you want to read the body without
+    /// consuming the request, consider using the `take_body` method and
+    /// then calling `Body::into_json` or using the Response's AsyncRead
+    /// implementation to read the body.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # fn main() -> Result<(), http_types::Error> { async_std::task::block_on(async {
+    /// use http_types::{Body, Url, Method, Response, StatusCode};    
+    /// use http_types::convert::{Serialize, Deserialize};
+    ///
+    /// #[derive(Debug, Serialize, Deserialize)]
+    /// struct Cat { name: String }
+    ///
+    /// let cat = Cat { name: String::from("chashu") };
+    /// let mut res = Response::new(StatusCode::Ok);    
+    /// res.set_body(Body::from_json(cat)?);
+    ///
+    /// let cat: Cat = res.body_json().await?;
+    /// assert_eq!(&cat.name, "chashu");
+    /// # Ok(()) }) }
+    /// ```
+    pub async fn body_json<T: DeserializeOwned>(self) -> crate::Result<T> {
+        self.body.into_json().await
     }
 
     /// Set the response MIME.


### PR DESCRIPTION
A big driving force behind http-types was the desire to share repeated logic between Tide and Surf, and in the process establish common idioms for web protocols. So far we've covered headers and URLs, but bodies are part of that as well.

So far for `Body` we have `Body::from_string` and `Body::into_string` with the corresponding `Request::body_string` and `Response::body_string` methods. This adds a parallel path for that for JSON as well. This is the first step to bringing us on par with [surf's conversions](https://docs.rs/surf/1.0.3/surf/struct.Request.html#method.body).

## Future directions
After this patch we should probably fill out the rest of the chart:

| text/plain | octet-stream | JSON | www-form-encoding | mime detection |
|---|---|---|---|---|
| `Body::from_string` | `Body::from_bytes` | `Body::from_json` | `Body::from_form` | `Body::from_file` |
| `Body::into_string` | `Body::into_bytes` | `Body::into_json` | `Body::into_form` | tbd |
| `Request::body_string` | `Request::body_bytes` | `Request::body_json` | `Request::body_form` | tbd |
| `Response::body_string` | `Response::body_bytes` | `Response::body_json` | `Response::body_form` |  tbd |

This will make implementing these methods in both Tide and Surf significantly easier, making it so we only need to forward function calls. Thanks!