### PR TITLE
Add feature for enabling signed and encrypted cookie support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ docs = ["unstable"]
 unstable = []
 hyperium_http = ["http"]
 async_std = [] # "async-std" when it is not default
+cookie-secure = ["cookie/secure"]
 
 [dependencies]
 # Note(yoshuawuyts): used for async_std's `channel` only; use "core" once possible.


### PR DESCRIPTION
The cookie crate uses the ring crate's HMAC module to implement signed
cookies and its AEAD module for authenticated encrypted cookies.