### PR TITLE
Improve usage ergonomics

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,7 @@ cookie = "0.12.0"
 infer = "0.1.2"
 omnom = "2.1.1"
 pin-project-lite = "0.1.0"
-url = "2.1.0"
+url = "2.1.1"
 serde_json = "1.0.51"
 serde = { version = "1.0.106", features = ["derive"] }
 serde_urlencoded = "0.6.1"

--- a/src/headers/header_name.rs
+++ b/src/headers/header_name.rs
@@ -71,7 +71,7 @@ impl From<&HeaderName> for HeaderName {
 
 impl<'a> From<&'a str> for HeaderName {
     fn from(value: &'a str) -> Self {
-        Self::from_str(value).unwrap()
+        Self::from_str(value).expect("String slice should be valid ASCII")
     }
 }
 

--- a/src/headers/header_name.rs
+++ b/src/headers/header_name.rs
@@ -63,11 +63,9 @@ impl FromStr for HeaderName {
     }
 }
 
-impl<'a> std::convert::TryFrom<&'a str> for HeaderName {
-    type Error = Error;
-
-    fn try_from(value: &'a str) -> Result<Self, Self::Error> {
-        Self::from_str(value)
+impl<'a> From<&'a str> for HeaderName {
+    fn from(value: &'a str) -> Self {
+        Self::from_str(value).unwrap()
     }
 }
 

--- a/src/headers/header_name.rs
+++ b/src/headers/header_name.rs
@@ -63,6 +63,12 @@ impl FromStr for HeaderName {
     }
 }
 
+impl From<&HeaderName> for HeaderName {
+    fn from(value: &HeaderName) -> HeaderName {
+        value.clone()
+    }
+}
+
 impl<'a> From<&'a str> for HeaderName {
     fn from(value: &'a str) -> Self {
         Self::from_str(value).unwrap()
@@ -133,5 +139,11 @@ mod tests {
 
         // Must validate regardless of casing.
         assert_eq!(static_header, &String::from("Hello"));
+    }
+
+    #[test]
+    fn pass_name_by_ref() {
+        let mut res = crate::Response::new(200);
+        res.insert_header(&crate::headers::HOST, "127.0.0.1");
     }
 }

--- a/src/headers/header_value.rs
+++ b/src/headers/header_value.rs
@@ -1,3 +1,4 @@
+use std::convert::TryFrom;
 use std::fmt::{self, Display};
 use std::str::FromStr;
 
@@ -83,7 +84,7 @@ impl FromStr for HeaderValue {
     }
 }
 
-impl<'a> std::convert::TryFrom<&'a str> for HeaderValue {
+impl<'a> TryFrom<&'a str> for HeaderValue {
     type Error = Error;
 
     fn try_from(value: &'a str) -> Result<Self, Self::Error> {

--- a/src/headers/header_values.rs
+++ b/src/headers/header_values.rs
@@ -95,6 +95,12 @@ impl<'a> PartialEq<&'a str> for HeaderValues {
     }
 }
 
+impl<'a> PartialEq<[&'a str]> for HeaderValues {
+    fn eq(&self, other: &[&'a str]) -> bool {
+        self.inner.iter().eq(other.iter())
+    }
+}
+
 impl PartialEq<String> for HeaderValues {
     fn eq(&self, other: &String) -> bool {
         self.inner.len() == 1 && &self.inner[0] == other

--- a/src/headers/headers.rs
+++ b/src/headers/headers.rs
@@ -1,7 +1,7 @@
 //! HTTP headers.
 
 use std::collections::HashMap;
-use std::convert::TryInto;
+use std::convert::Into;
 use std::iter::IntoIterator;
 use std::ops::Index;
 use std::str::FromStr;
@@ -23,7 +23,7 @@ use crate::headers::{
 /// use http_types::{Response, StatusCode};
 ///
 /// let mut res = Response::new(StatusCode::Ok);
-/// res.insert_header("hello", "foo0").unwrap();
+/// res.insert_header("hello", "foo0");
 /// assert_eq!(res["hello"], "foo0");
 /// ```
 #[derive(Debug, Clone)]
@@ -46,14 +46,12 @@ impl Headers {
     /// use `Headers::append`
     pub fn insert(
         &mut self,
-        name: impl TryInto<HeaderName>,
+        name: impl Into<HeaderName>,
         values: impl ToHeaderValues,
-    ) -> crate::Result<Option<HeaderValues>> {
-        let name = name
-            .try_into()
-            .map_err(|_| crate::format_err!("Could not convert into header name"))?;
-        let values: HeaderValues = values.to_header_values()?.collect();
-        Ok(self.headers.insert(name, values))
+    ) -> Option<HeaderValues> {
+        let name = name.into();
+        let values: HeaderValues = values.to_header_values().unwrap().collect();
+        self.headers.insert(name, values)
     }
 
     /// Append a header to the headers.
@@ -62,27 +60,25 @@ impl Headers {
     /// header if there aren't any. Or else append to the existing list of headers.
     pub fn append(
         &mut self,
-        name: impl TryInto<HeaderName>,
+        name: impl Into<HeaderName>,
         values: impl ToHeaderValues,
     ) -> crate::Result<()> {
-        let name = name
-            .try_into()
-            .map_err(|_| crate::format_err!("Could not convert into header name"))?;
+        let name = name.into();
         match self.get_mut(&name) {
             Some(headers) => {
                 let mut values: HeaderValues = values.to_header_values()?.collect();
                 headers.append(&mut values);
             }
             None => {
-                self.insert(name, values)?;
+                self.insert(name, values);
             }
         }
         Ok(())
     }
 
     /// Get a reference to a header.
-    pub fn get(&self, name: &HeaderName) -> Option<&HeaderValues> {
-        self.headers.get(name)
+    pub fn get(&self, name: impl Into<HeaderName>) -> Option<&HeaderValues> {
+        self.headers.get(&name.into())
     }
 
     /// Get a mutable reference to a header.
@@ -123,7 +119,7 @@ impl Headers {
     }
 }
 
-impl Index<&HeaderName> for Headers {
+impl Index<HeaderName> for Headers {
     type Output = HeaderValues;
 
     /// Returns a reference to the value corresponding to the supplied name.
@@ -132,7 +128,7 @@ impl Index<&HeaderName> for Headers {
     ///
     /// Panics if the name is not present in `Headers`.
     #[inline]
-    fn index(&self, name: &HeaderName) -> &HeaderValues {
+    fn index(&self, name: HeaderName) -> &HeaderValues {
         self.get(name).expect("no entry found for name")
     }
 }
@@ -148,7 +144,7 @@ impl Index<&str> for Headers {
     #[inline]
     fn index(&self, name: &str) -> &HeaderValues {
         let name = HeaderName::from_str(name).expect("string slice needs to be valid ASCII");
-        self.get(&name).expect("no entry found for name")
+        self.get(name).expect("no entry found for name")
     }
 }
 
@@ -202,20 +198,9 @@ mod tests {
         headers.append(static_header.clone(), "foo1")?;
         headers.append(non_static_header.clone(), "foo2")?;
 
-        assert_eq!(
-            &headers.get(&STATIC_HEADER).unwrap()[..],
-            &["foo0", "foo1", "foo2",][..]
-        );
-
-        assert_eq!(
-            &headers.get(&static_header).unwrap()[..],
-            &["foo0", "foo1", "foo2",][..]
-        );
-
-        assert_eq!(
-            &headers.get(&non_static_header).unwrap()[..],
-            &["foo0", "foo1", "foo2",][..]
-        );
+        assert_eq!(headers[STATIC_HEADER], ["foo0", "foo1", "foo2",][..]);
+        assert_eq!(headers[static_header], ["foo0", "foo1", "foo2",][..]);
+        assert_eq!(headers[non_static_header], ["foo0", "foo1", "foo2",][..]);
 
         Ok(())
     }
@@ -223,7 +208,8 @@ mod tests {
     #[test]
     fn index_into_headers() {
         let mut headers = Headers::new();
-        headers.insert("hello", "foo0").unwrap();
+        headers.insert("hello", "foo0");
         assert_eq!(headers["hello"], "foo0");
+        assert_eq!(headers.get("hello").unwrap(), "foo0");
     }
 }

--- a/src/headers/headers.rs
+++ b/src/headers/headers.rs
@@ -64,7 +64,7 @@ impl Headers {
         values: impl ToHeaderValues,
     ) -> crate::Result<()> {
         let name = name.into();
-        match self.get_mut(&name) {
+        match self.get_mut(name.clone()) {
             Some(headers) => {
                 let mut values: HeaderValues = values.to_header_values()?.collect();
                 headers.append(&mut values);
@@ -82,13 +82,13 @@ impl Headers {
     }
 
     /// Get a mutable reference to a header.
-    pub fn get_mut(&mut self, name: &HeaderName) -> Option<&mut HeaderValues> {
-        self.headers.get_mut(name)
+    pub fn get_mut(&mut self, name: impl Into<HeaderName>) -> Option<&mut HeaderValues> {
+        self.headers.get_mut(&name.into())
     }
 
     /// Remove a header.
-    pub fn remove(&mut self, name: &HeaderName) -> Option<HeaderValues> {
-        self.headers.remove(name)
+    pub fn remove(&mut self, name: impl Into<HeaderName>) -> Option<HeaderValues> {
+        self.headers.remove(&name.into())
     }
 
     /// An iterator visiting all header pairs in arbitrary order.

--- a/src/hyperium_http.rs
+++ b/src/hyperium_http.rs
@@ -120,8 +120,7 @@ impl From<Request> for http::Request<Body> {
 impl From<http::Response<Body>> for Response {
     fn from(res: http::Response<Body>) -> Self {
         let (parts, body) = res.into_parts();
-        let status = parts.status.into();
-        let mut res = Response::new(status);
+        let mut res = Response::new(parts.status);
         res.set_body(body);
         res.set_version(Some(parts.version.into()));
         hyperium_headers_to_headers(parts.headers, res.as_mut());

--- a/src/request.rs
+++ b/src/request.rs
@@ -369,13 +369,13 @@ impl Request {
     }
 
     /// Get a mutable reference to a header.
-    pub fn header_mut(&mut self, name: &HeaderName) -> Option<&mut HeaderValues> {
-        self.headers.get_mut(name)
+    pub fn header_mut(&mut self, name: impl Into<HeaderName>) -> Option<&mut HeaderValues> {
+        self.headers.get_mut(name.into())
     }
 
     /// Remove a header.
-    pub fn remove_header(&mut self, name: &HeaderName) -> Option<HeaderValues> {
-        self.headers.remove(name)
+    pub fn remove_header(&mut self, name: impl Into<HeaderName>) -> Option<HeaderValues> {
+        self.headers.remove(name.into())
     }
 
     /// Set an HTTP header.

--- a/src/response.rs
+++ b/src/response.rs
@@ -1,7 +1,8 @@
 use async_std::io::{self, BufRead, Read};
 use async_std::sync;
 
-use std::convert::Into;
+use std::convert::{Into, TryInto};
+use std::fmt::Debug;
 use std::mem;
 use std::ops::Index;
 use std::pin::Pin;
@@ -48,7 +49,14 @@ pin_project_lite::pin_project! {
 
 impl Response {
     /// Create a new response.
-    pub fn new(status: StatusCode) -> Self {
+    pub fn new<S>(status: S) -> Self
+    where
+        S: TryInto<StatusCode>,
+        S::Error: Debug,
+    {
+        let status = status
+            .try_into()
+            .expect("Could not convert into a valid `StatusCode`");
         let (sender, receiver) = sync::channel(1);
         Self {
             status,

--- a/src/response.rs
+++ b/src/response.rs
@@ -69,18 +69,18 @@ impl Response {
     }
 
     /// Get a mutable reference to a header.
-    pub fn header_mut(&mut self, name: &HeaderName) -> Option<&mut HeaderValues> {
-        self.headers.get_mut(name)
+    pub fn header_mut(&mut self, name: impl Into<HeaderName>) -> Option<&mut HeaderValues> {
+        self.headers.get_mut(name.into())
     }
 
     /// Get an HTTP header.
     pub fn header(&self, name: impl Into<HeaderName>) -> Option<&HeaderValues> {
-        self.headers.get(name)
+        self.headers.get(name.into())
     }
 
     /// Remove a header.
-    pub fn remove_header(&mut self, name: &HeaderName) -> Option<HeaderValues> {
-        self.headers.remove(name)
+    pub fn remove_header(&mut self, name: impl Into<HeaderName>) -> Option<HeaderValues> {
+        self.headers.remove(name.into())
     }
 
     /// Set an HTTP header.

--- a/src/response.rs
+++ b/src/response.rs
@@ -648,6 +648,7 @@ impl<'a> IntoIterator for &'a mut Response {
     }
 }
 
+#[cfg(test)]
 mod test {
     use super::Response;
     #[test]

--- a/src/response.rs
+++ b/src/response.rs
@@ -647,3 +647,11 @@ impl<'a> IntoIterator for &'a mut Response {
         self.headers.iter_mut()
     }
 }
+
+mod test {
+    use super::Response;
+    #[test]
+    fn construct_shorthand() {
+        let _res = Response::new(200);
+    }
+}

--- a/src/security/csp.rs
+++ b/src/security/csp.rs
@@ -121,11 +121,7 @@ pub struct ReportToEndpoint {
 /// security::default(&mut res);
 /// policy.apply(&mut res);
 ///
-/// let name =
-///     headers::HeaderName::from_ascii("content-security-policy".to_owned().into_bytes()).unwrap();
-/// let headers = res.header(&name).unwrap();
-/// let header = headers.iter().next().unwrap();
-/// assert_eq!(header, "base-uri 'none'; default-src 'self' areweasyncyet.rs; object-src 'none'; script-src 'self' 'unsafe-inline'; upgrade-insecure-requests");
+/// assert_eq!(res["content-security-policy"], "base-uri 'none'; default-src 'self' areweasyncyet.rs; object-src 'none'; script-src 'self' 'unsafe-inline'; upgrade-insecure-requests");
 /// ```
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ContentSecurityPolicy {
@@ -358,9 +354,6 @@ impl ContentSecurityPolicy {
         } else {
             "Content-Security-Policy"
         };
-        headers
-            .as_mut()
-            .insert(name, self.value().to_owned())
-            .unwrap();
+        headers.as_mut().insert(name, self.value().to_owned());
     }
 }

--- a/src/security/mod.rs
+++ b/src/security/mod.rs
@@ -105,7 +105,7 @@ pub fn powered_by(mut headers: impl AsMut<Headers>, value: Option<HeaderValue>) 
             headers.as_mut().insert(name, value);
         }
         None => {
-            headers.as_mut().remove(&name);
+            headers.as_mut().remove(name);
         }
     };
 }

--- a/src/security/mod.rs
+++ b/src/security/mod.rs
@@ -50,10 +50,7 @@ pub fn default(mut headers: impl AsMut<Headers>) {
 // /// ```
 #[inline]
 pub fn dns_prefetch_control(mut headers: impl AsMut<Headers>) {
-    headers
-        .as_mut()
-        .insert("X-DNS-Prefetch-Control", "on")
-        .unwrap();
+    headers.as_mut().insert("X-DNS-Prefetch-Control", "on");
 }
 
 /// Set the frameguard level.
@@ -83,7 +80,7 @@ pub fn frameguard(mut headers: impl AsMut<Headers>, guard: Option<FrameOptions>)
         None | Some(FrameOptions::SameOrigin) => "sameorigin",
         Some(FrameOptions::Deny) => "deny",
     };
-    headers.as_mut().insert("X-Frame-Options", kind).unwrap();
+    headers.as_mut().insert("X-Frame-Options", kind);
 }
 
 /// Removes the `X-Powered-By` header to make it slightly harder for attackers to see what
@@ -96,7 +93,7 @@ pub fn frameguard(mut headers: impl AsMut<Headers>, guard: Option<FrameOptions>)
 // /// use http_types::Response;
 // ///
 // /// let mut res = Response::new(StatusCode::Ok);
-// /// headers.as_mut().insert("X-Powered-By", "Tide/Rust".parse().unwrap());
+// /// headers.as_mut().insert("X-Powered-By", "Tide/Rust".parse());
 // /// http_types::security::hide_powered_by(&mut headers);
 // /// assert_eq!(headers.get("X-Powered-By"), None);
 // /// ```
@@ -105,7 +102,7 @@ pub fn powered_by(mut headers: impl AsMut<Headers>, value: Option<HeaderValue>) 
     let name = HeaderName::from_lowercase_str("X-Powered-By");
     match value {
         Some(value) => {
-            headers.as_mut().insert(name, value).unwrap();
+            headers.as_mut().insert(name, value);
         }
         None => {
             headers.as_mut().remove(&name);
@@ -132,8 +129,7 @@ pub fn powered_by(mut headers: impl AsMut<Headers>, value: Option<HeaderValue>) 
 pub fn hsts(mut headers: impl AsMut<Headers>) {
     headers
         .as_mut()
-        .insert("Strict-Transport-Security", "max-age=5184000")
-        .unwrap();
+        .insert("Strict-Transport-Security", "max-age=5184000");
 }
 
 /// Prevent browsers from trying to guess (“sniff”) the MIME type, which can have security
@@ -151,10 +147,7 @@ pub fn hsts(mut headers: impl AsMut<Headers>) {
 // /// ```
 #[inline]
 pub fn nosniff(mut headers: impl AsMut<Headers>) {
-    headers
-        .as_mut()
-        .insert("X-Content-Type-Options", "nosniff")
-        .unwrap();
+    headers.as_mut().insert("X-Content-Type-Options", "nosniff");
 }
 
 /// Sets the `X-XSS-Protection` header to prevent reflected XSS attacks.
@@ -171,10 +164,7 @@ pub fn nosniff(mut headers: impl AsMut<Headers>) {
 // /// ```
 #[inline]
 pub fn xss_filter(mut headers: impl AsMut<Headers>) {
-    headers
-        .as_mut()
-        .insert("X-XSS-Protection", "1; mode=block")
-        .unwrap();
+    headers.as_mut().insert("X-XSS-Protection", "1; mode=block");
 }
 
 /// Set the Referrer-Policy level

--- a/src/status.rs
+++ b/src/status.rs
@@ -1,5 +1,5 @@
 use crate::{Error, StatusCode};
-use core::convert::{Infallible, TryInto};
+use core::convert::{Infallible, Into};
 use std::error::Error as StdError;
 
 /// Provides the `status` method for `Result` and `Option`.
@@ -9,15 +9,13 @@ pub trait Status<T, E>: private::Sealed {
     /// Wrap the error value with an additional status code.
     fn status<S>(self, status: S) -> Result<T, Error>
     where
-        S: TryInto<StatusCode>,
-        S::Error: std::fmt::Debug;
+        S: Into<StatusCode>;
 
     /// Wrap the error value with an additional status code that is evaluated
     /// lazily only once an error does occur.
     fn with_status<S, F>(self, f: F) -> Result<T, Error>
     where
-        S: TryInto<StatusCode>,
-        S::Error: std::fmt::Debug,
+        S: Into<StatusCode>,
         F: FnOnce() -> S;
 }
 
@@ -27,23 +25,21 @@ where
 {
     fn status<S>(self, status: S) -> Result<T, Error>
     where
-        S: TryInto<StatusCode>,
-        S::Error: std::fmt::Debug,
+        S: Into<StatusCode>,
     {
         self.map_err(|error| {
-            let status = status.try_into().unwrap();
+            let status = status.into();
             Error::new(status, error)
         })
     }
 
     fn with_status<S, F>(self, f: F) -> Result<T, Error>
     where
-        S: TryInto<StatusCode>,
-        S::Error: std::fmt::Debug,
+        S: Into<StatusCode>,
         F: FnOnce() -> S,
     {
         self.map_err(|error| {
-            let status = f().try_into().unwrap();
+            let status = f().into();
             Error::new(status, error)
         })
     }
@@ -52,23 +48,21 @@ where
 impl<T> Status<T, Infallible> for Option<T> {
     fn status<S>(self, status: S) -> Result<T, Error>
     where
-        S: TryInto<StatusCode>,
-        S::Error: std::fmt::Debug,
+        S: Into<StatusCode>,
     {
         self.ok_or_else(|| {
-            let status = status.try_into().unwrap();
+            let status = status.into();
             Error::from_str(status, "NoneError")
         })
     }
 
     fn with_status<S, F>(self, f: F) -> Result<T, Error>
     where
-        S: TryInto<StatusCode>,
-        S::Error: std::fmt::Debug,
+        S: Into<StatusCode>,
         F: FnOnce() -> S,
     {
         self.ok_or_else(|| {
-            let status = f().try_into().unwrap();
+            let status = f().into();
             Error::from_str(status, "NoneError")
         })
     }

--- a/src/trailers.rs
+++ b/src/trailers.rs
@@ -121,17 +121,17 @@ impl Trailers {
     }
 
     /// Get a reference to a header.
-    pub fn get(&self, name: impl Into<HeaderName>) -> Option<&HeaderValues> {
+    pub fn get(&self, name: &impl Into<HeaderName>) -> Option<&HeaderValues> {
         self.headers.get(name)
     }
 
     /// Get a mutable reference to a header.
-    pub fn get_mut(&mut self, name: &HeaderName) -> Option<&mut HeaderValues> {
+    pub fn get_mut(&mut self, name: impl Into<HeaderName>) -> Option<&mut HeaderValues> {
         self.headers.get_mut(name)
     }
 
     /// Remove a header.
-    pub fn remove(&mut self, name: &HeaderName) -> Option<HeaderValues> {
+    pub fn remove(&mut self, name: impl Into<HeaderName>) -> Option<HeaderValues> {
         self.headers.remove(name)
     }
 

--- a/src/trailers.rs
+++ b/src/trailers.rs
@@ -31,7 +31,7 @@
 //!
 //! let sender = req.send_trailers();
 //! let mut trailers = Trailers::new();
-//! trailers.insert("Content-Type", "text/plain")?;
+//! trailers.insert("Content-Type", "text/plain");
 //!
 //! task::spawn(async move {
 //!     let trailers = req.recv_trailers().await;
@@ -53,7 +53,7 @@ use crate::headers::{
 use async_std::prelude::*;
 use async_std::sync;
 
-use std::convert::TryInto;
+use std::convert::Into;
 use std::future::Future;
 use std::ops::{Deref, DerefMut, Index};
 use std::pin::Pin;
@@ -83,15 +83,15 @@ impl Trailers {
     /// use http_types::Trailers;
     ///
     /// let mut trailers = Trailers::new();
-    /// trailers.insert("Content-Type", "text/plain")?;
+    /// trailers.insert("Content-Type", "text/plain");
     /// #
     /// # Ok(()) }
     /// ```
     pub fn insert(
         &mut self,
-        name: impl TryInto<HeaderName>,
+        name: impl Into<HeaderName>,
         values: impl ToHeaderValues,
-    ) -> crate::Result<Option<HeaderValues>> {
+    ) -> Option<HeaderValues> {
         self.headers.insert(name, values)
     }
 
@@ -114,14 +114,14 @@ impl Trailers {
     /// ```
     pub fn append(
         &mut self,
-        name: impl TryInto<HeaderName>,
+        name: impl Into<HeaderName>,
         values: impl ToHeaderValues,
     ) -> crate::Result<()> {
         self.headers.append(name, values)
     }
 
     /// Get a reference to a header.
-    pub fn get(&self, name: &HeaderName) -> Option<&HeaderValues> {
+    pub fn get(&self, name: impl Into<HeaderName>) -> Option<&HeaderValues> {
         self.headers.get(name)
     }
 
@@ -181,7 +181,7 @@ impl DerefMut for Trailers {
     }
 }
 
-impl Index<&HeaderName> for Trailers {
+impl Index<HeaderName> for Trailers {
     type Output = HeaderValues;
 
     /// Returns a reference to the value corresponding to the supplied name.
@@ -190,7 +190,7 @@ impl Index<&HeaderName> for Trailers {
     ///
     /// Panics if the name is not present in `Trailers`.
     #[inline]
-    fn index(&self, name: &HeaderName) -> &HeaderValues {
+    fn index(&self, name: HeaderName) -> &HeaderValues {
         self.headers.index(name)
     }
 }

--- a/src/trailers.rs
+++ b/src/trailers.rs
@@ -121,7 +121,7 @@ impl Trailers {
     }
 
     /// Get a reference to a header.
-    pub fn get(&self, name: &impl Into<HeaderName>) -> Option<&HeaderValues> {
+    pub fn get(&self, name: impl Into<HeaderName>) -> Option<&HeaderValues> {
         self.headers.get(name)
     }
 

--- a/tests/headers.rs
+++ b/tests/headers.rs
@@ -1,0 +1,8 @@
+// use http_types::{Response, StatusCode};
+
+// #[test]
+// fn headers_cmp() {
+//     let mut res = Response::new(StatusCode::Ok);
+//     res.insert_header("content-type", "application/json");
+//     assert_eq!(res.header("content-type").unwrap(), "application/json");
+// }

--- a/tests/security.rs
+++ b/tests/security.rs
@@ -1,4 +1,4 @@
-use http_types::{headers::HeaderName, security, Response, StatusCode};
+use http_types::{security, Response, StatusCode};
 
 #[test]
 fn security_test() {
@@ -18,11 +18,5 @@ fn security_test() {
     security::default(&mut res);
     policy.apply(&mut res);
 
-    let header = res
-        .header(&HeaderName::from_ascii("content-security-policy".to_owned().into_bytes()).unwrap())
-        .unwrap()
-        .iter()
-        .next()
-        .unwrap();
-    assert_eq!(header, "base-uri 'none'; default-src 'self' areweasyncyet.rs; object-src 'none'; script-src 'self' 'unsafe-inline'; upgrade-insecure-requests");
+    assert_eq!(res["content-security-policy"], "base-uri 'none'; default-src 'self' areweasyncyet.rs; object-src 'none'; script-src 'self' 'unsafe-inline'; upgrade-insecure-requests");
 }


### PR DESCRIPTION
I need to write some more words on this, but in short this patch exists to make this crate much nicer to work with. In particular constructing new responses and comparing headers was pretty tricky. This makes that all much nicer to do.

## Changes
- this enables shorthand constructors for req/res by taking values by `impl TryInto`.
    - this still allows all existing code to work -- e.g. constructing req/res based on user input can still be done, and errors can still be handled.
    - in general this removes quite a few unwraps, bringing it overall closer to ergonomics in other langs.