### PR TITLE
Make recv_trailers return a concrete type

### DIFF
--- a/src/request.rs
+++ b/src/request.rs
@@ -10,7 +10,7 @@ use crate::headers::{
     self, HeaderName, HeaderValue, Headers, Names, ToHeaderValues, Values, CONTENT_TYPE,
 };
 use crate::mime::Mime;
-use crate::trailers::{Trailers, TrailersSender};
+use crate::trailers::{self, Trailers};
 use crate::Cookie;
 use crate::{Body, Method, TypeMap, Url, Version};
 
@@ -31,8 +31,8 @@ pin_project_lite::pin_project! {
         url: Url,
         headers: Headers,
         version: Option<Version>,
-        sender: Option<sync::Sender<crate::Result<Trailers>>>,
-        receiver: sync::Receiver<crate::Result<Trailers>>,
+        sender: Option<sync::Sender<Trailers>>,
+        receiver: Option<sync::Receiver<Trailers>>,
         #[pin]
         body: Body,
         local: TypeMap,
@@ -50,7 +50,7 @@ impl Request {
             version: None,
             body: Body::empty(),
             sender: Some(sender),
-            receiver,
+            receiver: Some(receiver),
             local: TypeMap::new(),
         }
     }
@@ -431,17 +431,21 @@ impl Request {
     }
 
     /// Sends trailers to the a receiver.
-    pub fn send_trailers(&mut self) -> TrailersSender {
+    pub fn send_trailers(&mut self) -> trailers::Sender {
         let sender = self
             .sender
             .take()
             .expect("Trailers sender can only be constructed once");
-        TrailersSender::new(sender)
+        trailers::Sender::new(sender)
     }
 
     /// Receive trailers from a sender.
-    pub async fn recv_trailers(&self) -> Option<crate::Result<Trailers>> {
-        self.receiver.recv().await
+    pub async fn recv_trailers(&mut self) -> trailers::Receiver {
+        let receiver = self
+            .receiver
+            .take()
+            .expect("Trailers receiver can only be constructed once");
+        trailers::Receiver::new(receiver)
     }
 
     /// An iterator visiting all header pairs in arbitrary order.


### PR DESCRIPTION
Closes https://github.com/http-rs/http-types/issues/96. This makes is so `recv_trailers` returns a concrete type that can be stored inside parsers. Additionally the types have been renamed, and the `Result` has been removed since it wasn't doing its intended job for error handling. Thanks!