### PR TITLE
Remove the Sync bound for Body::from_reader

### DIFF
--- a/src/body.rs
+++ b/src/body.rs
@@ -55,7 +55,7 @@ pin_project_lite::pin_project! {
     /// and not rely on the fallback mechanisms. However, they're still there if you need them.
     pub struct Body {
         #[pin]
-        reader: Box<dyn BufRead + Unpin + Send + Sync + 'static>,
+        reader: Box<dyn BufRead + Unpin + Send + 'static>,
         mime: Mime,
         length: Option<usize>,
     }
@@ -102,10 +102,7 @@ impl Body {
     /// let len = 10;
     /// req.set_body(Body::from_reader(cursor, Some(len)));
     /// ```
-    pub fn from_reader(
-        reader: impl BufRead + Unpin + Send + Sync + 'static,
-        len: Option<usize>,
-    ) -> Self {
+    pub fn from_reader(reader: impl BufRead + Unpin + Send + 'static, len: Option<usize>) -> Self {
         Self {
             reader: Box::new(reader),
             mime: mime::BYTE_STREAM,


### PR DESCRIPTION
I think this reader does not need `Sync`, because it is impossible for multiple threads to read `Body` at the same time, what do you think?