### PR TITLE
Add `range` submodule

### DIFF
--- a/src/conditional/if_range.rs
+++ b/src/conditional/if_range.rs
@@ -1,0 +1,213 @@
+use crate::conditional::ETag;
+use crate::headers::{HeaderName, HeaderValue, Headers, ToHeaderValues, IF_RANGE};
+use crate::utils::{fmt_http_date, parse_http_date};
+
+use std::fmt::{self, Display};
+use std::option;
+use std::time::SystemTime;
+
+/// Apply the HTTP method if the ETag or date matches
+///
+/// # Specifications
+///
+/// - [RFC 7233, section 3.2: Range](https://tools.ietf.org/html/rfc7233#section-3.2)
+/// - [RFC 7232, section 2.3: ETag](https://tools.ietf.org/html/rfc7232#section-2.3)
+/// - [RFC 7231, section 7.1.1.1: Date/Time Formats](https://tools.ietf.org/html/rfc7231#section-7.1.1.1)
+///
+/// # Examples
+///
+/// If-Range with strong ETag:
+///
+/// ```
+/// # fn main() -> http_types::Result<()> {
+/// #
+/// use http_types::conditional::{ETag, IfRange};
+/// use http_types::Response;
+///
+/// let strong_etag = ETag::new(String::from("aBcdEFghijkl"));
+/// let ifrange = IfRange::from(strong_etag.clone());
+///
+/// let mut res = Response::new(200);
+/// ifrange.apply(&mut res);
+///
+/// let ifrange = IfRange::from_headers(res)?.unwrap();
+/// assert_eq!(ifrange, IfRange::ETag(strong_etag));
+/// #
+/// # Ok(()) }
+/// ```
+///
+/// If-Range with HTTP Date:
+///
+/// ```
+/// # fn main() -> http_types::Result<()> {
+/// #
+/// use http_types::conditional::IfRange;
+/// use http_types::{Error, Response, StatusCode};
+/// use std::time::{Duration, SystemTime};
+///
+/// let time = SystemTime::now() + Duration::from_secs(5 * 60);
+/// let ifrange = IfRange::from(time);
+///
+/// let mut res = Response::new(200);
+/// ifrange.apply(&mut res);
+///
+/// let ifrange = IfRange::from_headers(res)?.unwrap();
+///
+/// let response_time = match ifrange {
+///     IfRange::Date(d) => d,
+///     _ => {
+///         return Err(Error::from_str(
+///             StatusCode::RequestedRangeNotSatisfiable,
+///             "Invalid If-Range header",
+///         ))
+///     }
+/// };
+///
+/// // HTTP dates only have second-precision.
+/// let elapsed = time.duration_since(response_time)?;
+/// assert_eq!(elapsed.as_secs(), 0);
+/// #
+/// # Ok(()) }
+/// ```
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum IfRange {
+    /// If-Range condition expressed with an `ETag`.
+    ETag(ETag),
+    /// If-Range condition expressed with an `HTTP Date`.
+    Date(SystemTime),
+}
+
+impl IfRange {
+    /// Create an instance of `IfRange` from a `Headers` instance.
+    pub fn from_headers(headers: impl AsRef<Headers>) -> crate::Result<Option<Self>> {
+        let headers = match headers.as_ref().get(IF_RANGE) {
+            Some(headers) => headers,
+            None => return Ok(None),
+        };
+
+        // If we successfully parsed the header then there's always at least one
+        // entry. We want the last entry.
+        let header = headers.iter().last().unwrap();
+        let header_str = header.as_str();
+
+        parse_http_date(header_str)
+            .map(|d| Some(IfRange::from(d)))
+            .or_else(|_| Ok(Some(IfRange::from(ETag::from_str(header_str)?))))
+    }
+
+    /// Insert a `HeaderName` + `HeaderValue` pair into a `Headers` instance.
+    pub fn apply(&self, mut headers: impl AsMut<Headers>) {
+        headers.as_mut().insert(IF_RANGE, self.value());
+    }
+
+    /// Get the `HeaderName`.
+    pub fn name(&self) -> HeaderName {
+        IF_RANGE
+    }
+
+    /// Get the `HeaderValue`.
+    pub fn value(&self) -> HeaderValue {
+        let output = self.to_string();
+
+        // SAFETY: the internal string is validated to be ASCII.
+        unsafe { HeaderValue::from_bytes_unchecked(output.into()) }
+    }
+}
+
+impl Display for IfRange {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let s = match self {
+            IfRange::ETag(t) => t.to_string(),
+            IfRange::Date(d) => fmt_http_date(*d),
+        };
+        write!(f, "{}", s)
+    }
+}
+
+impl ToHeaderValues for IfRange {
+    type Iter = option::IntoIter<HeaderValue>;
+    fn to_header_values(&self) -> crate::Result<Self::Iter> {
+        // A HeaderValue will always convert into itself.
+        Ok(self.value().to_header_values().unwrap())
+    }
+}
+
+impl From<ETag> for IfRange {
+    fn from(etag: ETag) -> Self {
+        IfRange::ETag(etag)
+    }
+}
+
+impl From<SystemTime> for IfRange {
+    fn from(time: SystemTime) -> Self {
+        IfRange::Date(time)
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use crate::headers::Headers;
+    use crate::{Error, StatusCode};
+
+    use std::time::Duration;
+
+    #[test]
+    fn if_range_time() -> crate::Result<()> {
+        let time = SystemTime::now() + Duration::from_secs(5 * 60);
+        let if_range = IfRange::from(time);
+
+        let mut headers = Headers::new();
+        if_range.apply(&mut headers);
+
+        let if_range = IfRange::from_headers(headers)?.unwrap();
+
+        let header_time = match if_range {
+            IfRange::Date(d) => d,
+            _ => {
+                return Err(Error::from_str(
+                    StatusCode::RequestedRangeNotSatisfiable,
+                    "Invalid If-Range header",
+                ))
+            }
+        };
+
+        // HTTP dates only have second-precision
+        let elapsed = time.duration_since(header_time)?;
+        assert_eq!(elapsed.as_secs(), 0);
+        Ok(())
+    }
+
+    #[test]
+    fn if_range_etag() -> crate::Result<()> {
+        let etag = ETag::new(String::from("foobar"));
+        let if_range = IfRange::from(etag.clone());
+
+        let mut headers = Headers::new();
+        if_range.apply(&mut headers);
+
+        let if_range = IfRange::from_headers(headers)?.unwrap();
+
+        let header_etag = match if_range {
+            IfRange::ETag(t) => t,
+            _ => {
+                return Err(Error::from_str(
+                    StatusCode::RequestedRangeNotSatisfiable,
+                    "Invalid If-Range header",
+                ))
+            }
+        };
+
+        assert_eq!(header_etag, etag);
+        Ok(())
+    }
+
+    #[test]
+    fn bad_request_on_parse_error() -> crate::Result<()> {
+        let mut headers = Headers::new();
+        headers.insert(IF_RANGE, "<nori ate the tag. yum.>");
+        let err = IfRange::from_headers(headers).unwrap_err();
+        assert_eq!(err.status(), 400);
+        Ok(())
+    }
+}

--- a/src/conditional/mod.rs
+++ b/src/conditional/mod.rs
@@ -10,6 +10,7 @@
 
 mod etag;
 mod if_modified_since;
+mod if_range;
 mod if_unmodified_since;
 mod last_modified;
 mod vary;
@@ -26,6 +27,8 @@ pub use if_match::IfMatch;
 pub use if_modified_since::IfModifiedSince;
 #[doc(inline)]
 pub use if_none_match::IfNoneMatch;
+#[doc(inline)]
+pub use if_range::IfRange;
 #[doc(inline)]
 pub use if_unmodified_since::IfUnmodifiedSince;
 #[doc(inline)]

--- a/src/headers/constants.rs
+++ b/src/headers/constants.rs
@@ -138,6 +138,9 @@ pub const PROXY_AUTHORIZATION: HeaderName = HeaderName::from_lowercase_str("prox
 /// The `Proxy-Connection` Header
 pub const PROXY_CONNECTION: HeaderName = HeaderName::from_lowercase_str("proxy-connection");
 
+/// The `Range` Header
+pub const RANGE: HeaderName = HeaderName::from_lowercase_str("range");
+
 ///  The `Referer` Header
 pub const REFERER: HeaderName = HeaderName::from_lowercase_str("referer");
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -125,6 +125,7 @@ pub mod headers;
 pub mod mime;
 pub mod other;
 pub mod proxies;
+pub mod range;
 pub mod server;
 
 mod body;

--- a/src/range/accept_ranges.rs
+++ b/src/range/accept_ranges.rs
@@ -1,0 +1,178 @@
+use crate::range::bytes;
+use crate::{
+    headers::{HeaderName, HeaderValue, Headers, ToHeaderValues, ACCEPT_RANGES},
+    Error,
+};
+
+use std::fmt::{self, Debug, Display};
+use std::option;
+
+/// HTTP Accept-Ranges response header.
+///
+/// Accept-Ranges header indicates that the server supports
+/// range requests and specifies the unit to be used by
+/// clients for range requests.
+///
+/// The default value is to not accept range requests.
+///
+/// # Specifications
+///
+/// - [RFC 7233, section 2.3: Accept-Ranges](https://tools.ietf.org/html/rfc7233#section-2.3)
+/// - [RFC 7233, section 2.1: Byte Ranges](https://tools.ietf.org/html/rfc7233#section-2.1)
+/// - [IANA HTTP parameters, range-units: HTTP Range Unit Registry](https://www.iana.org/assignments/http-parameters/http-parameters.xhtml)
+///
+/// # Examples
+///
+/// Accepting ranges specified in byte unit (the widely used default):
+///
+/// ```
+/// # fn main() -> http_types::Result<()> {
+/// #
+/// use http_types::range::AcceptRanges;
+/// use http_types::Response;
+///
+/// let accept_ranges = AcceptRanges::Bytes;
+///
+/// let mut res = Response::new(200);
+/// accept_ranges.apply(&mut res);
+///
+/// let accept_ranges = AcceptRanges::from_headers(res)?.unwrap();
+/// assert_eq!(accept_ranges, AcceptRanges::Bytes);
+/// #
+/// # Ok(()) }
+/// ```
+///
+/// Range requests not accepted:
+///
+/// ```
+/// # fn main() -> http_types::Result<()> {
+/// #
+/// use http_types::range::AcceptRanges;
+/// use http_types::Response;
+///
+/// let accept_ranges = AcceptRanges::None;
+///
+/// let mut res = Response::new(200);
+/// accept_ranges.apply(&mut res);
+///
+/// let accept_ranges = AcceptRanges::from_headers(res)?.unwrap();
+/// assert_eq!(accept_ranges, AcceptRanges::None);
+/// #
+/// # Ok(()) }
+/// ```
+#[derive(Debug, Clone, Eq, PartialEq)]
+#[non_exhaustive]
+pub enum AcceptRanges {
+    /// Accepts bytes based range requests.
+    Bytes,
+    /// Do not accept range requests.
+    None,
+}
+
+impl AcceptRanges {
+    /// The "none" value used when range requests are not accepted.
+    const NONE: &'static str = "none";
+
+    /// Create a new instance from headers.
+    ///
+    /// Only a single AcceptRanges per resource is assumed to exist. If multiple Accept-Ranges
+    /// headers are found the last one is used.
+    pub fn from_headers(headers: impl AsRef<Headers>) -> crate::Result<Option<Self>> {
+        let headers = match headers.as_ref().get(ACCEPT_RANGES) {
+            Some(headers) => headers,
+            None => return Ok(None),
+        };
+
+        // If a header is returned we can assume at least one exists.
+        let s = headers.iter().last().unwrap().as_str();
+        Self::from_str(s).map(Some)
+    }
+
+    /// Create an AcceptRanges from a string.
+    pub(crate) fn from_str(s: &str) -> crate::Result<Self> {
+        match s {
+            Self::NONE => Ok(AcceptRanges::None),
+            bytes::ACCEPT_RANGE_VALUE => Ok(AcceptRanges::Bytes),
+            _ => Err(Error::new_adhoc("unknown Accept-Ranges header")),
+        }
+    }
+
+    /// Sets the `Accept-Ranges` header.
+    pub fn apply(&self, mut headers: impl AsMut<Headers>) {
+        headers.as_mut().insert(ACCEPT_RANGES, self.value());
+    }
+
+    /// Get the `HeaderName`.
+    pub fn name(&self) -> HeaderName {
+        ACCEPT_RANGES
+    }
+
+    /// Get the `HeaderValue`.
+    pub fn value(&self) -> HeaderValue {
+        let s = match self {
+            AcceptRanges::Bytes => bytes::ACCEPT_RANGE_VALUE,
+            AcceptRanges::None => AcceptRanges::NONE,
+        };
+        // SAFETY: the internal string is validated to be ASCII.
+        unsafe { HeaderValue::from_bytes_unchecked(s.into()) }
+    }
+}
+
+impl Display for AcceptRanges {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            AcceptRanges::Bytes => write!(f, "{}", bytes::ACCEPT_RANGE_VALUE),
+            AcceptRanges::None => write!(f, "{}", AcceptRanges::NONE),
+        }
+    }
+}
+
+impl ToHeaderValues for AcceptRanges {
+    type Iter = option::IntoIter<HeaderValue>;
+    fn to_header_values(&self) -> crate::Result<Self::Iter> {
+        // A HeaderValue will always convert into itself.
+        Ok(self.value().to_header_values().unwrap())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::headers::Headers;
+
+    use crate::Response;
+
+    #[test]
+    fn accept_ranges_none() -> crate::Result<()> {
+        let mut headers = Headers::new();
+        headers.insert(ACCEPT_RANGES, "none");
+        let accept_ranges = AcceptRanges::from_headers(headers).unwrap().unwrap();
+        assert_eq!(accept_ranges, AcceptRanges::None);
+
+        let accept_ranges = AcceptRanges::None;
+        let mut res = Response::new(200);
+        accept_ranges.apply(&mut res);
+
+        let raw_header_value = res.header(ACCEPT_RANGES).unwrap();
+        assert_eq!(raw_header_value, "none");
+
+        Ok(())
+    }
+
+    #[test]
+    fn accept_ranges_bytes() -> crate::Result<()> {
+        let mut headers = Headers::new();
+        headers.insert(ACCEPT_RANGES, "bytes");
+        let accept_ranges = AcceptRanges::from_headers(headers).unwrap().unwrap();
+        assert_eq!(accept_ranges, AcceptRanges::Bytes);
+
+        let accept_ranges = AcceptRanges::Bytes;
+        let mut res = Response::new(200);
+        accept_ranges.apply(&mut res);
+
+        let raw_header_value = res.header(ACCEPT_RANGES).unwrap();
+        assert_eq!(raw_header_value, "bytes");
+
+        Ok(())
+    }
+}

--- a/src/range/bytes.rs
+++ b/src/range/bytes.rs
@@ -1,0 +1,542 @@
+use crate::{Error, StatusCode};
+
+use std::fmt::{self, Debug, Display};
+use std::str::FromStr;
+
+pub(crate) const ACCEPT_RANGE_VALUE: &str = "bytes";
+pub(crate) const RANGE_PREFIX: &str = "bytes=";
+pub(crate) const CONTENT_RANGE_PREFIX: &str = "bytes ";
+
+/// The representation of a single HTTP byte range.
+///
+/// # Specifications
+///
+/// - [RFC 7233, section 2.1: Range](https://tools.ietf.org/html/rfc7233#section-2.1)
+/// - [RFC 7233, Appendix D: Collected ABNF](https://tools.ietf.org/html/rfc7233#appendix-D)
+#[derive(Default, Debug, Clone, Eq, PartialEq, Copy)]
+pub struct BytesRange {
+    /// The range start.
+    ///
+    /// If empty the ends indicates a relative start
+    /// from the end of the document.
+    pub start: Option<u64>,
+    /// The range end.
+    ///
+    /// If empty the range goes through the end
+    /// of the document.
+    pub end: Option<u64>,
+}
+
+impl BytesRange {
+    /// Create a new instance with start and end.
+    pub fn new<S, E>(start: S, end: E) -> Self
+    where
+        S: Into<Option<u64>>,
+        E: Into<Option<u64>>,
+    {
+        Self {
+            start: start.into(),
+            end: end.into(),
+        }
+    }
+
+    /// Returns true if the range's bounds match the given document size.
+    pub fn match_size(&self, size: u64) -> bool {
+        if let Some(start) = self.start {
+            if start > size - 1 {
+                return false;
+            }
+        }
+        if let Some(end) = self.end {
+            if end > size - 1 {
+                return false;
+            }
+        }
+        true
+    }
+}
+
+impl Display for BytesRange {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "{}-{}",
+            self.start
+                .map(|v| v.to_string())
+                .unwrap_or_else(String::new),
+            self.end.map(|v| v.to_string()).unwrap_or_else(String::new),
+        )
+    }
+}
+
+impl FromStr for BytesRange {
+    type Err = Error;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let fn_err = || {
+            Err(Error::from_str(
+                StatusCode::RequestedRangeNotSatisfiable,
+                "Invalid Range header for byte ranges",
+            ))
+        };
+
+        let mut s = s.trim().splitn(2, '-');
+        let start = str_to_bound(s.next())?;
+        let end = str_to_bound(s.next())?;
+
+        if start.is_none() && end.is_none() {
+            return fn_err();
+        }
+
+        if let Some(start) = start {
+            if let Some(end) = end {
+                if end <= start {
+                    return fn_err();
+                }
+            }
+        }
+
+        Ok(BytesRange::new(start, end))
+    }
+}
+
+fn str_to_bound(s: Option<&str>) -> crate::Result<Option<u64>> {
+    s.and_then(|s| if s.is_empty() { None } else { Some(s) })
+        .map(|s| {
+            u64::from_str(s).map_err(|_| {
+                Error::from_str(
+                    StatusCode::RequestedRangeNotSatisfiable,
+                    "Invalid Range header for byte ranges",
+                )
+            })
+        })
+        .transpose()
+}
+
+/// A set of `BytesRange` representing a range request.
+///
+///
+/// # Specifications
+///
+/// - [RFC 7233, section 3.1: Range](https://tools.ietf.org/html/rfc7233#section-3.1)
+/// - [RFC 7233, Appendix D: Collected ABNF](https://tools.ietf.org/html/rfc7233#appendix-D)
+#[derive(Default, Debug, Clone, Eq, PartialEq)]
+pub struct BytesRangeSet {
+    ranges: Vec<BytesRange>,
+}
+
+impl BytesRangeSet {
+    /// Create a new instance with an empty range set.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Pushes a new byte range at the end of the byte range set.
+    pub fn push<S, E>(&mut self, start: S, end: E)
+    where
+        S: Into<Option<u64>>,
+        E: Into<Option<u64>>,
+    {
+        let range = BytesRange::new(start, end);
+        self.ranges.push(range);
+    }
+
+    /// Pushes a `BytesRange` at the end of the byte range set.
+    pub fn push_range<S, E>(&mut self, range: BytesRange)
+    where
+        S: Into<Option<u64>>,
+        E: Into<Option<u64>>,
+    {
+        self.ranges.push(range);
+    }
+
+    /// Returns the number of `BytesRange` in the set.
+    pub fn len(&self) -> usize {
+        self.ranges.len()
+    }
+
+    /// Returns true if the set contains no element.
+    pub fn is_empty(&self) -> bool {
+        self.ranges.is_empty()
+    }
+
+    /// Returns an `Iterator` over the `BytesRange`.
+    pub fn iter(&self) -> impl Iterator<Item = &BytesRange> {
+        self.ranges.iter()
+    }
+
+    /// Returns the first `BytesRange` in the set.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the set is empty. A `BytesRangeSet`
+    /// built from a `Range` header is warranted to be none empty.
+    pub fn first(&self) -> Option<BytesRange> {
+        self.ranges.get(0).copied()
+    }
+
+    /// Validates that the ranges are within the expected document size.
+    ///
+    /// Returns `HTTP 416 Range Not Satisfiable` if one range is out of bounds.
+    ///
+    /// # Examples
+    ///
+    /// Most of the time applications want to validate the range set against
+    /// the actual size of the document, as per the RFC specification:
+    ///
+    /// ```
+    /// # fn main() -> http_types::Result<()> {
+    /// #
+    /// use http_types::range::{BytesRange, BytesRangeSet, Range};
+    /// use http_types::{Method, Request, StatusCode, Url};
+    /// use std::convert::TryInto;
+    ///
+    /// let mut range_set = BytesRangeSet::new();
+    /// range_set.push(0, 500);
+    /// let range = Range::Bytes(range_set);
+    ///
+    /// let mut req = Request::new(Method::Get, Url::parse("http://example.com").unwrap());
+    /// range.apply(&mut req);
+    ///
+    /// let range = Range::from_headers(req)?.unwrap();
+    ///
+    /// if let Range::Bytes(range_set) = range {
+    ///     let err = range_set.match_size(350).unwrap_err();
+    ///     assert_eq!(err.status(), StatusCode::RequestedRangeNotSatisfiable);
+    /// }
+    /// #
+    /// # Ok(()) }
+    /// ```
+    pub fn match_size(&self, size: u64) -> crate::Result<()> {
+        for range in &self.ranges {
+            if !range.match_size(size) {
+                return Err(Error::from_str(
+                    StatusCode::RequestedRangeNotSatisfiable,
+                    "Invalid Range header for byte ranges",
+                ));
+            }
+        }
+        Ok(())
+    }
+
+    /// Create a ByteRanges from a string.
+    pub(crate) fn from_str(s: &str) -> crate::Result<Self> {
+        let fn_err = || {
+            Error::from_str(
+                StatusCode::BadRequest,
+                "Invalid Range header for byte ranges",
+            )
+        };
+
+        let mut ranges = Self::new();
+
+        for range_str in s.split(',') {
+            let range = BytesRange::from_str(range_str)?;
+            ranges.ranges.push(range);
+        }
+
+        if ranges.ranges.is_empty() {
+            return Err(fn_err());
+        }
+
+        Ok(ranges)
+    }
+}
+
+impl IntoIterator for BytesRangeSet {
+    type Item = BytesRange;
+    type IntoIter = std::vec::IntoIter<Self::Item>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.ranges.into_iter()
+    }
+}
+
+impl<'a> IntoIterator for &'a BytesRangeSet {
+    type Item = &'a BytesRange;
+    type IntoIter = std::slice::Iter<'a, BytesRange>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.ranges.iter()
+    }
+}
+
+impl Display for BytesRangeSet {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        for (i, range) in self.iter().enumerate() {
+            if i > 0 {
+                write!(f, ",")?;
+            }
+            write!(f, "{}", range)?;
+        }
+        Ok(())
+    }
+}
+
+/// The representation of a HTTP ContentRange response header with bytes.
+///
+/// # Specifications
+///
+/// - [RFC 7233, section 4.2: Range](https://tools.ietf.org/html/rfc7233#section-4.2)
+#[derive(Default, Debug, Clone, Eq, PartialEq)]
+pub struct BytesContentRange {
+    size: Option<u64>,
+    range: Option<BytesRange>,
+}
+
+impl BytesContentRange {
+    /// Create a new instance with no range and no size.
+    pub fn new() -> Self {
+        BytesContentRange::default()
+    }
+
+    /// Returns a new instance with a given range defined by `start` and `end` bounds.
+    pub fn with_range(mut self, start: u64, end: u64) -> Self {
+        self.range = Some(BytesRange::new(start, end));
+        self
+    }
+
+    /// Returns a new instance with a size.
+    pub fn with_size(mut self, size: u64) -> Self {
+        self.size = Some(size);
+        self
+    }
+
+    /// Returns the `ByteRange` if any.
+    pub fn range(&self) -> Option<BytesRange> {
+        self.range
+    }
+
+    /// Returns the size if any.
+    pub fn size(&self) -> Option<u64> {
+        self.size
+    }
+
+    /// Create a ByteRanges from a string.
+    pub(crate) fn from_str(s: &str) -> crate::Result<Self> {
+        let fn_err = || {
+            Error::from_str(
+                StatusCode::RequestedRangeNotSatisfiable,
+                "Invalid Content-Range value",
+            )
+        };
+
+        let mut bytes_content_range = BytesContentRange::new();
+
+        let mut s = s.trim_start().splitn(2, '/');
+
+        let range_s = s.next().ok_or_else(fn_err)?;
+        if range_s != "*" {
+            let range = BytesRange::from_str(range_s).map_err(|_| fn_err())?;
+            if range.start.is_none() || range.end.is_none() {
+                return Err(fn_err());
+            }
+            bytes_content_range.range.replace(range);
+        }
+
+        let size_s = s.next().ok_or_else(fn_err)?;
+        if size_s != "*" {
+            let size = u64::from_str(size_s).map_err(|_| fn_err())?;
+            bytes_content_range = bytes_content_range.with_size(size);
+        }
+
+        if bytes_content_range.range.is_none() && bytes_content_range.size.is_none() {
+            return Err(fn_err());
+        }
+        if let Some(size) = bytes_content_range.size {
+            if let Some(end) = bytes_content_range.range.and_then(|r| r.end) {
+                if size <= end {
+                    return Err(fn_err());
+                }
+            }
+        }
+
+        Ok(bytes_content_range)
+    }
+}
+
+impl Display for BytesContentRange {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "{}/{}",
+            self.range
+                .map(|r| r.to_string())
+                .unwrap_or_else(|| "*".into()),
+            self.size
+                .map(|s| s.to_string())
+                .unwrap_or_else(|| "*".into())
+        )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn byte_range_start_end() -> crate::Result<()> {
+        let range = BytesRange::from_str("1-5")?;
+        assert_eq!(range, BytesRange::new(1, 5));
+        Ok(())
+    }
+
+    #[test]
+    fn byte_range_start_no_end() -> crate::Result<()> {
+        let range = BytesRange::from_str("1-")?;
+        assert_eq!(range, BytesRange::new(1, None));
+        Ok(())
+    }
+
+    #[test]
+    fn byte_range_no_start_end() -> crate::Result<()> {
+        let range = BytesRange::from_str("-5")?;
+        assert_eq!(range, BytesRange::new(None, 5));
+        Ok(())
+    }
+
+    #[test]
+    #[should_panic(expected = "Invalid Range header for byte ranges")]
+    fn byte_range_no_start_no_end() {
+        BytesRange::from_str("-").unwrap();
+    }
+
+    #[test]
+    #[should_panic(expected = "Invalid Range header for byte ranges")]
+    fn byte_range_start_after_end() {
+        BytesRange::from_str("3-1").unwrap();
+    }
+
+    #[test]
+    #[should_panic(expected = "Invalid Range header for byte ranges")]
+    fn byte_range_invalid_integer() {
+        BytesRange::from_str("abc-5").unwrap();
+    }
+
+    #[test]
+    fn byte_range_match_size() {
+        let range = BytesRange::new(0, 4);
+        assert_eq!(range.match_size(5), true);
+    }
+
+    #[test]
+    fn byte_range_not_match_size() {
+        let range = BytesRange::new(0, 4);
+        assert_eq!(range.match_size(3), false);
+    }
+
+    #[test]
+    fn byte_range_not_match_size_start() {
+        let range = BytesRange::new(4, None);
+        assert_eq!(range.match_size(4), false);
+    }
+
+    #[test]
+    fn byte_range_not_match_size_end() {
+        let range = BytesRange::new(None, 5);
+        assert_eq!(range.match_size(5), false);
+    }
+
+    #[test]
+    fn bytes_range_set_single_range() -> crate::Result<()> {
+        let range_set = BytesRangeSet::from_str("1-5")?;
+        assert_eq!(range_set.len(), 1);
+        assert_eq!(range_set.first(), Some(BytesRange::new(1, 5)));
+        Ok(())
+    }
+
+    #[test]
+    fn bytes_range_set_multiple_ranges() -> crate::Result<()> {
+        let range_set = BytesRangeSet::from_str("1-5, -5")?;
+        assert_eq!(range_set.len(), 2);
+        let mut iter = range_set.iter();
+        assert_eq!(iter.next(), Some(&BytesRange::new(1, 5)));
+        assert_eq!(iter.next(), Some(&BytesRange::new(None, 5)));
+        Ok(())
+    }
+
+    #[test]
+    fn bytes_range_set_no_match_size() {
+        let range_set = BytesRangeSet::from_str("1-5, -10").unwrap();
+        let err = range_set.match_size(6).unwrap_err();
+        assert_eq!(err.status(), StatusCode::RequestedRangeNotSatisfiable);
+    }
+
+    #[test]
+    fn bytes_range_match_size() {
+        let range_set = BytesRangeSet::from_str("1-5, -10").unwrap();
+        range_set.match_size(11).unwrap();
+    }
+
+    #[test]
+    fn bytes_content_range_and_size() -> crate::Result<()> {
+        let content_range = BytesContentRange::from_str("1-5/100")?;
+        assert_eq!(content_range.range(), Some(BytesRange::new(1, 5)));
+        assert_eq!(content_range.size(), Some(100));
+        Ok(())
+    }
+
+    #[test]
+    fn bytes_content_range_and_unknown_size() -> crate::Result<()> {
+        let content_range = BytesContentRange::from_str("1-5/*")?;
+        assert_eq!(content_range.range(), Some(BytesRange::new(1, 5)));
+        assert_eq!(content_range.size(), None);
+        Ok(())
+    }
+
+    #[test]
+    fn bytes_content_no_range_and_size() -> crate::Result<()> {
+        let content_range = BytesContentRange::from_str("*/100")?;
+        assert_eq!(content_range.range(), None);
+        assert_eq!(content_range.size(), Some(100));
+        Ok(())
+    }
+
+    #[test]
+    #[should_panic(expected = "Invalid Content-Range value")]
+    fn bytes_content_no_range_and_no_size() {
+        BytesContentRange::from_str("*/*").unwrap();
+    }
+
+    #[test]
+    #[should_panic(expected = "Invalid Content-Range value")]
+    fn bytes_content_invalid_range() {
+        BytesContentRange::from_str("a-b/*").unwrap();
+    }
+
+    #[test]
+    #[should_panic(expected = "Invalid Content-Range value")]
+    fn bytes_content_invalid_size() {
+        BytesContentRange::from_str("*/abc").unwrap();
+    }
+
+    #[test]
+    #[should_panic(expected = "Invalid Content-Range value")]
+    fn bytes_content_invalid_range_end() {
+        BytesContentRange::from_str("5-4/*").unwrap();
+    }
+
+    #[test]
+    #[should_panic(expected = "Invalid Content-Range value")]
+    fn bytes_content_range_overflow_size() {
+        BytesContentRange::from_str("1-4/3").unwrap();
+    }
+
+    #[test]
+    fn bytes_content_apply_format_range_and_size() {
+        let content_range = BytesContentRange::new().with_range(1, 5).with_size(100);
+        assert_eq!(content_range.to_string(), "1-5/100");
+    }
+
+    #[test]
+    fn bytes_content_apply_format_range_and_no_size() {
+        let content_range = BytesContentRange::new().with_range(1, 5);
+        assert_eq!(content_range.to_string(), "1-5/*");
+    }
+
+    #[test]
+    fn bytes_content_apply_no_range_and_size() {
+        let content_range = BytesContentRange::new().with_size(100);
+        assert_eq!(content_range.to_string(), "*/100");
+    }
+}

--- a/src/range/content_range.rs
+++ b/src/range/content_range.rs
@@ -1,0 +1,210 @@
+use crate::headers::{HeaderName, HeaderValue, Headers, ToHeaderValues, CONTENT_RANGE};
+use crate::range::{bytes, BytesContentRange};
+use crate::{Error, StatusCode};
+
+use std::fmt::{self, Debug, Display};
+use std::option;
+
+/// HTTP ContentRange response header.
+///
+/// The "Content-Range" header field is sent in a single part 206
+/// (Partial Content) response to indicate the partial range of the
+/// selected representation enclosed as the message payload, sent in each
+/// part of a multipart 206 response to indicate the range enclosed
+/// within each body part, and sent in 416 (Range Not Satisfiable)
+/// responses to provide information about the selected representation.
+///
+/// # Specifications
+///
+/// - [RFC 7233, section 4.2: Range](https://tools.ietf.org/html/rfc7233#section-4.2)
+///
+/// # Examples
+///
+/// Encoding a Content-Range header for byte range 1-5 of a 10 bytes size document:
+///
+/// ```
+/// # fn main() -> http_types::Result<()> {
+/// #
+/// use http_types::range::{BytesContentRange, BytesRange, ContentRange};
+/// use http_types::{Response, StatusCode};
+///
+/// let bytes_content_range = BytesContentRange::new().with_range(1, 5).with_size(10);
+/// let content_range = ContentRange::Bytes(bytes_content_range);
+///
+/// let mut res = Response::new(StatusCode::PartialContent);
+/// content_range.apply(&mut res);
+///
+/// let content_range = ContentRange::from_headers(res)?.unwrap();
+/// if let ContentRange::Bytes(bytes_content_range) = content_range {
+///     assert_eq!(bytes_content_range.range(), Some(BytesRange::new(1, 5)));
+///     assert_eq!(bytes_content_range.size(), Some(10));
+/// }
+/// #
+/// # Ok(()) }
+/// ```
+///
+/// Encoding a Content-Range header for byte range 1-5 with unknown size:
+///
+/// ```
+/// # fn main() -> http_types::Result<()> {
+/// #
+/// use http_types::range::{BytesContentRange, BytesRange, ContentRange};
+/// use http_types::{Response, StatusCode};
+///
+/// let mut bytes_content_range = BytesContentRange::new().with_range(1, 5);
+/// let content_range = ContentRange::Bytes(bytes_content_range);
+///
+/// let mut res = Response::new(StatusCode::PartialContent);
+/// content_range.apply(&mut res);
+///
+/// let content_range = ContentRange::from_headers(res)?.unwrap();
+/// if let ContentRange::Bytes(bytes_content_range) = content_range {
+///     assert_eq!(bytes_content_range.range(), Some(BytesRange::new(1, 5)));
+///     assert_eq!(bytes_content_range.size(), None);
+/// }
+/// #
+/// # Ok(()) }
+/// ```
+///
+/// Responding to an invalid range request for a 10 bytes document:
+///
+/// ```
+/// # fn main() -> http_types::Result<()> {
+/// #
+/// use http_types::range::{BytesContentRange, BytesRange, ContentRange};
+/// use http_types::{Response, StatusCode};
+///
+/// let bytes_content_range = BytesContentRange::new().with_size(10);
+/// let content_range = ContentRange::Bytes(bytes_content_range);
+///
+/// let mut res = Response::new(StatusCode::RequestedRangeNotSatisfiable);
+/// content_range.apply(&mut res);
+///
+/// let content_range = ContentRange::from_headers(res)?.unwrap();
+/// if let ContentRange::Bytes(bytes_content_range) = content_range {
+///     assert_eq!(bytes_content_range.range(), None);
+///     assert_eq!(bytes_content_range.size(), Some(10));
+/// }
+/// #
+/// # Ok(()) }
+/// ```
+#[derive(Debug, Clone, Eq, PartialEq)]
+#[non_exhaustive]
+pub enum ContentRange {
+    /// Bytes based content range header.
+    Bytes(BytesContentRange),
+}
+
+impl ContentRange {
+    /// Create a new instance from a Content-Range headers.
+    ///
+    /// Only a single Content-Range per resource is assumed to exist. If multiple Range
+    /// headers are found the last one is used.
+    pub fn from_headers(headers: impl AsRef<Headers>) -> crate::Result<Option<Self>> {
+        let headers = match headers.as_ref().get(CONTENT_RANGE) {
+            Some(headers) => headers,
+            None => return Ok(None),
+        };
+
+        // If a header is returned we can assume at least one exists.
+        let s = headers.iter().last().unwrap().as_str();
+
+        Self::from_str(s).map(Some)
+    }
+
+    /// Create a ByteRanges from a string.
+    pub(crate) fn from_str(s: &str) -> crate::Result<Self> {
+        let fn_err = || {
+            Error::from_str(
+                StatusCode::RequestedRangeNotSatisfiable,
+                "Invalid Content-Range value",
+            )
+        };
+
+        match s {
+            s if s.starts_with(bytes::CONTENT_RANGE_PREFIX) => {
+                let s = &s[bytes::CONTENT_RANGE_PREFIX.len()..];
+                BytesContentRange::from_str(s).map(ContentRange::Bytes)
+            }
+            _ => Err(fn_err()),
+        }
+    }
+
+    /// Sets the `Range` header.
+    pub fn apply(&self, mut headers: impl AsMut<Headers>) {
+        headers.as_mut().insert(CONTENT_RANGE, self.value());
+    }
+
+    /// Get the `HeaderName`.
+    pub fn name(&self) -> HeaderName {
+        CONTENT_RANGE
+    }
+
+    /// Get the `HeaderValue`.
+    pub fn value(&self) -> HeaderValue {
+        let s = self.to_string();
+        // SAFETY: the internal string is validated to be ASCII.
+        unsafe { HeaderValue::from_bytes_unchecked(s.into()) }
+    }
+}
+
+impl Display for ContentRange {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match *self {
+            ContentRange::Bytes(ref bytes_content_range) => {
+                write!(f, "{}{}", bytes::CONTENT_RANGE_PREFIX, bytes_content_range)
+            }
+        }
+    }
+}
+
+impl ToHeaderValues for ContentRange {
+    type Iter = option::IntoIter<HeaderValue>;
+    fn to_header_values(&self) -> crate::Result<Self::Iter> {
+        // A HeaderValue will always convert into itself.
+        Ok(self.value().to_header_values().unwrap())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use crate::headers::CONTENT_RANGE;
+    use crate::range::BytesRange;
+    use crate::{Response, StatusCode};
+
+    #[test]
+    fn bytes_content_range() -> crate::Result<()> {
+        let mut res = Response::new(StatusCode::PartialContent);
+        res.insert_header(CONTENT_RANGE, "bytes 1-5/100");
+        let content_range = ContentRange::from_headers(res)?.unwrap();
+
+        match content_range {
+            ContentRange::Bytes(bytes_content_range) => {
+                assert_eq!(bytes_content_range.range(), Some(BytesRange::new(1, 5)));
+                assert_eq!(bytes_content_range.size(), Some(100));
+            }
+        }
+
+        Ok(())
+    }
+
+    #[test]
+    fn bytes_content_range_apply() -> crate::Result<()> {
+        let bytes_content_range = BytesContentRange::new().with_range(1, 5).with_size(10);
+        let content_range = ContentRange::Bytes(bytes_content_range);
+        let mut res = Response::new(StatusCode::PartialContent);
+        content_range.apply(&mut res);
+        assert_eq!(res[CONTENT_RANGE], "bytes 1-5/10");
+        Ok(())
+    }
+
+    #[test]
+    fn invalid_unit() {
+        let mut res = Response::new(StatusCode::PartialContent);
+        res.insert_header(CONTENT_RANGE, "foo 1-5/*");
+        let err = ContentRange::from_headers(res).unwrap_err();
+        assert_eq!(err.status(), StatusCode::RequestedRangeNotSatisfiable);
+    }
+}

--- a/src/range/mod.rs
+++ b/src/range/mod.rs
@@ -1,0 +1,27 @@
+//! HTTP range requests.
+//!
+//! This submodule includes headers and types to handle HTTP range requests.
+//! This allows to address use cases such resuming an interrupted download
+//! or downloading a subpart of a large document like a video.
+//!
+//! The implementation so far is limited to bytes ranges. The specification
+//! allows for other types but does not specify any. Range requests using
+//! a custom type will have to be processed *manually*, parsing the various
+//! headers `Range`, `If-Range`, `Content-Range` ... with the custom type
+//! specification.
+//!
+//! # Further reading
+//!
+//! - [MDN: HTTP Range Requests](https://developer.mozilla.org/en-US/docs/Web/HTTP/Range_requests)
+//! - [IETF: HTTP Range Requests](https://tools.ietf.org/html/rfc7233)
+
+mod accept_ranges;
+mod bytes;
+mod content_range;
+#[allow(clippy::module_inception)]
+mod range;
+
+pub use accept_ranges::AcceptRanges;
+pub use bytes::{BytesContentRange, BytesRange, BytesRangeSet};
+pub use content_range::ContentRange;
+pub use range::Range;

--- a/src/range/range.rs
+++ b/src/range/range.rs
@@ -1,0 +1,162 @@
+use crate::headers::{HeaderName, HeaderValue, Headers, ToHeaderValues, RANGE};
+use crate::range::{bytes, BytesRangeSet};
+use crate::{Error, StatusCode};
+
+use std::fmt::{self, Debug, Display};
+use std::option;
+
+/// HTTP Range request header.
+///
+/// Range header in a GET request modifies the method
+/// semantics to request transfer of only one or more subranges of the
+/// selected representation data, rather than the entire selected
+/// representation data.
+///
+/// # Specifications
+///
+/// - [RFC 7233, section 3.1: Range](https://tools.ietf.org/html/rfc7233#section-3.1)
+/// - [RFC 7233, Appendix D: Collected ABNF](https://tools.ietf.org/html/rfc7233#appendix-D)
+/// - [IANA HTTP parameters, range-units: HTTP Range Unit Registry](https://www.iana.org/assignments/http-parameters/http-parameters.xhtml#range-units)
+///
+/// # Examples
+///
+/// Range header using bytes:
+///
+/// ```
+/// # fn main() -> http_types::Result<()> {
+/// #
+/// use http_types::range::{BytesRangeSet, Range};
+/// use http_types::{Method, Request, Url};
+///
+/// let mut byte_range_set = BytesRangeSet::new();
+/// byte_range_set.push(0, 500);
+///
+/// let range = Range::Bytes(byte_range_set.clone());
+/// let mut req = Request::new(Method::Get, Url::parse("http://example.com").unwrap());
+/// range.apply(&mut req);
+///
+/// let range = Range::from_headers(req)?.unwrap();
+/// assert_eq!(range, Range::Bytes(byte_range_set));
+/// #
+/// # Ok(()) }
+/// ```
+#[derive(Debug, Clone, Eq, PartialEq)]
+#[non_exhaustive]
+pub enum Range {
+    /// Bytes based range requests.
+    Bytes(BytesRangeSet),
+}
+
+impl Range {
+    /// Create a new instance from a Range headers.
+    ///
+    /// Only a single Range per resource is assumed to exist. If multiple Range
+    /// headers are found the last one is used.
+    pub fn from_headers(headers: impl AsRef<Headers>) -> crate::Result<Option<Self>> {
+        let headers = match headers.as_ref().get(RANGE) {
+            Some(headers) => headers,
+            None => return Ok(None),
+        };
+
+        // If a header is returned we can assume at least one exists.
+        let s = headers.iter().last().unwrap().as_str();
+
+        Self::from_str(s).map(Some)
+    }
+
+    /// Create a ByteRanges from a string.
+    pub(crate) fn from_str(s: &str) -> crate::Result<Self> {
+        let fn_err = || {
+            Error::from_str(
+                StatusCode::BadRequest,
+                "Invalid Range header for byte ranges",
+            )
+        };
+
+        match s {
+            s if s.starts_with(bytes::RANGE_PREFIX) => {
+                let s = &s[bytes::RANGE_PREFIX.len()..];
+                BytesRangeSet::from_str(s).map(Range::Bytes)
+            }
+            _ => Err(fn_err()),
+        }
+    }
+
+    /// Sets the `Range` header.
+    pub fn apply(&self, mut headers: impl AsMut<Headers>) {
+        headers.as_mut().insert(RANGE, self.value());
+    }
+
+    /// Get the `HeaderName`.
+    pub fn name(&self) -> HeaderName {
+        RANGE
+    }
+
+    /// Get the `HeaderValue`.
+    pub fn value(&self) -> HeaderValue {
+        let s = self.to_string();
+        // SAFETY: the internal string is validated to be ASCII.
+        unsafe { HeaderValue::from_bytes_unchecked(s.into()) }
+    }
+}
+
+impl Display for Range {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match *self {
+            Range::Bytes(ref bytes_range) => {
+                write!(f, "{}{}", bytes::RANGE_PREFIX, bytes_range)
+            }
+        }
+    }
+}
+
+impl ToHeaderValues for Range {
+    type Iter = option::IntoIter<HeaderValue>;
+    fn to_header_values(&self) -> crate::Result<Self::Iter> {
+        // A HeaderValue will always convert into itself.
+        Ok(self.value().to_header_values().unwrap())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::headers::RANGE;
+    use crate::range::{BytesRange, BytesRangeSet};
+    use crate::{Method, Request, Url};
+
+    #[test]
+    fn bytes_range() -> crate::Result<()> {
+        let mut req = Request::new(Method::Get, Url::parse("http://example.com").unwrap());
+        req.insert_header(RANGE, "bytes=1-5");
+        let range = Range::from_headers(req)?.unwrap();
+        match range {
+            Range::Bytes(bytes_range_set) => {
+                assert_eq!(bytes_range_set.len(), 1);
+                assert_eq!(bytes_range_set.first(), Some(BytesRange::new(1, 5)));
+            }
+        }
+
+        Ok(())
+    }
+
+    #[test]
+    fn bytes_range_apply() -> crate::Result<()> {
+        let mut ranges = BytesRangeSet::new();
+        ranges.push(1, 5);
+        ranges.push(None, 5);
+        let range = Range::Bytes(ranges);
+        let mut req = Request::new(Method::Get, Url::parse("http://example.com").unwrap());
+        range.apply(&mut req);
+        assert_eq!(req[RANGE], "bytes=1-5,-5");
+        Ok(())
+    }
+
+    #[test]
+    fn invalid_unit() {
+        let mut req = Request::new(Method::Get, Url::parse("http://example.com").unwrap());
+        req.insert_header(RANGE, "foo=1-5");
+        let err = Range::from_headers(req).unwrap_err();
+        assert_eq!(err.status(), StatusCode::BadRequest);
+    }
+}


### PR DESCRIPTION
This introduce a new 'range' module
to support encoding, decoding and validation of HTTP range requests.

This could be a helper to implement http-rs/tide#63 and enhance tide's serve_dir with range requests.

This is also an experiment toward typed headers discussed in #99.

I am using a simple design where the typed header implements `TryFrom` and `ToHeaderValues`. This has the advantage to be fully compatible with the current header APIs. However I believe we could push Rust type system a little further.

For instance we could enhance the `Headers` type with a new method and trait: 

```rust
trait TypedHeader: ToHeaderValues {
    const HeaderName: &'static str;
}

impl Headers {
    // TODO: find a better name
    pub fn get_typed<T>(&self) -> Option<T>
    where
            T: TypedHeader,
    {
        // TODO: implementation
    }
}
```
One could then retrieve a typed value directly from the headers :

```rust
let range: Option<Range> = headers.get_typed();
```
I am not sure if it works, but I could add a few commits on this pull request if you want a try.

Thanks in advance for your comments !
Cheers.

  