### PR TITLE
Enable secure cookies by default

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ features = ["docs"]
 rustdoc-args = ["--cfg", "feature=\"docs\""]
 
 [features]
-default = ["async_std"]
+default = ["async_std", "cookie-secure"]
 docs = ["unstable"]
 unstable = []
 hyperium_http = ["http"]


### PR DESCRIPTION
As per https://github.com/http-rs/http-types/pull/152#pullrequestreview-420895344, secure cookies would likely be more useful than not.  This enables the feature by default, allowing dependees to opt-out if they don't need them.