### PR TITLE
Fix incorrect headervalues comparison

### DIFF
--- a/src/headers/header_values.rs
+++ b/src/headers/header_values.rs
@@ -85,25 +85,25 @@ impl Display for HeaderValues {
 
 impl PartialEq<str> for HeaderValues {
     fn eq(&self, other: &str) -> bool {
-        self.inner[0] == other
+        self.inner.len() == 1 && self.inner[0] == other
     }
 }
 
 impl<'a> PartialEq<&'a str> for HeaderValues {
     fn eq(&self, other: &&'a str) -> bool {
-        &self.inner[0] == other
+        self.inner.len() == 1 && &self.inner[0] == other
     }
 }
 
 impl PartialEq<String> for HeaderValues {
     fn eq(&self, other: &String) -> bool {
-        &self.inner[0] == other
+        self.inner.len() == 1 && &self.inner[0] == other
     }
 }
 
 impl<'a> PartialEq<&String> for HeaderValues {
     fn eq(&self, other: &&String) -> bool {
-        &&self.inner[0] == other
+        self.inner.len() == 1 && &&self.inner[0] == other
     }
 }
 


### PR DESCRIPTION
We weren't validating we're indeed only one item long when comparing HeaderValues with singular other items. If we aren't we should reject. Thanks!