### PR TITLE
Add peer and local socket addrs, as well as Request::remote

### DIFF
--- a/src/request.rs
+++ b/src/request.rs
@@ -60,12 +60,12 @@ impl Request {
         }
     }
 
-    /// get the peer socket address for the underlying transport, if appropriate
+    /// Get the peer socket address for the underlying transport, if appropriate
     pub fn peer_addr(&self) -> Option<SocketAddr> {
         self.peer_addr
     }
 
-    /// get the local socket address for the underlying transport, if appropriate
+    /// Get the local socket address for the underlying transport, if appropriate
     pub fn local_addr(&self) -> Option<SocketAddr> {
         self.local_addr
     }

--- a/src/request.rs
+++ b/src/request.rs
@@ -1,9 +1,9 @@
 use async_std::io::{self, BufRead, Read};
 use async_std::sync;
 
-use std::net::SocketAddr;
 use std::convert::TryInto;
 use std::mem;
+use std::net::SocketAddr;
 use std::pin::Pin;
 use std::task::{Context, Poll};
 
@@ -69,7 +69,6 @@ impl Request {
     pub fn local_addr(&self) -> Option<SocketAddr> {
         self.local_addr
     }
-        
 
     /// Get the HTTP method
     pub fn method(&self) -> Method {

--- a/src/request.rs
+++ b/src/request.rs
@@ -59,22 +59,28 @@ impl Request {
         }
     }
 
-    #[doc(hidden)]
+    /// Sets a string representation of the peer address of this
+    /// request. This might take the form of an ip/fqdn and port or a
+    /// local socket address.
     pub fn set_peer_addr(&mut self, peer_addr: Option<impl std::string::ToString>) {
         self.peer_addr = peer_addr.map(|addr| addr.to_string());
     }
 
-    #[doc(hidden)]
+    /// Sets a string representation of the local address that this
+    /// request was received on. This might take the form of an ip/fqdn and
+    /// port, or a local socket address.
     pub fn set_local_addr(&mut self, local_addr: Option<impl std::string::ToString>) {
         self.local_addr = local_addr.map(|addr| addr.to_string());
     }
 
-    /// Get the peer socket address for the underlying transport, if appropriate
+    /// Get the peer socket address for the underlying transport, if
+    /// that information is available for this request.
     pub fn peer_addr(&self) -> Option<&str> {
         self.peer_addr.as_deref()
     }
 
-    /// Get the local socket address for the underlying transport, if appropriate
+    /// Get the local socket address for the underlying transport, if
+    /// that information is available for this request.
     pub fn local_addr(&self) -> Option<&str> {
         self.local_addr.as_deref()
     }
@@ -84,9 +90,7 @@ impl Request {
         self.forwarded_for().or(self.peer_addr())
     }
 
-    /// Parses the Forwarded or X-Forwarded-For headers.
-    /// The returned String will either be an IP address or a domain and an optional port.
-    pub fn forwarded_for(&self) -> Option<&str> {
+    fn forwarded_for(&self) -> Option<&str> {
         if let Some(header) = self.header(&"Forwarded".parse().unwrap()) {
             header.as_str().split(";").find_map(|key_equals_value| {
                 let parts = key_equals_value.split("=").collect::<Vec<_>>();

--- a/src/request.rs
+++ b/src/request.rs
@@ -1,6 +1,7 @@
 use async_std::io::{self, BufRead, Read};
 use async_std::sync;
 
+use std::net::SocketAddr;
 use std::convert::TryInto;
 use std::mem;
 use std::pin::Pin;
@@ -36,6 +37,8 @@ pin_project_lite::pin_project! {
         #[pin]
         body: Body,
         local: TypeMap,
+        local_addr: Option<SocketAddr>,
+        peer_addr: Option<SocketAddr>,
     }
 }
 
@@ -52,8 +55,21 @@ impl Request {
             sender: Some(sender),
             receiver: Some(receiver),
             local: TypeMap::new(),
+            peer_addr: None,
+            local_addr: None,
         }
     }
+
+    /// get the peer socket address for the underlying transport, if appropriate
+    pub fn peer_addr(&self) -> Option<SocketAddr> {
+        self.peer_addr
+    }
+
+    /// get the local socket address for the underlying transport, if appropriate
+    pub fn local_addr(&self) -> Option<SocketAddr> {
+        self.local_addr
+    }
+        
 
     /// Get the HTTP method
     pub fn method(&self) -> Method {

--- a/src/request.rs
+++ b/src/request.rs
@@ -480,6 +480,8 @@ impl Clone for Request {
             receiver: self.receiver.clone(),
             body: Body::empty(),
             local: TypeMap::new(),
+            peer_addr: self.peer_addr.clone(),
+            local_addr: self.local_addr.clone(),
         }
     }
 }

--- a/src/response.rs
+++ b/src/response.rs
@@ -335,6 +335,16 @@ impl Response {
         self.version
     }
 
+    #[doc(hidden)]
+    pub fn set_peer_addr(&mut self, peer_addr: Option<impl std::string::ToString>) {
+        self.peer_addr = peer_addr.map(|addr| addr.to_string());
+    }
+
+    #[doc(hidden)]
+    pub fn set_local_addr(&mut self, local_addr: Option<impl std::string::ToString>) {
+        self.local_addr = local_addr.map(|addr| addr.to_string());
+    }
+
     /// Get the peer socket address for the underlying transport, if appropriate
     pub fn peer_addr(&self) -> Option<&str> {
         self.peer_addr.as_deref()

--- a/src/response.rs
+++ b/src/response.rs
@@ -3,7 +3,6 @@ use async_std::sync;
 
 use std::convert::TryInto;
 use std::mem;
-use std::net::SocketAddr;
 use std::pin::Pin;
 use std::task::{Context, Poll};
 
@@ -40,8 +39,8 @@ pin_project_lite::pin_project! {
         #[pin]
         body: Body,
         local: TypeMap,
-        local_addr: Option<SocketAddr>,
-        peer_addr: Option<SocketAddr>,
+        local_addr: Option<String>,
+        peer_addr: Option<String>,
     }
 }
 
@@ -337,13 +336,13 @@ impl Response {
     }
 
     /// Get the peer socket address for the underlying transport, if appropriate
-    pub fn peer_addr(&self) -> Option<SocketAddr> {
-        self.peer_addr
+    pub fn peer_addr(&self) -> Option<&str> {
+        self.peer_addr.as_deref()
     }
 
     /// Get the local socket address for the underlying transport, if appropriate
-    pub fn local_addr(&self) -> Option<SocketAddr> {
-        self.local_addr
+    pub fn local_addr(&self) -> Option<&str> {
+        self.local_addr.as_deref()
     }
 
     /// Set the HTTP version.
@@ -540,3 +539,4 @@ impl<'a> IntoIterator for &'a mut Response {
         self.headers.iter_mut()
     }
 }
+

--- a/src/response.rs
+++ b/src/response.rs
@@ -335,12 +335,16 @@ impl Response {
         self.version
     }
 
-    #[doc(hidden)]
+    /// Sets a string representation of the peer address that this
+    /// response was sent to. This might take the form of an ip/fqdn
+    /// and port or a local socket address.
     pub fn set_peer_addr(&mut self, peer_addr: Option<impl std::string::ToString>) {
         self.peer_addr = peer_addr.map(|addr| addr.to_string());
     }
 
-    #[doc(hidden)]
+    /// Sets a string representation of the local address that this
+    /// response was sent on. This might take the form of an ip/fqdn and
+    /// port, or a local socket address.
     pub fn set_local_addr(&mut self, local_addr: Option<impl std::string::ToString>) {
         self.local_addr = local_addr.map(|addr| addr.to_string());
     }

--- a/src/response.rs
+++ b/src/response.rs
@@ -539,4 +539,3 @@ impl<'a> IntoIterator for &'a mut Response {
         self.headers.iter_mut()
     }
 }
-

--- a/src/response.rs
+++ b/src/response.rs
@@ -3,6 +3,7 @@ use async_std::sync;
 
 use std::convert::TryInto;
 use std::mem;
+use std::net::SocketAddr;
 use std::pin::Pin;
 use std::task::{Context, Poll};
 
@@ -39,6 +40,8 @@ pin_project_lite::pin_project! {
         #[pin]
         body: Body,
         local: TypeMap,
+        local_addr: Option<SocketAddr>,
+        peer_addr: Option<SocketAddr>,
     }
 }
 
@@ -54,6 +57,8 @@ impl Response {
             sender: Some(sender),
             receiver: Some(receiver),
             local: TypeMap::new(),
+            peer_addr: None,
+            local_addr: None,
         }
     }
 
@@ -331,6 +336,16 @@ impl Response {
         self.version
     }
 
+    /// Get the peer socket address for the underlying transport, if appropriate
+    pub fn peer_addr(&self) -> Option<SocketAddr> {
+        self.peer_addr
+    }
+
+    /// Get the local socket address for the underlying transport, if appropriate
+    pub fn local_addr(&self) -> Option<SocketAddr> {
+        self.local_addr
+    }
+
     /// Set the HTTP version.
     ///
     /// # Examples
@@ -430,6 +445,8 @@ impl Clone for Response {
             receiver: self.receiver.clone(),
             body: Body::empty(),
             local: TypeMap::new(),
+            peer_addr: self.peer_addr.clone(),
+            local_addr: self.local_addr.clone(),
         }
     }
 }


### PR DESCRIPTION
this is the first PR of three to address https://github.com/http-rs/tide/issues/462

This also adds an initial implementation of Request::remote and Request::forwarded_for. Parsing the Forwarded header value probably would be more elegant with a proper parsing or regex library, but I didn't want to add an additional dependency just for this.