### PR TITLE
Fix async-std 1.6.0 channel changes

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "http-types"
-version = "1.3.0"
+version = "1.3.1"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/http-rs/http-types"
 documentation = "https://docs.rs/http-types"
@@ -24,7 +24,7 @@ hyperium_http = ["http"]
 [dependencies]
 
 # Note(yoshuawuyts): used for async_std's `channel` only; use "core" once possible.
-async-std = { version = "1.4.0", features = ["unstable"] }
+async-std = { version = "1.6.0", features = ["unstable"] }
 
 # features: hyperium/http
 http = { version = "0.2.0", optional = true }

--- a/src/request.rs
+++ b/src/request.rs
@@ -441,7 +441,7 @@ impl Request {
 
     /// Receive trailers from a sender.
     pub async fn recv_trailers(&self) -> Option<crate::Result<Trailers>> {
-        self.receiver.recv().await
+        self.receiver.recv().await.ok()
     }
 
     /// An iterator visiting all header pairs in arbitrary order.

--- a/src/response.rs
+++ b/src/response.rs
@@ -406,7 +406,7 @@ impl Response {
 
     /// Receive trailers from a sender.
     pub async fn recv_trailers(&self) -> Option<crate::Result<Trailers>> {
-        self.receiver.recv().await
+        self.receiver.recv().await.ok()
     }
 
     /// An iterator visiting all header pairs in arbitrary order.


### PR DESCRIPTION
Fixes async-std upgrades to 1.6.0. To be published as http-types 1.3.1. Thanks!