### PR TITLE
Index

### DIFF
--- a/src/headers/headers.rs
+++ b/src/headers/headers.rs
@@ -1,0 +1,176 @@
+//! HTTP headers.
+
+use std::collections::HashMap;
+use std::convert::TryInto;
+use std::iter::IntoIterator;
+
+use crate::headers::{
+    HeaderName, HeaderValues, IntoIter, Iter, IterMut, Names, ToHeaderValues, Values,
+};
+
+/// A collection of HTTP Headers.
+#[derive(Debug, Clone)]
+pub struct Headers {
+    pub(crate) headers: HashMap<HeaderName, HeaderValues>,
+}
+
+impl Headers {
+    /// Create a new instance.
+    pub(crate) fn new() -> Self {
+        Self {
+            headers: HashMap::new(),
+        }
+    }
+
+    /// Insert a header into the headers.
+    ///
+    /// Not that this will replace all header values for a given header name.
+    /// If you wish to add header values for a header name that already exists
+    /// use `Headers::append`
+    pub fn insert(
+        &mut self,
+        name: impl TryInto<HeaderName>,
+        values: impl ToHeaderValues,
+    ) -> crate::Result<Option<HeaderValues>> {
+        let name = name
+            .try_into()
+            .map_err(|_| crate::format_err!("Could not convert into header name"))?;
+        let values: HeaderValues = values.to_header_values()?.collect();
+        Ok(self.headers.insert(name, values))
+    }
+
+    /// Append a header to the headers.
+    ///
+    /// Unlike `insert` this function will not override the contents of a header, but insert a
+    /// header if there aren't any. Or else append to the existing list of headers.
+    pub fn append(
+        &mut self,
+        name: impl TryInto<HeaderName>,
+        values: impl ToHeaderValues,
+    ) -> crate::Result<()> {
+        let name = name
+            .try_into()
+            .map_err(|_| crate::format_err!("Could not convert into header name"))?;
+        match self.get_mut(&name) {
+            Some(headers) => {
+                let mut values: HeaderValues = values.to_header_values()?.collect();
+                headers.append(&mut values);
+            }
+            None => {
+                self.insert(name, values)?;
+            }
+        }
+        Ok(())
+    }
+
+    /// Get a reference to a header.
+    pub fn get(&self, name: &HeaderName) -> Option<&HeaderValues> {
+        self.headers.get(name)
+    }
+
+    /// Get a mutable reference to a header.
+    pub fn get_mut(&mut self, name: &HeaderName) -> Option<&mut HeaderValues> {
+        self.headers.get_mut(name)
+    }
+
+    /// Remove a header.
+    pub fn remove(&mut self, name: &HeaderName) -> Option<HeaderValues> {
+        self.headers.remove(name)
+    }
+
+    /// An iterator visiting all header pairs in arbitrary order.
+    pub fn iter(&self) -> Iter<'_> {
+        Iter {
+            inner: self.headers.iter(),
+        }
+    }
+
+    /// An iterator visiting all header pairs in arbitrary order, with mutable references to the
+    /// values.
+    pub fn iter_mut(&mut self) -> IterMut<'_> {
+        IterMut {
+            inner: self.headers.iter_mut(),
+        }
+    }
+
+    /// An iterator visiting all header names in arbitrary order.
+    pub fn names(&self) -> Names<'_> {
+        Names {
+            inner: self.headers.keys(),
+        }
+    }
+
+    /// An iterator visiting all header values in arbitrary order.
+    pub fn values(&self) -> Values<'_> {
+        Values::new(self.headers.values())
+    }
+}
+
+impl IntoIterator for Headers {
+    type Item = (HeaderName, HeaderValues);
+    type IntoIter = IntoIter;
+
+    /// Returns a iterator of references over the remaining items.
+    #[inline]
+    fn into_iter(self) -> Self::IntoIter {
+        IntoIter {
+            inner: self.headers.into_iter(),
+        }
+    }
+}
+
+impl<'a> IntoIterator for &'a Headers {
+    type Item = (&'a HeaderName, &'a HeaderValues);
+    type IntoIter = Iter<'a>;
+
+    #[inline]
+    fn into_iter(self) -> Self::IntoIter {
+        self.iter()
+    }
+}
+
+impl<'a> IntoIterator for &'a mut Headers {
+    type Item = (&'a HeaderName, &'a mut HeaderValues);
+    type IntoIter = IterMut<'a>;
+
+    #[inline]
+    fn into_iter(self) -> Self::IntoIter {
+        self.iter_mut()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::str::FromStr;
+
+    const STATIC_HEADER: HeaderName = HeaderName::from_lowercase_str("hello");
+
+    #[test]
+    fn test_header_name_static_non_static() -> crate::Result<()> {
+        let static_header = HeaderName::from_lowercase_str("hello");
+        let non_static_header = HeaderName::from_str("hello")?;
+
+        let mut headers = Headers::new();
+        headers.append(STATIC_HEADER, "foo0")?;
+        headers.append(static_header.clone(), "foo1")?;
+        headers.append(non_static_header.clone(), "foo2")?;
+
+        assert_eq!(
+            &headers.get(&STATIC_HEADER).unwrap()[..],
+            &["foo0", "foo1", "foo2",][..]
+        );
+
+        assert_eq!(
+            &headers.get(&static_header).unwrap()[..],
+            &["foo0", "foo1", "foo2",][..]
+        );
+
+        assert_eq!(
+            &headers.get(&non_static_header).unwrap()[..],
+            &["foo0", "foo1", "foo2",][..]
+        );
+
+        Ok(())
+    }
+}

--- a/src/headers/mod.rs
+++ b/src/headers/mod.rs
@@ -1,13 +1,10 @@
 //! HTTP headers.
 
-use std::collections::HashMap;
-use std::convert::TryInto;
-use std::iter::IntoIterator;
-
 mod constants;
 mod header_name;
 mod header_value;
 mod header_values;
+mod headers;
 mod into_iter;
 mod iter;
 mod iter_mut;
@@ -19,176 +16,10 @@ pub use constants::*;
 pub use header_name::HeaderName;
 pub use header_value::HeaderValue;
 pub use header_values::HeaderValues;
+pub use headers::Headers;
 pub use into_iter::IntoIter;
 pub use iter::Iter;
 pub use iter_mut::IterMut;
 pub use names::Names;
 pub use to_header_values::ToHeaderValues;
 pub use values::Values;
-
-/// A collection of HTTP Headers.
-#[derive(Debug, Clone)]
-pub struct Headers {
-    pub(crate) headers: HashMap<HeaderName, HeaderValues>,
-}
-
-impl Headers {
-    /// Create a new instance.
-    pub(crate) fn new() -> Self {
-        Self {
-            headers: HashMap::new(),
-        }
-    }
-
-    /// Insert a header into the headers.
-    ///
-    /// Not that this will replace all header values for a given header name.
-    /// If you wish to add header values for a header name that already exists
-    /// use `Headers::append`
-    pub fn insert(
-        &mut self,
-        name: impl TryInto<HeaderName>,
-        values: impl ToHeaderValues,
-    ) -> crate::Result<Option<HeaderValues>> {
-        let name = name
-            .try_into()
-            .map_err(|_| crate::format_err!("Could not convert into header name"))?;
-        let values: HeaderValues = values.to_header_values()?.collect();
-        Ok(self.headers.insert(name, values))
-    }
-
-    /// Append a header to the headers.
-    ///
-    /// Unlike `insert` this function will not override the contents of a header, but insert a
-    /// header if there aren't any. Or else append to the existing list of headers.
-    pub fn append(
-        &mut self,
-        name: impl TryInto<HeaderName>,
-        values: impl ToHeaderValues,
-    ) -> crate::Result<()> {
-        let name = name
-            .try_into()
-            .map_err(|_| crate::format_err!("Could not convert into header name"))?;
-        match self.get_mut(&name) {
-            Some(headers) => {
-                let mut values: HeaderValues = values.to_header_values()?.collect();
-                headers.append(&mut values);
-            }
-            None => {
-                self.insert(name, values)?;
-            }
-        }
-        Ok(())
-    }
-
-    /// Get a reference to a header.
-    pub fn get(&self, name: &HeaderName) -> Option<&HeaderValues> {
-        self.headers.get(name)
-    }
-
-    /// Get a mutable reference to a header.
-    pub fn get_mut(&mut self, name: &HeaderName) -> Option<&mut HeaderValues> {
-        self.headers.get_mut(name)
-    }
-
-    /// Remove a header.
-    pub fn remove(&mut self, name: &HeaderName) -> Option<HeaderValues> {
-        self.headers.remove(name)
-    }
-
-    /// An iterator visiting all header pairs in arbitrary order.
-    pub fn iter(&self) -> Iter<'_> {
-        Iter {
-            inner: self.headers.iter(),
-        }
-    }
-
-    /// An iterator visiting all header pairs in arbitrary order, with mutable references to the
-    /// values.
-    pub fn iter_mut(&mut self) -> IterMut<'_> {
-        IterMut {
-            inner: self.headers.iter_mut(),
-        }
-    }
-
-    /// An iterator visiting all header names in arbitrary order.
-    pub fn names(&self) -> Names<'_> {
-        Names {
-            inner: self.headers.keys(),
-        }
-    }
-
-    /// An iterator visiting all header values in arbitrary order.
-    pub fn values(&self) -> Values<'_> {
-        Values::new(self.headers.values())
-    }
-}
-
-impl IntoIterator for Headers {
-    type Item = (HeaderName, HeaderValues);
-    type IntoIter = IntoIter;
-
-    /// Returns a iterator of references over the remaining items.
-    #[inline]
-    fn into_iter(self) -> Self::IntoIter {
-        IntoIter {
-            inner: self.headers.into_iter(),
-        }
-    }
-}
-
-impl<'a> IntoIterator for &'a Headers {
-    type Item = (&'a HeaderName, &'a HeaderValues);
-    type IntoIter = Iter<'a>;
-
-    #[inline]
-    fn into_iter(self) -> Self::IntoIter {
-        self.iter()
-    }
-}
-
-impl<'a> IntoIterator for &'a mut Headers {
-    type Item = (&'a HeaderName, &'a mut HeaderValues);
-    type IntoIter = IterMut<'a>;
-
-    #[inline]
-    fn into_iter(self) -> Self::IntoIter {
-        self.iter_mut()
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use std::str::FromStr;
-
-    const STATIC_HEADER: HeaderName = HeaderName::from_lowercase_str("hello");
-
-    #[test]
-    fn test_header_name_static_non_static() -> crate::Result<()> {
-        let static_header = HeaderName::from_lowercase_str("hello");
-        let non_static_header = HeaderName::from_str("hello")?;
-
-        let mut headers = Headers::new();
-        headers.append(STATIC_HEADER, "foo0")?;
-        headers.append(static_header.clone(), "foo1")?;
-        headers.append(non_static_header.clone(), "foo2")?;
-
-        assert_eq!(
-            &headers.get(&STATIC_HEADER).unwrap()[..],
-            &["foo0", "foo1", "foo2",][..]
-        );
-
-        assert_eq!(
-            &headers.get(&static_header).unwrap()[..],
-            &["foo0", "foo1", "foo2",][..]
-        );
-
-        assert_eq!(
-            &headers.get(&non_static_header).unwrap()[..],
-            &["foo0", "foo1", "foo2",][..]
-        );
-
-        Ok(())
-    }
-}

--- a/src/request.rs
+++ b/src/request.rs
@@ -3,6 +3,7 @@ use async_std::sync;
 
 use std::convert::TryInto;
 use std::mem;
+use std::ops::Index;
 use std::pin::Pin;
 use std::task::{Context, Poll};
 
@@ -481,6 +482,34 @@ impl AsMut<Headers> for Request {
 impl From<Request> for Body {
     fn from(req: Request) -> Body {
         req.body
+    }
+}
+
+impl Index<&HeaderName> for Request {
+    type Output = HeaderValues;
+
+    /// Returns a reference to the value corresponding to the supplied name.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the name is not present in `Request`.
+    #[inline]
+    fn index(&self, name: &HeaderName) -> &HeaderValues {
+        self.headers.index(name)
+    }
+}
+
+impl Index<&str> for Request {
+    type Output = HeaderValues;
+
+    /// Returns a reference to the value corresponding to the supplied name.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the name is not present in `Request`.
+    #[inline]
+    fn index(&self, name: &str) -> &HeaderValues {
+        self.headers.index(name)
     }
 }
 

--- a/src/response.rs
+++ b/src/response.rs
@@ -3,6 +3,7 @@ use async_std::sync;
 
 use std::convert::TryInto;
 use std::mem;
+use std::ops::Index;
 use std::pin::Pin;
 use std::task::{Context, Poll};
 
@@ -446,6 +447,33 @@ impl AsMut<Headers> for Response {
 impl From<()> for Response {
     fn from(_: ()) -> Self {
         Response::new(StatusCode::NoContent)
+    }
+}
+impl Index<&HeaderName> for Response {
+    type Output = HeaderValues;
+
+    /// Returns a reference to the value corresponding to the supplied name.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the name is not present in `Response`.
+    #[inline]
+    fn index(&self, name: &HeaderName) -> &HeaderValues {
+        self.headers.index(name)
+    }
+}
+
+impl Index<&str> for Response {
+    type Output = HeaderValues;
+
+    /// Returns a reference to the value corresponding to the supplied name.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the name is not present in `Response`.
+    #[inline]
+    fn index(&self, name: &str) -> &HeaderValues {
+        self.headers.index(name)
     }
 }
 

--- a/src/trailers.rs
+++ b/src/trailers.rs
@@ -55,7 +55,7 @@ use async_std::sync;
 
 use std::convert::TryInto;
 use std::future::Future;
-use std::ops::{Deref, DerefMut};
+use std::ops::{Deref, DerefMut, Index};
 use std::pin::Pin;
 use std::task::{Context, Poll};
 
@@ -178,6 +178,34 @@ impl Deref for Trailers {
 impl DerefMut for Trailers {
     fn deref_mut(&mut self) -> &mut Self::Target {
         &mut self.headers
+    }
+}
+
+impl Index<&HeaderName> for Trailers {
+    type Output = HeaderValues;
+
+    /// Returns a reference to the value corresponding to the supplied name.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the name is not present in `Trailers`.
+    #[inline]
+    fn index(&self, name: &HeaderName) -> &HeaderValues {
+        self.headers.index(name)
+    }
+}
+
+impl Index<&str> for Trailers {
+    type Output = HeaderValues;
+
+    /// Returns a reference to the value corresponding to the supplied name.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the name is not present in `Trailers`.
+    #[inline]
+    fn index(&self, name: &str) -> &HeaderValues {
+        self.headers.index(name)
     }
 }
 


### PR DESCRIPTION
Depends on https://github.com/http-rs/http-types/pull/109. This allows us to index into headers as:

```rust
use http_types::{Response, StatusCode};

let mut res = Response::new(StatusCode::Ok);
res.insert_header("hello", "foo0").unwrap();
assert_eq!(res["hello"], "foo0");
```

This should make it significantly easier to test whether headers exist. Thanks!