### PR TITLE
Rename TypeMap to Extensions

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -121,13 +121,13 @@ pub mod mime;
 
 mod body;
 mod error;
+mod extensions;
 mod macros;
 mod method;
 mod request;
 mod response;
 mod status;
 mod status_code;
-mod type_map;
 mod version;
 
 cfg_unstable! {
@@ -171,7 +171,7 @@ pub mod security;
 mod hyperium_http;
 
 #[doc(inline)]
-pub use crate::type_map::TypeMap;
+pub use crate::extensions::Extensions;
 
 /// Traits for conversions between types.
 pub mod convert {

--- a/src/request.rs
+++ b/src/request.rs
@@ -14,7 +14,7 @@ use crate::headers::{
 };
 use crate::mime::Mime;
 use crate::trailers::{self, Trailers};
-use crate::{Body, Method, TypeMap, Url, Version};
+use crate::{Body, Extensions, Method, Url, Version};
 
 pin_project_lite::pin_project! {
     /// An HTTP request.
@@ -37,9 +37,9 @@ pin_project_lite::pin_project! {
         receiver: Option<sync::Receiver<Trailers>>,
         #[pin]
         body: Body,
-        local: TypeMap,
         local_addr: Option<String>,
         peer_addr: Option<String>,
+        ext: Extensions,
     }
 }
 
@@ -55,7 +55,7 @@ impl Request {
             body: Body::empty(),
             sender: Some(sender),
             receiver: Some(receiver),
-            local: TypeMap::new(),
+            ext: Extensions::new(),
             peer_addr: None,
             local_addr: None,
         }
@@ -539,12 +539,11 @@ impl Request {
     }
 
     /// Returns a reference to the existing local state.
-    pub fn local(&self) -> &TypeMap {
-        &self.local
+    pub fn ext(&self) -> &Extensions {
+        &self.ext
     }
 
     /// Returns a mutuable reference to the existing local state.
-    ///
     ///
     /// # Examples
     ///
@@ -554,13 +553,13 @@ impl Request {
     /// use http_types::{Url, Method, Request, Version};
     ///
     /// let mut req = Request::new(Method::Get, Url::parse("https://example.com")?);
-    /// req.local_mut().insert("hello from the extension");
-    /// assert_eq!(req.local().get(), Some(&"hello from the extension"));
+    /// req.ext_mut().insert("hello from the extension");
+    /// assert_eq!(req.ext().get(), Some(&"hello from the extension"));
     /// #
     /// # Ok(()) }
     /// ```
-    pub fn local_mut(&mut self) -> &mut TypeMap {
-        &mut self.local
+    pub fn ext_mut(&mut self) -> &mut Extensions {
+        &mut self.ext
     }
 }
 
@@ -575,7 +574,7 @@ impl Clone for Request {
             sender: self.sender.clone(),
             receiver: self.receiver.clone(),
             body: Body::empty(),
-            local: TypeMap::new(),
+            ext: Extensions::new(),
             peer_addr: self.peer_addr.clone(),
             local_addr: self.local_addr.clone(),
         }

--- a/src/response.rs
+++ b/src/response.rs
@@ -14,7 +14,7 @@ use crate::headers::{
 };
 use crate::mime::Mime;
 use crate::trailers::{self, Trailers};
-use crate::{Body, StatusCode, TypeMap, Version};
+use crate::{Body, Extensions, StatusCode, Version};
 
 pin_project_lite::pin_project! {
     /// An HTTP response.
@@ -40,7 +40,7 @@ pin_project_lite::pin_project! {
         receiver: Option<sync::Receiver<Trailers>>,
         #[pin]
         body: Body,
-        local: TypeMap,
+        ext: Extensions,
         local_addr: Option<String>,
         peer_addr: Option<String>,
     }
@@ -57,7 +57,7 @@ impl Response {
             body: Body::empty(),
             sender: Some(sender),
             receiver: Some(receiver),
-            local: TypeMap::new(),
+            ext: Extensions::new(),
             peer_addr: None,
             local_addr: None,
         }
@@ -481,8 +481,8 @@ impl Response {
     }
 
     /// Returns a reference to the existing local.
-    pub fn local(&self) -> &TypeMap {
-        &self.local
+    pub fn ext(&self) -> &Extensions {
+        &self.ext
     }
 
     /// Returns a mutuable reference to the existing local state.
@@ -496,13 +496,13 @@ impl Response {
     /// use http_types::{StatusCode, Response, Version};
     ///
     /// let mut res = Response::new(StatusCode::Ok);
-    /// res.local_mut().insert("hello from the extension");
-    /// assert_eq!(res.local().get(), Some(&"hello from the extension"));
+    /// res.ext_mut().insert("hello from the extension");
+    /// assert_eq!(res.ext().get(), Some(&"hello from the extension"));
     /// #
     /// # Ok(()) }
     /// ```
-    pub fn local_mut(&mut self) -> &mut TypeMap {
-        &mut self.local
+    pub fn ext_mut(&mut self) -> &mut Extensions {
+        &mut self.ext
     }
 }
 
@@ -516,7 +516,7 @@ impl Clone for Response {
             sender: self.sender.clone(),
             receiver: self.receiver.clone(),
             body: Body::empty(),
-            local: TypeMap::new(),
+            ext: Extensions::new(),
             peer_addr: self.peer_addr.clone(),
             local_addr: self.local_addr.clone(),
         }


### PR DESCRIPTION
Implements #116. Thanks!

## Screenshots

![Screenshot_2020-04-24 http_types - Rust](https://user-images.githubusercontent.com/2467194/80204431-21f97880-8629-11ea-9bc0-b8fa4c89285b.png)
