### PR TITLE
Add From<async_std::fs::File> for Body

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,14 +16,16 @@ features = ["docs"]
 rustdoc-args = ["--cfg", "feature=\"docs\""]
 
 [features]
-default = []
+default = ["async_std"]
 docs = ["unstable"]
 unstable = []
 hyperium_http = ["http"]
+async_std = [] # "async-std" when it is not default
 
 [dependencies]
 
 # Note(yoshuawuyts): used for async_std's `channel` only; use "core" once possible.
+# features: async_std
 async-std = { version = "1.4.0", features = ["unstable"] }
 
 # features: hyperium/http

--- a/src/body.rs
+++ b/src/body.rs
@@ -109,6 +109,30 @@ impl Body {
         }
     }
 
+    /// Create a `Body` from an async-std File.
+    ///
+    /// The Mime type set to `application/octet-stream` if no other mime type has been set or can
+    /// be sniffed.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// use http_types::{Body, Response, StatusCode};
+    /// use async_std::fs::File;
+    ///
+    /// # async_std::task::block_on(async {
+    /// let mut res = Response::new(StatusCode::Ok);
+    /// let file = File::open("/path/to/file").await.unwrap();
+    /// res.set_body(Body::from_file(file));
+    /// // or
+    /// res.set_body(File::open("/path/to/file").await.unwrap());
+    /// # });
+    /// ```
+    #[cfg(feature = "async_std")]
+    pub fn from_file(file: async_std::fs::File) -> Self {
+        file.into()
+    }
+
     /// Get the length of the body in bytes.
     ///
     /// # Examples
@@ -218,6 +242,24 @@ impl From<Vec<u8>> for Body {
         Self {
             length: Some(b.len()),
             reader: Box::new(io::Cursor::new(b)),
+            mime: mime::BYTE_STREAM,
+        }
+    }
+}
+
+#[cfg(feature = "async_std")]
+impl From<async_std::fs::File> for Body {
+    fn from(file: async_std::fs::File) -> Self {
+        let length = async_std::task::block_on(async {
+            file.metadata()
+                .await
+                .expect("unable to read file metadata")
+                .len()
+        });
+
+        Self {
+            length: Some(length as usize),
+            reader: Box::new(async_std::io::BufReader::new(file)),
             mime: mime::BYTE_STREAM,
         }
     }


### PR DESCRIPTION
+ adds an async_std feature flag
+ implements `From<async_std::fs::File> for http_types::Body`, conditional on the async_std feature flag
+ adds a `http_types::Body::from_file` function that uses the From conversion, also behind the feature flag

Concerns:
I implemented From instead of TryFrom because Request and Response signatures expect `Into<Body>`, but using `expect` in library code seems sketchy. Because this and potentially other conversions into Body are fallible, changing Request/Response set_body to accept a `TryInto<Body>` and propagating potential errors up to library user code would remove the need for the `expect`

I started to implement `From<&Path>`/`From<PathBuf>` but that's even more likely to fail than reading metadata from an already-open file.