### PR TITLE
Clippy: fix errors and enable ci

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -26,6 +26,7 @@ jobs:
       uses: actions-rs/toolchain@v1
       with:
         toolchain: ${{ matrix.rust }}
+        components: clippy
         override: true
 
     - name: check
@@ -39,6 +40,12 @@ jobs:
       with:
         command:  check
         args: --all --benches --bins --examples --tests --features "hyperium_http,unstable"
+
+    - name: clippy
+      uses: actions-rs/cargo@v1
+      with:
+        command: clippy
+        args: -- -D warnings
 
     - name: tests
       uses: actions-rs/cargo@v1

--- a/src/body.rs
+++ b/src/body.rs
@@ -439,7 +439,7 @@ impl<'a> From<&'a str> for Body {
 
 impl From<Vec<u8>> for Body {
     fn from(b: Vec<u8>) -> Self {
-        Self::from_bytes(b.to_owned())
+        Self::from_bytes(b)
     }
 }
 

--- a/src/headers/header_values.rs
+++ b/src/headers/header_values.rs
@@ -113,13 +113,13 @@ impl<'a> PartialEq<[&'a str]> for HeaderValues {
 
 impl PartialEq<String> for HeaderValues {
     fn eq(&self, other: &String) -> bool {
-        self.inner.len() == 1 && &self.inner[0] == other
+        self.inner.len() == 1 && self.inner[0] == *other
     }
 }
 
 impl<'a> PartialEq<&String> for HeaderValues {
     fn eq(&self, other: &&String) -> bool {
-        self.inner.len() == 1 && &&self.inner[0] == other
+        self.inner.len() == 1 && self.inner[0] == **other
     }
 }
 

--- a/src/headers/headers.rs
+++ b/src/headers/headers.rs
@@ -61,7 +61,7 @@ impl Headers {
     /// header if there aren't any. Or else append to the existing list of headers.
     pub fn append(&mut self, name: impl Into<HeaderName>, values: impl ToHeaderValues) {
         let name = name.into();
-        match self.get_mut(name.clone()) {
+        match self.get_mut(&name) {
             Some(headers) => {
                 let mut values: HeaderValues = values.to_header_values().unwrap().collect();
                 headers.append(&mut values);

--- a/src/headers/mod.rs
+++ b/src/headers/mod.rs
@@ -4,6 +4,7 @@ mod constants;
 mod header_name;
 mod header_value;
 mod header_values;
+#[allow(clippy::module_inception)]
 mod headers;
 mod into_iter;
 mod iter;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -95,6 +95,7 @@
 
 #![deny(missing_debug_implementations, nonstandard_style)]
 #![warn(missing_docs, unreachable_pub)]
+#![allow(clippy::new_without_default)]
 #![cfg_attr(test, deny(warnings))]
 #![cfg_attr(feature = "docs", feature(doc_cfg))]
 #![doc(html_favicon_url = "https://yoshuawuyts.com/assets/http-rs/favicon.ico")]

--- a/src/request.rs
+++ b/src/request.rs
@@ -113,7 +113,7 @@ impl Request {
         self.forwarded_header_part("host")
             .or_else(|| {
                 self.header("X-Forwarded-Host")
-                    .and_then(|h| h.as_str().split(",").next())
+                    .and_then(|h| h.as_str().split(',').next())
             })
             .or_else(|| self.header(&headers::HOST).map(|h| h.as_str()))
             .or_else(|| self.url().host_str())
@@ -121,8 +121,8 @@ impl Request {
 
     fn forwarded_header_part(&self, part: &str) -> Option<&str> {
         self.header("Forwarded").and_then(|header| {
-            header.as_str().split(";").find_map(|key_equals_value| {
-                let parts = key_equals_value.split("=").collect::<Vec<_>>();
+            header.as_str().split(';').find_map(|key_equals_value| {
+                let parts = key_equals_value.split('=').collect::<Vec<_>>();
                 if parts.len() == 2 && parts[0].eq_ignore_ascii_case(part) {
                     Some(parts[1])
                 } else {
@@ -135,7 +135,7 @@ impl Request {
     fn forwarded_for(&self) -> Option<&str> {
         self.forwarded_header_part("for").or_else(|| {
             self.header("X-Forwarded-For")
-                .and_then(|header| header.as_str().split(",").next())
+                .and_then(|header| header.as_str().split(',').next())
         })
     }
 
@@ -863,10 +863,10 @@ impl Clone for Request {
     /// extensions.
     fn clone(&self) -> Self {
         Request {
-            method: self.method.clone(),
+            method: self.method,
             url: self.url.clone(),
             headers: self.headers.clone(),
-            version: self.version.clone(),
+            version: self.version,
             trailers_sender: None,
             trailers_receiver: None,
             body: Body::empty(),
@@ -1136,8 +1136,8 @@ mod tests {
             set_x_forwarded_for(&mut request, "forwarded-for-client.com");
             request.peer_addr = Some("127.0.0.1:8000".into());
 
-            assert_eq!(request.forwarded_for(), Some("forwarded.com".into()));
-            assert_eq!(request.remote(), Some("forwarded.com".into()));
+            assert_eq!(request.forwarded_for(), Some("forwarded.com"));
+            assert_eq!(request.remote(), Some("forwarded.com"));
         }
 
         #[test]
@@ -1146,7 +1146,7 @@ mod tests {
             request.peer_addr = Some("127.0.0.1:8000".into());
 
             assert_eq!(request.forwarded_for(), None);
-            assert_eq!(request.remote(), Some("127.0.0.1:8000".into()));
+            assert_eq!(request.remote(), Some("127.0.0.1:8000"));
         }
 
         #[test]

--- a/src/response.rs
+++ b/src/response.rs
@@ -635,9 +635,9 @@ impl Clone for Response {
     /// extensions.
     fn clone(&self) -> Self {
         Self {
-            status: self.status.clone(),
+            status: self.status,
             headers: self.headers.clone(),
-            version: self.version.clone(),
+            version: self.version,
             trailers_sender: self.trailers_sender.clone(),
             trailers_receiver: self.trailers_receiver.clone(),
             #[cfg(feature = "unstable")]

--- a/src/security/csp.rs
+++ b/src/security/csp.rs
@@ -354,6 +354,6 @@ impl ContentSecurityPolicy {
         } else {
             "Content-Security-Policy"
         };
-        headers.as_mut().insert(name, self.value().to_owned());
+        headers.as_mut().insert(name, self.value());
     }
 }

--- a/tests/error.rs
+++ b/tests/error.rs
@@ -13,8 +13,7 @@ fn can_be_boxed() {
 #[test]
 fn internal_server_error_by_default() {
     fn run() -> http_types::Result<()> {
-        Err(io::Error::new(io::ErrorKind::Other, "Oh no"))?;
-        Ok(())
+        Err(io::Error::new(io::ErrorKind::Other, "Oh no").into())
     }
     let err = run().unwrap_err();
     assert_eq!(err.status(), 500);
@@ -23,7 +22,7 @@ fn internal_server_error_by_default() {
 #[test]
 fn ensure() {
     fn inner() -> http_types::Result<()> {
-        ensure!(1 == 1, "Oh yes");
+        ensure!(true, "Oh yes");
         bail!("Oh no!");
     }
     let res = inner();


### PR DESCRIPTION
Hello,

I am not sure about the project adherence to clippy. Reading #92 i understand it is accepted as a best practice with some exceptions such `new_without_default`.

I have thus fixed minor and straightforward clippy errors and warnings with a few exceptions described in the commit comment.

I have also added a github CI check to help keep the project clippy clean. Since clippy is consuming some precious minutes it can be moved to ubuntu only (as fmt checks) instead of all OSes if requested.

Cheers !

