### PR TITLE
Status should take TryInto<StatusCode>

### DIFF
--- a/src/response.rs
+++ b/src/response.rs
@@ -656,8 +656,15 @@ impl<'a> IntoIterator for &'a mut Response {
 #[cfg(test)]
 mod test {
     use super::Response;
+
     #[test]
-    fn construct_shorthand() {
+    fn construct_shorthand_with_valid_status_code() {
         let _res = Response::new(200);
+    }
+
+    #[test]
+    #[should_panic(expected = "Could not convert into a valid `StatusCode`")]
+    fn construct_shorthand_with_invalid_status_code() {
+        let _res = Response::new(600);
     }
 }

--- a/src/response.rs
+++ b/src/response.rs
@@ -98,7 +98,7 @@ impl Response {
     /// ```
     /// # fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync + 'static>> {
     /// #
-    /// use http_types::{Url, Method, Response, StatusCode};
+    /// use http_types::{Method, Response, StatusCode, Url};
     ///
     /// let mut req = Response::new(StatusCode::Ok);
     /// req.insert_header("Content-Type", "text/plain");
@@ -115,8 +115,9 @@ impl Response {
 
     /// Append a header to the headers.
     ///
-    /// Unlike `insert` this function will not override the contents of a header, but insert a
-    /// header if there aren't any. Or else append to the existing list of headers.
+    /// Unlike `insert` this function will not override the contents of a
+    /// header, but insert a header if there aren't any. Or else append to
+    /// the existing list of headers.
     ///
     /// # Examples
     ///
@@ -161,7 +162,7 @@ impl Response {
     /// # fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync + 'static>> {
     /// # async_std::task::block_on(async {
     /// #
-    /// use http_types::{Body, Url, Method, Response, StatusCode};
+    /// use http_types::{Body, Method, Response, StatusCode, Url};
     ///
     /// let mut req = Response::new(StatusCode::Ok);
     /// req.set_body("Hello, Nori!");
@@ -190,7 +191,7 @@ impl Response {
     /// # fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync + 'static>> {
     /// # async_std::task::block_on(async {
     /// #
-    /// use http_types::{Body, Url, Method, Response, StatusCode};
+    /// use http_types::{Body, Method, Response, StatusCode, Url};
     ///
     /// let mut req = Response::new(StatusCode::Ok);
     /// req.set_body("Hello, Nori!");
@@ -218,7 +219,7 @@ impl Response {
     /// # fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync + 'static>> {
     /// # async_std::task::block_on(async {
     /// #
-    /// use http_types::{Body, Url, Method, Response, StatusCode};
+    /// use http_types::{Body, Method, Response, StatusCode, Url};
     ///
     /// let mut req = Response::new(StatusCode::Ok);
     /// req.set_body("Hello, Nori!");
@@ -251,10 +252,10 @@ impl Response {
     /// # use std::io::prelude::*;
     /// # fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync + 'static>> {
     /// # async_std::task::block_on(async {
-    /// use http_types::{Body, Url, Method, Response, StatusCode};    
     /// use async_std::io::Cursor;
+    /// use http_types::{Body, Method, Response, StatusCode, Url};
     ///
-    /// let mut res = Response::new(StatusCode::Ok);    
+    /// let mut res = Response::new(StatusCode::Ok);
     /// let cursor = Cursor::new("Hello Nori");
     /// let body = Body::from_reader(cursor, None);
     /// res.set_body(body);
@@ -277,7 +278,7 @@ impl Response {
     ///
     /// ```
     /// # fn main() -> Result<(), http_types::Error> { async_std::task::block_on(async {
-    /// use http_types::{Body, Url, Method, Response, StatusCode};
+    /// use http_types::{Body, Method, Response, StatusCode, Url};
     ///
     /// let bytes = vec![1, 2, 3];
     /// let mut res = Response::new(StatusCode::Ok);
@@ -303,14 +304,18 @@ impl Response {
     ///
     /// ```
     /// # fn main() -> Result<(), http_types::Error> { async_std::task::block_on(async {
-    /// use http_types::{Body, Url, Method, Response, StatusCode};    
-    /// use http_types::convert::{Serialize, Deserialize};
+    /// use http_types::convert::{Deserialize, Serialize};
+    /// use http_types::{Body, Method, Response, StatusCode, Url};
     ///
     /// #[derive(Debug, Serialize, Deserialize)]
-    /// struct Cat { name: String }
+    /// struct Cat {
+    ///     name: String,
+    /// }
     ///
-    /// let cat = Cat { name: String::from("chashu") };
-    /// let mut res = Response::new(StatusCode::Ok);    
+    /// let cat = Cat {
+    ///     name: String::from("chashu"),
+    /// };
+    /// let mut res = Response::new(StatusCode::Ok);
     /// res.set_body(Body::from_json(&cat)?);
     ///
     /// let cat: Cat = res.body_json().await?;
@@ -333,14 +338,18 @@ impl Response {
     ///
     /// ```
     /// # fn main() -> Result<(), http_types::Error> { async_std::task::block_on(async {
-    /// use http_types::{Body, Url, Method, Response, StatusCode};    
-    /// use http_types::convert::{Serialize, Deserialize};
+    /// use http_types::convert::{Deserialize, Serialize};
+    /// use http_types::{Body, Method, Response, StatusCode, Url};
     ///
     /// #[derive(Debug, Serialize, Deserialize)]
-    /// struct Cat { name: String }
+    /// struct Cat {
+    ///     name: String,
+    /// }
     ///
-    /// let cat = Cat { name: String::from("chashu") };
-    /// let mut res = Response::new(StatusCode::Ok);    
+    /// let cat = Cat {
+    ///     name: String::from("chashu"),
+    /// };
+    /// let mut res = Response::new(StatusCode::Ok);
     /// res.set_body(Body::from_form(&cat)?);
     ///
     /// let cat: Cat = res.body_form().await?;
@@ -374,14 +383,16 @@ impl Response {
 
     /// Get the length of the body stream, if it has been set.
     ///
-    /// This value is set when passing a fixed-size object into as the body. E.g. a string, or a
-    /// buffer. Consumers of this API should check this value to decide whether to use `Chunked`
-    /// encoding, or set the response length.
+    /// This value is set when passing a fixed-size object into as the body.
+    /// E.g. a string, or a buffer. Consumers of this API should check this
+    /// value to decide whether to use `Chunked` encoding, or set the
+    /// response length.
     pub fn len(&self) -> Option<usize> {
         self.body.len()
     }
 
-    /// Returns `true` if the set length of the body stream is zero, `false` otherwise.
+    /// Returns `true` if the set length of the body stream is zero, `false`
+    /// otherwise.
     pub fn is_empty(&self) -> Option<bool> {
         self.body.is_empty()
     }
@@ -426,7 +437,8 @@ impl Response {
         self.peer_addr.as_deref()
     }
 
-    /// Get the local socket address for the underlying transport, if appropriate
+    /// Get the local socket address for the underlying transport, if
+    /// appropriate
     pub fn local_addr(&self) -> Option<&str> {
         self.local_addr.as_deref()
     }
@@ -477,8 +489,8 @@ impl Response {
         self.headers.iter()
     }
 
-    /// An iterator visiting all header pairs in arbitrary order, with mutable references to the
-    /// values.
+    /// An iterator visiting all header pairs in arbitrary order, with mutable
+    /// references to the values.
     pub fn iter_mut(&mut self) -> headers::IterMut<'_> {
         self.headers.iter_mut()
     }
@@ -506,7 +518,7 @@ impl Response {
     /// ```
     /// # fn main() -> Result<(), http_types::Error> {
     /// #
-    /// use http_types::{StatusCode, Response, Version};
+    /// use http_types::{Response, StatusCode, Version};
     ///
     /// let mut res = Response::new(StatusCode::Ok);
     /// res.ext_mut().insert("hello from the extension");
@@ -520,7 +532,8 @@ impl Response {
 }
 
 impl Clone for Response {
-    /// Clone the response, resolving the body to `Body::empty()` and removing extensions.
+    /// Clone the response, resolving the body to `Body::empty()` and removing
+    /// extensions.
     fn clone(&self) -> Self {
         Self {
             status: self.status.clone(),

--- a/src/status.rs
+++ b/src/status.rs
@@ -26,6 +26,14 @@ impl<T, E> Status<T, E> for Result<T, E>
 where
     E: StdError + Send + Sync + 'static,
 {
+    /// Wrap the error value with an additional status code.
+    ///
+    /// # Panics
+    ///
+    /// Panics if [`Status`][status] is not a valid [`StatusCode`][statuscode].
+    ///
+    /// [status]: crate::Status
+    /// [statuscode]: crate::StatusCode
     fn status<S>(self, status: S) -> Result<T, Error>
     where
         S: TryInto<StatusCode>,
@@ -39,6 +47,15 @@ where
         })
     }
 
+    /// Wrap the error value with an additional status code that is evaluated
+    /// lazily only once an error does occur.
+    ///
+    /// # Panics
+    ///
+    /// Panics if [`Status`][status] is not a valid [`StatusCode`][statuscode].
+    ///
+    /// [status]: crate::Status
+    /// [statuscode]: crate::StatusCode
     fn with_status<S, F>(self, f: F) -> Result<T, Error>
     where
         S: TryInto<StatusCode>,
@@ -55,6 +72,14 @@ where
 }
 
 impl<T> Status<T, Infallible> for Option<T> {
+    /// Wrap the error value with an additional status code.
+    ///
+    /// # Panics
+    ///
+    /// Panics if [`Status`][status] is not a valid [`StatusCode`][statuscode].
+    ///
+    /// [status]: crate::Status
+    /// [statuscode]: crate::StatusCode
     fn status<S>(self, status: S) -> Result<T, Error>
     where
         S: TryInto<StatusCode>,
@@ -68,6 +93,15 @@ impl<T> Status<T, Infallible> for Option<T> {
         })
     }
 
+    /// Wrap the error value with an additional status code that is evaluated
+    /// lazily only once an error does occur.
+    ///
+    /// # Panics
+    ///
+    /// Panics if [`Status`][status] is not a valid [`StatusCode`][statuscode].
+    ///
+    /// [status]: crate::Status
+    /// [statuscode]: crate::StatusCode
     fn with_status<S, F>(self, f: F) -> Result<T, Error>
     where
         S: TryInto<StatusCode>,

--- a/src/status.rs
+++ b/src/status.rs
@@ -123,3 +123,21 @@ pub(crate) mod private {
     impl<T, E> Sealed for Result<T, E> {}
     impl<T> Sealed for Option<T> {}
 }
+
+#[cfg(test)]
+mod test {
+    use super::Status;
+
+    #[test]
+    fn construct_shorthand_with_valid_status_code() {
+        let _res = Some(()).status(200).unwrap();
+    }
+
+    #[test]
+    #[should_panic(expected = "Could not convert into a valid `StatusCode`")]
+    fn construct_shorthand_with_invalid_status_code() {
+        let res: Result<(), std::io::Error> =
+            Err(std::io::Error::new(std::io::ErrorKind::Other, "oh no!"));
+        let _res = res.status(600).unwrap();
+    }
+}

--- a/src/status_code.rs
+++ b/src/status_code.rs
@@ -9,20 +9,22 @@ use std::fmt::{self, Display};
 pub enum StatusCode {
     /// 100 Continue
     ///
-    /// This interim response indicates that everything so far is OK and that the client should
-    /// continue the request, or ignore the response if the request is already finished.
+    /// This interim response indicates that everything so far is OK and that
+    /// the client should continue the request, or ignore the response if
+    /// the request is already finished.
     Continue = 100,
 
     /// 101 Switching Protocols
     ///
-    /// This code is sent in response to an Upgrade request header from the client, and
-    /// indicates the protocol the server is switching to.
+    /// This code is sent in response to an Upgrade request header from the
+    /// client, and indicates the protocol the server is switching to.
     SwitchingProtocols = 101,
 
     /// 103 Early Hints
     ///
-    /// This status code is primarily intended to be used with the Link header, letting the
-    /// user agent start preloading resources while the server prepares a response.
+    /// This status code is primarily intended to be used with the Link header,
+    /// letting the user agent start preloading resources while the server
+    /// prepares a response.
     EarlyHints = 103,
 
     /// 200 Ok
@@ -32,30 +34,34 @@ pub enum StatusCode {
 
     /// 201 Created
     ///
-    /// The request has succeeded and a new resource has been created as a result. This is
-    /// typically the response sent after POST requests, or some PUT requests.
+    /// The request has succeeded and a new resource has been created as a
+    /// result. This is typically the response sent after POST requests, or
+    /// some PUT requests.
     Created = 201,
 
     /// 202 Accepted
     ///
-    /// The request has been received but not yet acted upon. It is noncommittal, since there
-    /// is no way in HTTP to later send an asynchronous response indicating the outcome of the
-    /// request. It is intended for cases where another process or server handles the request,
+    /// The request has been received but not yet acted upon. It is
+    /// noncommittal, since there is no way in HTTP to later send an
+    /// asynchronous response indicating the outcome of the request. It is
+    /// intended for cases where another process or server handles the request,
     /// or for batch processing.
     Accepted = 202,
 
     /// 203 Non Authoritative Information
     ///
-    /// This response code means the returned meta-information is not exactly the same as is
-    /// available from the origin server, but is collected from a local or a third-party copy.
-    /// This is mostly used for mirrors or backups of another resource. Except for that
-    /// specific case, the "200 OK" response is preferred to this status.
+    /// This response code means the returned meta-information is not exactly
+    /// the same as is available from the origin server, but is collected
+    /// from a local or a third-party copy. This is mostly used for mirrors
+    /// or backups of another resource. Except for that specific case, the
+    /// "200 OK" response is preferred to this status.
     NonAuthoritativeInformation = 203,
 
     /// 204 No Content
     ///
-    /// There is no content to send for this request, but the headers may be useful. The
-    /// user-agent may update its cached headers for this resource with the new ones.
+    /// There is no content to send for this request, but the headers may be
+    /// useful. The user-agent may update its cached headers for this
+    /// resource with the new ones.
     NoContent = 204,
 
     /// 205 Reset Content
@@ -65,187 +71,204 @@ pub enum StatusCode {
 
     /// 206 Partial Content
     ///
-    /// This response code is used when the Range header is sent from the client to request
-    /// only part of a resource.
+    /// This response code is used when the Range header is sent from the client
+    /// to request only part of a resource.
     PartialContent = 206,
 
     /// 226 Im Used
     ///
-    /// The server has fulfilled a GET request for the resource, and the response is a
-    /// representation of the result of one or more instance-manipulations applied to the
-    /// current instance.
+    /// The server has fulfilled a GET request for the resource, and the
+    /// response is a representation of the result of one or more
+    /// instance-manipulations applied to the current instance.
     ImUsed = 226,
 
     /// 300 Multiple Choice
     ///
-    /// The request has more than one possible response. The user-agent or user should choose one
-    /// of them. (There is no standardized way of choosing one of the responses, but HTML links to
-    /// the possibilities are recommended so the user can pick.)
+    /// The request has more than one possible response. The user-agent or user
+    /// should choose one of them. (There is no standardized way of choosing
+    /// one of the responses, but HTML links to the possibilities are
+    /// recommended so the user can pick.)
     MultipleChoice = 300,
 
     /// 301 Moved Permanently
     ///
-    /// The URL of the requested resource has been changed permanently. The new URL is given in the
-    /// response.
+    /// The URL of the requested resource has been changed permanently. The new
+    /// URL is given in the response.
     MovedPermanently = 301,
 
     /// 302 Found
     ///
-    /// This response code means that the URI of requested resource has been changed temporarily.
-    /// Further changes in the URI might be made in the future. Therefore, this same URI should be
-    /// used by the client in future requests.
+    /// This response code means that the URI of requested resource has been
+    /// changed temporarily. Further changes in the URI might be made in the
+    /// future. Therefore, this same URI should be used by the client in
+    /// future requests.
     Found = 302,
 
     /// 303 See Other
     ///
-    /// The server sent this response to direct the client to get the requested resource at another
-    /// URI with a GET request.
+    /// The server sent this response to direct the client to get the requested
+    /// resource at another URI with a GET request.
     SeeOther = 303,
 
     /// 304 Not Modified
     ///
-    /// This is used for caching purposes. It tells the client that the response has not been
-    /// modified, so the client can continue to use the same cached version of the response.
+    /// This is used for caching purposes. It tells the client that the response
+    /// has not been modified, so the client can continue to use the same
+    /// cached version of the response.
     NotModified = 304,
 
     /// 307 Temporary Redirect
     ///
-    /// The server sends this response to direct the client to get the requested resource at
-    /// another URI with same method that was used in the prior request. This has the same
-    /// semantics as the 302 Found HTTP response code, with the exception that the user agent must
-    /// not change the HTTP method used: If a POST was used in the first request, a POST must be
-    /// used in the second request.
+    /// The server sends this response to direct the client to get the requested
+    /// resource at another URI with same method that was used in the prior
+    /// request. This has the same semantics as the 302 Found HTTP response
+    /// code, with the exception that the user agent must not change the
+    /// HTTP method used: If a POST was used in the first request, a POST must
+    /// be used in the second request.
     TemporaryRedirect = 307,
 
     /// 308 Permanent Redirect
     ///
-    /// This means that the resource is now permanently located at another URI, specified by the
-    /// Location: HTTP Response header. This has the same semantics as the 301 Moved Permanently
-    /// HTTP response code, with the exception that the user agent must not change the HTTP method
-    /// used: If a POST was used in the first request, a POST must be used in the second request.
+    /// This means that the resource is now permanently located at another URI,
+    /// specified by the Location: HTTP Response header. This has the same
+    /// semantics as the 301 Moved Permanently HTTP response code, with the
+    /// exception that the user agent must not change the HTTP method
+    /// used: If a POST was used in the first request, a POST must be used in
+    /// the second request.
     PermanentRedirect = 308,
 
     /// 400 Bad Request
     ///
     /// The server could not understand the request due to invalid syntax.
     ///
-    /// Although the HTTP standard specifies "unauthorized", semantically this response means
-    /// "unauthenticated". That is, the client must authenticate itself to get the requested
-    /// response.
+    /// Although the HTTP standard specifies "unauthorized", semantically this
+    /// response means "unauthenticated". That is, the client must
+    /// authenticate itself to get the requested response.
     BadRequest = 400,
 
     /// 401 Unauthorized
     ///
-    /// This response code is reserved for future use. The initial aim for creating this code was
-    /// using it for digital payment systems, however this status code is used very rarely and no
-    /// standard convention exists.
+    /// This response code is reserved for future use. The initial aim for
+    /// creating this code was using it for digital payment systems, however
+    /// this status code is used very rarely and no standard convention
+    /// exists.
     Unauthorized = 401,
 
     /// 402 Payment Required
     ///
-    /// The client does not have access rights to the content; that is, it is unauthorized, so the
-    /// server is refusing to give the requested resource. Unlike 401, the client's identity is
-    /// known to the server.
+    /// The client does not have access rights to the content; that is, it is
+    /// unauthorized, so the server is refusing to give the requested
+    /// resource. Unlike 401, the client's identity is known to the server.
     PaymentRequired = 402,
 
     /// 403 Forbidden
     ///
-    /// The server can not find requested resource. In the browser, this means the URL is not
-    /// recognized. In an API, this can also mean that the endpoint is valid but the resource
-    /// itself does not exist. Servers may also send this response instead of 403 to hide the
-    /// existence of a resource from an unauthorized client. This response code is probably the
-    /// most famous one due to its frequent occurrence on the web.
+    /// The server can not find requested resource. In the browser, this means
+    /// the URL is not recognized. In an API, this can also mean that the
+    /// endpoint is valid but the resource itself does not exist. Servers
+    /// may also send this response instead of 403 to hide the existence of
+    /// a resource from an unauthorized client. This response code is probably
+    /// the most famous one due to its frequent occurrence on the web.
     Forbidden = 403,
 
     /// 404 Not Found
-    /// The server can not find requested resource. In the browser, this means the URL is not
-    /// recognized. In an API, this can also mean that the endpoint is valid but the resource
-    /// itself does not exist. Servers may also send this response instead of 403 to hide the
-    /// existence of a resource from an unauthorized client. This response code is probably the
-    /// most famous one due to its frequent occurrence on the web.
+    /// The server can not find requested resource. In the browser, this means
+    /// the URL is not recognized. In an API, this can also mean that the
+    /// endpoint is valid but the resource itself does not exist. Servers
+    /// may also send this response instead of 403 to hide the existence of
+    /// a resource from an unauthorized client. This response code is probably
+    /// the most famous one due to its frequent occurrence on the web.
     NotFound = 404,
 
     /// 405 Method Not Allowed
     ///
-    /// The request method is known by the server but has been disabled and cannot be used. For
-    /// example, an API may forbid DELETE-ing a resource. The two mandatory methods, GET and HEAD,
-    /// must never be disabled and should not return this error code.
+    /// The request method is known by the server but has been disabled and
+    /// cannot be used. For example, an API may forbid DELETE-ing a
+    /// resource. The two mandatory methods, GET and HEAD, must never be
+    /// disabled and should not return this error code.
     MethodNotAllowed = 405,
 
     /// 406 Not Acceptable
     ///
-    /// This response is sent when the web server, after performing server-driven content
-    /// negotiation, doesn't find any content that conforms to the criteria given by the user
-    /// agent.
+    /// This response is sent when the web server, after performing
+    /// server-driven content negotiation, doesn't find any content that
+    /// conforms to the criteria given by the user agent.
     NotAcceptable = 406,
 
     /// 407 Proxy Authentication Required
     ///
-    /// This is similar to 401 but authentication is needed to be done by a proxy.
+    /// This is similar to 401 but authentication is needed to be done by a
+    /// proxy.
     ProxyAuthenticationRequired = 407,
 
     /// 408 Request Timeout
     ///
-    /// This response is sent on an idle connection by some servers, even without any previous
-    /// request by the client. It means that the server would like to shut down this unused
-    /// connection. This response is used much more since some browsers, like Chrome, Firefox 27+,
-    /// or IE9, use HTTP pre-connection mechanisms to speed up surfing. Also note that some servers
-    /// merely shut down the connection without sending this message.
+    /// This response is sent on an idle connection by some servers, even
+    /// without any previous request by the client. It means that the server
+    /// would like to shut down this unused connection. This response is
+    /// used much more since some browsers, like Chrome, Firefox 27+,
+    /// or IE9, use HTTP pre-connection mechanisms to speed up surfing. Also
+    /// note that some servers merely shut down the connection without
+    /// sending this message.
     RequestTimeout = 408,
 
     /// 409 Conflict
     ///
-    /// This response is sent when a request conflicts with the current state of the server.
+    /// This response is sent when a request conflicts with the current state of
+    /// the server.
     Conflict = 409,
 
     /// 410 Gone
     ///
-    /// This response is sent when the requested content has been permanently deleted from server,
-    /// with no forwarding address. Clients are expected to remove their caches and links to the
-    /// resource. The HTTP specification intends this status code to be used for "limited-time,
-    /// promotional services". APIs should not feel compelled to indicate resources that have been
-    /// deleted with this status code.
+    /// This response is sent when the requested content has been permanently
+    /// deleted from server, with no forwarding address. Clients are
+    /// expected to remove their caches and links to the resource. The HTTP
+    /// specification intends this status code to be used for "limited-time,
+    /// promotional services". APIs should not feel compelled to indicate
+    /// resources that have been deleted with this status code.
     Gone = 410,
 
     /// 411 Length Required
     ///
-    /// Server rejected the request because the Content-Length header field is not defined and the
-    /// server requires it.
+    /// Server rejected the request because the Content-Length header field is
+    /// not defined and the server requires it.
     LengthRequired = 411,
 
     /// 412 Precondition Failed
     ///
-    /// The client has indicated preconditions in its headers which the server does not meet.
+    /// The client has indicated preconditions in its headers which the server
+    /// does not meet.
     PreconditionFailed = 412,
 
     /// 413 Payload Too Large
     ///
-    /// Request entity is larger than limits defined by server; the server might close the
-    /// connection or return an Retry-After header field.
+    /// Request entity is larger than limits defined by server; the server might
+    /// close the connection or return an Retry-After header field.
     PayloadTooLarge = 413,
 
     /// 414 URI Too Long
     ///
-    /// The URI requested by the client is longer than the server is willing to interpret.
+    /// The URI requested by the client is longer than the server is willing to
+    /// interpret.
     UriTooLong = 414,
 
     /// 415 Unsupported Media Type
     ///
-    /// The media format of the requested data is not supported by the server, so the server is
-    /// rejecting the request.
+    /// The media format of the requested data is not supported by the server,
+    /// so the server is rejecting the request.
     UnsupportedMediaType = 415,
 
     /// 416 Requested Range Not Satisfiable
     ///
-    /// The range specified by the Range header field in the request can't be fulfilled; it's
-    /// possible that the range is outside the size of the target URI's data.
+    /// The range specified by the Range header field in the request can't be
+    /// fulfilled; it's possible that the range is outside the size of the
+    /// target URI's data.
     RequestedRangeNotSatisfiable = 416,
 
     /// 417 Expectation Failed
     ///
-    /// This response code means the expectation indicated by the Expect request header field can't
-    /// be met by the server.
-    ///
+    /// This response code means the expectation indicated by the Expect request
+    /// header field can't be met by the server.
     ExpectationFailed = 417,
     ///
     /// 418 I'm a teapot
@@ -255,14 +278,16 @@ pub enum StatusCode {
 
     /// 421 Misdirected Request
     ///
-    /// The request was directed at a server that is not able to produce a response. This can be
-    /// sent by a server that is not configured to produce responses for the combination of scheme
-    /// and authority that are included in the request URI.
+    /// The request was directed at a server that is not able to produce a
+    /// response. This can be sent by a server that is not configured to
+    /// produce responses for the combination of scheme and authority that
+    /// are included in the request URI.
     MisdirectedRequest = 421,
 
     /// 422 Unprocessable Entity
     ///
-    /// The request was well-formed but was unable to be followed due to semantic errors.
+    /// The request was well-formed but was unable to be followed due to
+    /// semantic errors.
     UnprocessableEntity = 422,
 
     /// 423 Locked
@@ -272,44 +297,50 @@ pub enum StatusCode {
 
     /// 424 Failed Dependency
     ///
-    /// The request failed because it depended on another request and that request failed (e.g., a PROPPATCH).
+    /// The request failed because it depended on another request and that
+    /// request failed (e.g., a PROPPATCH).
     FailedDependency = 424,
 
     /// 425 Too Early
     ///
-    /// Indicates that the server is unwilling to risk processing a request that might be replayed.
+    /// Indicates that the server is unwilling to risk processing a request that
+    /// might be replayed.
     TooEarly = 425,
 
     /// 426 Upgrade Required
     ///
-    /// The server refuses to perform the request using the current protocol but might be willing
-    /// to do so after the client upgrades to a different protocol. The server sends an Upgrade
-    /// header in a 426 response to indicate the required protocol(s).
+    /// The server refuses to perform the request using the current protocol but
+    /// might be willing to do so after the client upgrades to a different
+    /// protocol. The server sends an Upgrade header in a 426 response to
+    /// indicate the required protocol(s).
     UpgradeRequired = 426,
 
     /// 428 Precondition Required
     ///
-    /// The origin server requires the request to be conditional. This response is intended to
-    /// prevent the 'lost update' problem, where a client GETs a resource's state, modifies it, and
-    /// PUTs it back to the server, when meanwhile a third party has modified the state on the
+    /// The origin server requires the request to be conditional. This response
+    /// is intended to prevent the 'lost update' problem, where a client
+    /// GETs a resource's state, modifies it, and PUTs it back to the
+    /// server, when meanwhile a third party has modified the state on the
     /// server, leading to a conflict.
     PreconditionRequired = 428,
 
     /// 429 Too Many Requests
     ///
-    /// The user has sent too many requests in a given amount of time ("rate limiting").
+    /// The user has sent too many requests in a given amount of time ("rate
+    /// limiting").
     TooManyRequests = 429,
 
     /// 431 Request Header Fields Too Large
     ///
-    /// The server is unwilling to process the request because its header fields are too large. The
-    /// request may be resubmitted after reducing the size of the request header fields.
+    /// The server is unwilling to process the request because its header fields
+    /// are too large. The request may be resubmitted after reducing the
+    /// size of the request header fields.
     RequestHeaderFieldsTooLarge = 431,
 
     /// 451 Unavailable For Legal Reasons
     ///
-    /// The user-agent requested a resource that cannot legally be provided, such as a web page
-    /// censored by a government.
+    /// The user-agent requested a resource that cannot legally be provided,
+    /// such as a web page censored by a government.
     UnavailableForLegalReasons = 451,
 
     /// 500 Internal Server Error
@@ -319,32 +350,35 @@ pub enum StatusCode {
 
     /// 501 Not Implemented
     ///
-    /// The request method is not supported by the server and cannot be handled. The only methods
-    /// that servers are required to support (and therefore that must not return this code) are GET
-    /// and HEAD.
+    /// The request method is not supported by the server and cannot be handled.
+    /// The only methods that servers are required to support (and therefore
+    /// that must not return this code) are GET and HEAD.
     NotImplemented = 501,
 
     /// 502 Bad Gateway
     ///
-    /// This error response means that the server, while working as a gateway to get a response
-    /// needed to handle the request, got an invalid response.
+    /// This error response means that the server, while working as a gateway to
+    /// get a response needed to handle the request, got an invalid
+    /// response.
     BadGateway = 502,
 
     /// 503 Service Unavailable
     ///
-    /// The server is not ready to handle the request. Common causes are a server that is down for
-    /// maintenance or that is overloaded. Note that together with this response, a user-friendly
-    /// page explaining the problem should be sent. This responses should be used for temporary
-    /// conditions and the Retry-After: HTTP header should, if possible, contain the estimated time
-    /// before the recovery of the service. The webmaster must also take care about the
-    /// caching-related headers that are sent along with this response, as these temporary
-    /// condition responses should usually not be cached.
+    /// The server is not ready to handle the request. Common causes are a
+    /// server that is down for maintenance or that is overloaded. Note that
+    /// together with this response, a user-friendly page explaining the
+    /// problem should be sent. This responses should be used for temporary
+    /// conditions and the Retry-After: HTTP header should, if possible, contain
+    /// the estimated time before the recovery of the service. The webmaster
+    /// must also take care about the caching-related headers that are sent
+    /// along with this response, as these temporary condition responses
+    /// should usually not be cached.
     ServiceUnavailable = 503,
 
     /// 504 Gateway Timeout
     ///
-    /// This error response is given when the server is acting as a gateway and cannot get a
-    /// response in time.
+    /// This error response is given when the server is acting as a gateway and
+    /// cannot get a response in time.
     GatewayTimeout = 504,
 
     /// 505 HTTP Version Not Supported
@@ -354,14 +388,16 @@ pub enum StatusCode {
 
     /// 506 Variant Also Negotiates
     ///
-    /// The server has an internal configuration error: the chosen variant resource is configured
-    /// to engage in transparent content negotiation itself, and is therefore not a proper end
-    /// point in the negotiation process.
+    /// The server has an internal configuration error: the chosen variant
+    /// resource is configured to engage in transparent content negotiation
+    /// itself, and is therefore not a proper end point in the negotiation
+    /// process.
     VariantAlsoNegotiates = 506,
 
     /// 507 Insufficient Storage
     ///
-    /// The server is unable to store the representation needed to complete the request.
+    /// The server is unable to store the representation needed to complete the
+    /// request.
     InsufficientStorage = 507,
 
     /// 508 Loop Detected
@@ -371,19 +407,22 @@ pub enum StatusCode {
 
     /// 510 Not Extended
     ///
-    /// Further extensions to the request are required for the server to fulfil it.
+    /// Further extensions to the request are required for the server to fulfil
+    /// it.
     NotExtended = 510,
 
     /// 511 Network Authentication Required
     ///
-    /// The 511 status code indicates that the client needs to authenticate to gain network access.
+    /// The 511 status code indicates that the client needs to authenticate to
+    /// gain network access.
     NetworkAuthenticationRequired = 511,
 }
 
 impl StatusCode {
     /// Returns `true` if the status code is `1xx` range.
     ///
-    /// If this returns `true` it indicates that the request was received, continuing process.
+    /// If this returns `true` it indicates that the request was received,
+    /// continuing process.
     pub fn is_informational(&self) -> bool {
         let num: u16 = self.clone().into();
         num >= 100 && num < 200
@@ -391,8 +430,8 @@ impl StatusCode {
 
     /// Returns `true` if the status code is the `2xx` range.
     ///
-    /// If this returns `true` it indicates that the request was successfully received, understood,
-    /// and accepted.
+    /// If this returns `true` it indicates that the request was successfully
+    /// received, understood, and accepted.
     pub fn is_success(&self) -> bool {
         let num: u16 = self.clone().into();
         num >= 200 && num < 300
@@ -400,8 +439,8 @@ impl StatusCode {
 
     /// Returns `true` if the status code is the `3xx` range.
     ///
-    /// If this returns `true` it indicates that further action needs to be taken in order to
-    /// complete the request.
+    /// If this returns `true` it indicates that further action needs to be
+    /// taken in order to complete the request.
     pub fn is_redirection(&self) -> bool {
         let num: u16 = self.clone().into();
         num >= 300 && num < 400
@@ -409,8 +448,8 @@ impl StatusCode {
 
     /// Returns `true` if the status code is the `4xx` range.
     ///
-    /// If this returns `true` it indicates that the request contains bad syntax or cannot be
-    /// fulfilled.
+    /// If this returns `true` it indicates that the request contains bad syntax
+    /// or cannot be fulfilled.
     pub fn is_client_error(&self) -> bool {
         let num: u16 = self.clone().into();
         num >= 400 && num < 500
@@ -418,8 +457,8 @@ impl StatusCode {
 
     /// Returns `true` if the status code is the `5xx` range.
     ///
-    /// If this returns `true` it indicates that the server failed to fulfill an apparently valid
-    /// request.
+    /// If this returns `true` it indicates that the server failed to fulfill an
+    /// apparently valid request.
     pub fn is_server_error(&self) -> bool {
         let num: u16 = self.clone().into();
         num >= 500 && num < 600


### PR DESCRIPTION
Change the trait bound of `S` in the `Status` trait to accept a `TryInto<StatusCode>`; this would allow the `Status` trait to accept a wider range of input.

Uses the same approach as `Response::new`.

Refs: #155 

Draft PR until the checklist is complete:

- [X] feature implementation.
- [x] tests added.
- [x] documentation updated.