### PR TITLE
Remove cookie APIs from  Request & Response

### DIFF
--- a/src/request.rs
+++ b/src/request.rs
@@ -12,7 +12,6 @@ use crate::headers::{
 };
 use crate::mime::Mime;
 use crate::trailers::{self, Trailers};
-use crate::Cookie;
 use crate::{Body, Method, TypeMap, Url, Version};
 
 pin_project_lite::pin_project! {
@@ -361,74 +360,6 @@ impl Request {
     /// ```
     pub fn set_version(&mut self, version: Option<Version>) {
         self.version = version;
-    }
-
-    /// Get all cookies.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// # fn main() -> Result<(), http_types::Error> {
-    /// #
-    /// use http_types::{Cookie, Url, Method, Request, Version};
-    ///
-    /// let mut req = Request::new(Method::Get, Url::parse("https://example.com")?);
-    /// req.set_cookie(Cookie::new("name", "value"));
-    /// assert_eq!(req.cookies().unwrap(), vec![Cookie::new("name", "value")]);
-    /// #
-    /// # Ok(()) }
-    /// ```
-    pub fn cookies(&self) -> Result<Vec<Cookie<'_>>, crate::Error> {
-        match self.header(&headers::COOKIE) {
-            None => Ok(vec![]),
-            Some(h) => h.iter().try_fold(vec![], |mut acc, h| {
-                let cookie = Cookie::parse(h.as_str())?;
-                acc.push(cookie);
-                Ok(acc)
-            }),
-        }
-    }
-
-    /// Get a cookie by name.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// # fn main() -> Result<(), http_types::Error> {
-    /// #
-    /// use http_types::{Cookie, Url, Method, Request, Version};
-    ///
-    /// let mut req = Request::new(Method::Get, Url::parse("https://example.com")?);
-    /// req.set_cookie(Cookie::new("name", "value"));
-    /// assert_eq!(req.cookie("name").unwrap(), Some(Cookie::new("name", "value")));
-    /// #
-    /// # Ok(()) }
-    /// ```
-    pub fn cookie(&self, name: &str) -> Result<Option<Cookie<'_>>, crate::Error> {
-        let cookies = self.cookies()?;
-        let cookie = cookies.into_iter().find(|c| c.name() == name);
-        Ok(cookie)
-    }
-
-    /// Set a cookie.
-    ///
-    /// This will not override any existing cookies, and uses the `Cookies` header.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// # fn main() -> Result<(), http_types::Error> {
-    /// #
-    /// use http_types::{Cookie, Url, Method, Request, Version};
-    ///
-    /// let mut req = Request::new(Method::Get, Url::parse("https://example.com")?);
-    /// req.set_cookie(Cookie::new("name", "value"));
-    /// #
-    /// # Ok(()) }
-    /// ```
-    pub fn set_cookie(&mut self, cookie: Cookie<'_>) {
-        self.append_header(headers::COOKIE, HeaderValue::from(cookie))
-            .unwrap();
     }
 
     /// Sends trailers to the a receiver.

--- a/src/response.rs
+++ b/src/response.rs
@@ -12,7 +12,7 @@ use crate::headers::{
 };
 use crate::mime::Mime;
 use crate::trailers::{self, Trailers};
-use crate::{Body, Cookie, StatusCode, TypeMap, Version};
+use crate::{Body, StatusCode, TypeMap, Version};
 
 pin_project_lite::pin_project! {
     /// An HTTP response.
@@ -326,74 +326,6 @@ impl Response {
     /// Set the status.
     pub fn set_status(&mut self, status: StatusCode) {
         self.status = status;
-    }
-
-    /// Get all cookies.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// # fn main() -> Result<(), http_types::Error> {
-    /// #
-    /// use http_types::{Cookie, Response, StatusCode, Version};
-    ///
-    /// let mut res = Response::new(StatusCode::Ok);
-    /// res.set_cookie(Cookie::new("name", "value"));
-    /// assert_eq!(res.cookies().unwrap(), vec![Cookie::new("name", "value")]);
-    /// #
-    /// # Ok(()) }
-    /// ```
-    pub fn cookies(&self) -> Result<Vec<Cookie<'_>>, crate::Error> {
-        match self.header(&headers::SET_COOKIE) {
-            None => Ok(vec![]),
-            Some(h) => h.iter().try_fold(vec![], |mut acc, h| {
-                let cookie = Cookie::parse(h.as_str())?;
-                acc.push(cookie);
-                Ok(acc)
-            }),
-        }
-    }
-
-    /// Get a cookie by name.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// # fn main() -> Result<(), http_types::Error> {
-    /// #
-    /// use http_types::{Cookie, Response, StatusCode, Version};
-    ///
-    /// let mut res = Response::new(StatusCode::Ok);
-    /// res.set_cookie(Cookie::new("name", "value"));
-    /// assert_eq!(res.cookie("name").unwrap(), Some(Cookie::new("name", "value")));
-    /// #
-    /// # Ok(()) }
-    /// ```
-    pub fn cookie(&self, name: &str) -> Result<Option<Cookie<'_>>, crate::Error> {
-        let cookies = self.cookies()?;
-        let cookie = cookies.into_iter().find(|c| c.name() == name);
-        Ok(cookie)
-    }
-
-    /// Set a cookie.
-    ///
-    /// This will not override any existing cookies, and uses the `Cookies` header.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// # fn main() -> Result<(), http_types::Error> {
-    /// #
-    /// use http_types::{Cookie, Response, StatusCode, Version};
-    ///
-    /// let mut res = Response::new(StatusCode::Ok);
-    /// res.set_cookie(Cookie::new("name", "value"));
-    /// #
-    /// # Ok(()) }
-    /// ```
-    pub fn set_cookie(&mut self, cookie: Cookie<'_>) {
-        self.append_header(headers::SET_COOKIE, HeaderValue::from(cookie))
-            .unwrap();
     }
 
     /// Sends trailers to the a receiver.


### PR DESCRIPTION
Gets us closer towards https://github.com/http-rs/http-types/issues/64. The first step is to remove the existing cookie API since it's fundamentally insufficient. The next step is to move towards Tide's model of handling cookies. Thanks!