### PR TITLE
Add CI job for wasm32-unknown-unknown

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -62,3 +62,23 @@ jobs:
 
     - name: Docs
       run: cargo doc
+
+  check_wasm:
+    name: Check wasm targets
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@master
+
+    - name: Install nightly with wasm32-unknown-unknown
+      uses: actions-rs/toolchain@v1
+      with:
+        toolchain: nightly
+        target: wasm32-unknown-unknown
+        override: true
+
+    - name: check
+      uses: actions-rs/cargo@v1
+      with:
+        command: check
+        args: --target wasm32-unknown-unknown


### PR DESCRIPTION
RE comments on #153, added a job to check compilation on the wasm32-unknown-unknown target.

Since the tests can't be run directly, I think a separate job that just runs `cargo check` should be sufficient to prevent compilation regressions in the future.