### PR TITLE
src: rename remaining `from_ascii()` to `from_bytes()`

### DIFF
--- a/src/headers/header_name.rs
+++ b/src/headers/header_name.rs
@@ -9,8 +9,12 @@ use crate::Error;
 pub struct HeaderName(Cow<'static, str>);
 
 impl HeaderName {
-    /// Create a new `HeaderName`.
-    pub fn from_ascii(mut bytes: Vec<u8>) -> Result<Self, Error> {
+    /// Create a new `HeaderName` from a Vec of ASCII bytes.
+    ///
+    /// # Error
+    ///
+    /// This function will error if the bytes is not valid ASCII.
+    pub fn from_bytes(mut bytes: Vec<u8>) -> Result<Self, Error> {
         crate::ensure!(bytes.is_ascii(), "Bytes should be valid ASCII");
         bytes.make_ascii_lowercase();
 
@@ -33,7 +37,7 @@ impl HeaderName {
     /// ASCII. If this constraint is violated, it may cause memory
     /// unsafety issues with future users of the HeaderName, as the rest of the library assumes
     /// that Strings are valid ASCII.
-    pub unsafe fn from_ascii_unchecked(mut bytes: Vec<u8>) -> Self {
+    pub unsafe fn from_bytes_unchecked(mut bytes: Vec<u8>) -> Self {
         bytes.make_ascii_lowercase();
         let string = String::from_utf8_unchecked(bytes);
         HeaderName(Cow::Owned(string))

--- a/src/headers/header_value.rs
+++ b/src/headers/header_value.rs
@@ -13,12 +13,12 @@ pub struct HeaderValue {
 }
 
 impl HeaderValue {
-    /// Create a new `HeaderValue` from ASCII bytes.
+    /// Create a new `HeaderValue` from a Vec of ASCII bytes.
     ///
     /// # Error
     ///
-    /// This function will error if the string is not a valid ASCII.
-    pub fn from_ascii(bytes: &[u8]) -> Result<Self, Error> {
+    /// This function will error if the bytes is not valid ASCII.
+    pub fn from_bytes(bytes: &[u8]) -> Result<Self, Error> {
         crate::ensure!(bytes.is_ascii(), "Bytes should be valid ASCII");
 
         // This is permitted because ASCII is valid UTF-8, and we just checked that.
@@ -35,7 +35,7 @@ impl HeaderValue {
     /// ASCII. If this constraint is violated, it may cause memory
     /// unsafety issues with future users of the HeaderValue, as the rest of the library assumes
     /// that Strings are valid ASCII.
-    pub unsafe fn from_ascii_unchecked(bytes: Vec<u8>) -> Self {
+    pub unsafe fn from_bytes_unchecked(bytes: Vec<u8>) -> Self {
         let string = String::from_utf8_unchecked(bytes);
         Self { inner: string }
     }

--- a/src/hyperium_http.rs
+++ b/src/hyperium_http.rs
@@ -57,10 +57,10 @@ impl From<Version> for http::Version {
 fn hyperium_headers_to_headers(hyperium_headers: http::HeaderMap, headers: &mut Headers) {
     for (name, value) in hyperium_headers {
         let value = value.as_bytes().to_owned();
-        let value = unsafe { HeaderValue::from_ascii_unchecked(value) };
+        let value = unsafe { HeaderValue::from_bytes_unchecked(value) };
         if let Some(name) = name {
             let name = name.as_str().as_bytes().to_owned();
-            let name = unsafe { HeaderName::from_ascii_unchecked(name) };
+            let name = unsafe { HeaderName::from_bytes_unchecked(name) };
             headers.insert(name, value).unwrap();
         }
     }


### PR DESCRIPTION
Fixes #139

Also makes the docs for each a bit nicer.