### PR TITLE
Fix compilation on wasm32-unknown-unknown

### DIFF
--- a/src/body.rs
+++ b/src/body.rs
@@ -1,10 +1,8 @@
-use async_std::fs;
 use async_std::io::prelude::*;
 use async_std::io::{self, Cursor};
 use serde::{de::DeserializeOwned, Serialize};
 
 use std::fmt::{self, Debug};
-use std::path::Path;
 use std::pin::Pin;
 use std::task::{Context, Poll};
 
@@ -357,13 +355,13 @@ impl Body {
     /// res.set_body(Body::from_file("/path/to/file").await?);
     /// # Ok(()) }) }
     /// ```
-    #[cfg(feature = "async_std")]
+    #[cfg(all(feature = "async_std", not(target_os = "unknown")))]
     pub async fn from_file<P>(path: P) -> io::Result<Self>
     where
-        P: AsRef<Path>,
+        P: AsRef<std::path::Path>,
     {
         let path = path.as_ref();
-        let mut file = fs::File::open(path).await?;
+        let mut file = async_std::fs::File::open(path).await?;
         let len = file.metadata().await?.len();
 
         // Look at magic bytes first, look at extension second, fall back to
@@ -471,7 +469,7 @@ impl BufRead for Body {
 
 /// Look at first few bytes of a file to determine the mime type.
 /// This is used for various binary formats such as images and videos.
-#[cfg(feature = "async_std")]
+#[cfg(all(feature = "async_std", not(target_os = "unknown")))]
 async fn peek_mime(file: &mut async_std::fs::File) -> io::Result<Option<Mime>> {
     // We need to read the first 300 bytes to correctly infer formats such as tar.
     let mut buf = [0_u8; 300];
@@ -485,8 +483,8 @@ async fn peek_mime(file: &mut async_std::fs::File) -> io::Result<Option<Mime>> {
 
 /// Look at the extension of a file to determine the mime type.
 /// This is useful for plain-text formats such as HTML and CSS.
-#[cfg(feature = "async_std")]
-fn guess_ext(path: &Path) -> Option<Mime> {
+#[cfg(all(feature = "async_std", not(target_os = "unknown")))]
+fn guess_ext(path: &std::path::Path) -> Option<Mime> {
     let ext = path.extension().map(|p| p.to_str()).flatten();
     match ext {
         Some("html") => Some(mime::HTML),

--- a/src/method.rs
+++ b/src/method.rs
@@ -92,3 +92,19 @@ impl<'a> std::convert::TryFrom<&'a str> for Method {
         Self::from_str(value)
     }
 }
+
+impl AsRef<str> for Method {
+    fn as_ref(&self) -> &str {
+        match self {
+            Self::Get => "GET",
+            Self::Head => "HEAD",
+            Self::Post => "POST",
+            Self::Put => "PUT",
+            Self::Delete => "DELETE",
+            Self::Connect => "CONNECT",
+            Self::Options => "OPTIONS",
+            Self::Trace => "TRACE",
+            Self::Patch => "PATCH",
+        }
+    }
+}


### PR DESCRIPTION
The most recent release of http-types, 2.0.1, fails to compile on the wasm32-unknown-unknown target. I haven't checked previous versions to see exactly when the bug was introduced, but I suspect it was when async_std was updated to 1.6.

The cause of the problem is that async_std::fs is not available on wasm32-unknown-uknown. This PR gates all usages of that module behind the correct compilation options.

Additionally, I needed the AsRef<str> implementation on Method when fixing wasm compilation for http-client.