### PR TITLE
const utf8 mime

### DIFF
--- a/src/body.rs
+++ b/src/body.rs
@@ -190,7 +190,7 @@ impl From<String> for Body {
         Self {
             length: Some(s.len()),
             reader: Box::new(io::Cursor::new(s.into_bytes())),
-            mime: string_mime(),
+            mime: mime::PLAIN,
         }
     }
 }
@@ -200,17 +200,9 @@ impl<'a> From<&'a str> for Body {
         Self {
             length: Some(s.len()),
             reader: Box::new(io::Cursor::new(s.to_owned().into_bytes())),
-            mime: string_mime(),
+            mime: mime::PLAIN,
         }
     }
-}
-
-fn string_mime() -> mime::Mime {
-    let mut mime = mime::PLAIN;
-    let mut parameters = std::collections::HashMap::new();
-    parameters.insert("charset".to_owned(), "utf-8".to_owned());
-    mime.parameters = Some(parameters);
-    mime
 }
 
 impl From<Vec<u8>> for Body {

--- a/src/mime/constants.rs
+++ b/src/mime/constants.rs
@@ -1,3 +1,4 @@
+use super::ParamKind;
 use crate::Mime;
 
 /// Content-Type that matches anything.
@@ -11,7 +12,7 @@ pub const ANY: Mime = Mime {
     essence: String::new(),
     basetype: String::new(),
     subtype: String::new(),
-    parameters: None,
+    params: None,
     static_essence: Some("*/*"),
     static_basetype: Some("*"),
     static_subtype: Some("*"),
@@ -22,16 +23,16 @@ pub const ANY: Mime = Mime {
 /// # Mime Type
 ///
 /// ```txt
-/// application/javascript
+/// application/javascript; charset=utf-8
 /// ```
 pub const JAVASCRIPT: Mime = Mime {
     static_essence: Some("application/javascript"),
     essence: String::new(),
     basetype: String::new(),
     subtype: String::new(),
+    params: Some(ParamKind::Utf8),
     static_basetype: Some("application"),
     static_subtype: Some("javascript"),
-    parameters: None,
 };
 
 /// Content-Type for JSON.
@@ -46,9 +47,9 @@ pub const JSON: Mime = Mime {
     essence: String::new(),
     basetype: String::new(),
     subtype: String::new(),
+    params: None,
     static_basetype: Some("application"),
     static_subtype: Some("json"),
-    parameters: None,
 };
 
 /// Content-Type for CSS.
@@ -56,16 +57,16 @@ pub const JSON: Mime = Mime {
 /// # Mime Type
 ///
 /// ```txt
-/// text/css
+/// text/css; charset=utf-8
 /// ```
 pub const CSS: Mime = Mime {
     static_essence: Some("text/css"),
     essence: String::new(),
     basetype: String::new(),
     subtype: String::new(),
+    params: Some(ParamKind::Utf8),
     static_basetype: Some("text"),
     static_subtype: Some("css"),
-    parameters: None,
 };
 
 /// Content-Type for HTML.
@@ -73,16 +74,16 @@ pub const CSS: Mime = Mime {
 /// # Mime Type
 ///
 /// ```txt
-/// text/html
+/// text/html; charset=utf-8
 /// ```
 pub const HTML: Mime = Mime {
     static_essence: Some("text/html"),
     essence: String::new(),
     basetype: String::new(),
     subtype: String::new(),
+    params: Some(ParamKind::Utf8),
     static_basetype: Some("text"),
     static_subtype: Some("html"),
-    parameters: None,
 };
 
 /// Content-Type for Server Sent Events
@@ -99,7 +100,7 @@ pub const SSE: Mime = Mime {
     subtype: String::new(),
     static_basetype: Some("text"),
     static_subtype: Some("event-stream"),
-    parameters: None,
+    params: None,
 };
 
 /// Content-Type for plain text.
@@ -107,16 +108,16 @@ pub const SSE: Mime = Mime {
 /// # Mime Type
 ///
 /// ```txt
-/// text/plain
+/// text/plain; charset=utf-8
 /// ```
 pub const PLAIN: Mime = Mime {
     static_essence: Some("text/plain"),
     essence: String::new(),
     basetype: String::new(),
     subtype: String::new(),
+    params: Some(ParamKind::Utf8),
     static_basetype: Some("text"),
     static_subtype: Some("plain"),
-    parameters: None,
 };
 
 /// Content-Type for byte streams.
@@ -133,7 +134,7 @@ pub const BYTE_STREAM: Mime = Mime {
     subtype: String::new(),
     static_basetype: Some("application"),
     static_subtype: Some("octet-stream"),
-    parameters: None,
+    params: None,
 };
 
 /// Content-Type for form.
@@ -150,7 +151,7 @@ pub const FORM: Mime = Mime {
     subtype: String::new(),
     static_basetype: Some("application"),
     static_subtype: Some("x-www-form-urlencoded"),
-    parameters: None,
+    params: None,
 };
 
 /// Content-Type for a multipart form.
@@ -167,5 +168,5 @@ pub const MULTIPART_FORM: Mime = Mime {
     subtype: String::new(),
     static_basetype: Some("multipart"),
     static_subtype: Some("form-data"),
-    parameters: None,
+    params: None,
 };

--- a/src/mime/mod.rs
+++ b/src/mime/mod.rs
@@ -7,6 +7,7 @@ mod parse;
 
 pub use constants::*;
 
+use std::borrow::Cow;
 use std::collections::HashMap;
 use std::fmt::{self, Debug, Display};
 use std::option;
@@ -27,7 +28,7 @@ pub struct Mime {
     pub(crate) static_essence: Option<&'static str>,
     pub(crate) static_basetype: Option<&'static str>,
     pub(crate) static_subtype: Option<&'static str>,
-    pub(crate) parameters: Option<HashMap<String, String>>,
+    pub(crate) params: Option<ParamKind>,
 }
 
 impl Mime {
@@ -46,7 +47,7 @@ impl Mime {
             subtype: String::new(),  // TODO: fill in.
             static_basetype: None,   // TODO: fill in
             static_subtype: None,
-            parameters: None, // TODO: fill in.
+            params: None, // TODO: fill in.
         })
     }
 
@@ -81,13 +82,17 @@ impl Mime {
     }
 
     /// Get a reference to a param.
-    pub fn param(&self, s: &str) -> Option<&String> {
-        self.parameters.as_ref().map(|hm| hm.get(s)).flatten()
-    }
-
-    /// Get a mutable reference to a param.
-    pub fn param_mut(&mut self, s: &str) -> Option<&mut String> {
-        self.parameters.as_mut().map(|hm| hm.get_mut(s)).flatten()
+    pub fn param(&self, s: &str) -> Option<&ParamValue> {
+        self.params
+            .as_ref()
+            .map(|inner| match inner {
+                ParamKind::Map(hm) => hm.get(&ParamName(s.to_owned().into())),
+                ParamKind::Utf8 => match s {
+                    "charset" => Some(&ParamValue(Cow::Borrowed("utf8"))),
+                    _ => None,
+                },
+            })
+            .flatten()
     }
 }
 
@@ -98,13 +103,18 @@ impl Display for Mime {
         } else {
             write!(f, "{}", &self.essence)?
         }
-        if let Some(parameters) = &self.parameters {
-            assert!(!parameters.is_empty());
-            write!(f, "; ")?;
-            for (i, (key, value)) in parameters.iter().enumerate() {
-                write!(f, "{}={}", key, value)?;
-                if i != parameters.len() - 1 {
-                    write!(f, ",")?;
+        if let Some(params) = &self.params {
+            match params {
+                ParamKind::Utf8 => write!(f, "; charset=utf-8")?,
+                ParamKind::Map(params) => {
+                    assert!(!params.is_empty());
+                    write!(f, "; ")?;
+                    for (i, (key, value)) in params.iter().enumerate() {
+                        write!(f, "{}={}", key, value)?;
+                        if i != params.len() - 1 {
+                            write!(f, ",")?;
+                        }
+                    }
                 }
             }
         }
@@ -137,7 +147,7 @@ impl FromStr for Mime {
             subtype: String::new(),  // TODO: fill in.
             static_basetype: None,   // TODO: fill in
             static_subtype: None,    // TODO: fill in
-            parameters: None,        // TODO: fill in.
+            params: None,            // TODO: fill in.
         })
     }
 }
@@ -151,5 +161,53 @@ impl ToHeaderValues for Mime {
 
         // A HeaderValue will always convert into itself.
         Ok(header.to_header_values().unwrap())
+    }
+}
+/// A parameter name.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct ParamName(Cow<'static, str>);
+
+impl Display for ParamName {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        Display::fmt(&self.0, f)
+    }
+}
+
+/// A parameter value.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct ParamValue(Cow<'static, str>);
+
+impl Display for ParamValue {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        Display::fmt(&self.0, f)
+    }
+}
+
+impl<'a> PartialEq<&'a str> for ParamValue {
+    fn eq(&self, other: &&'a str) -> bool {
+        &self.0 == other
+    }
+}
+
+impl PartialEq<str> for ParamValue {
+    fn eq(&self, other: &str) -> bool {
+        &self.0 == other
+    }
+}
+
+/// This is a hack that allows us to mark a trait as utf8 during compilation. We
+/// can remove this once we can construct HashMap during compilation.
+#[derive(Debug, Clone)]
+pub(crate) enum ParamKind {
+    Utf8,
+    Map(HashMap<ParamName, ParamValue>),
+}
+
+impl ParamKind {
+    pub(crate) fn unwrap(&mut self) -> &mut HashMap<ParamName, ParamValue> {
+        match self {
+            Self::Map(t) => t,
+            _ => panic!("Unwrapped a ParamKind::utf8"),
+        }
     }
 }


### PR DESCRIPTION
Closes https://github.com/http-rs/http-types/issues/52. This allows our mime types to be const initialized with utf-8 declared. The way we achieve this is more or less a hack (we're using enums), but it's the best we got until we can initialize HashMap during const. This also allows us to remove some extra code from the tests. Thanks!