### PR TITLE
use serde_qs for querystrings

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,6 +40,7 @@ serde_json = "1.0.51"
 serde = { version = "1.0.106", features = ["derive"] }
 serde_urlencoded = "0.6.1"
 rand = "0.7.3"
+serde_qs = "0.6.0"
 
 [dev-dependencies]
 http = "0.2.0"

--- a/tests/querystring.rs
+++ b/tests/querystring.rs
@@ -30,7 +30,10 @@ fn unsuccessfully_deserialize_query() {
 
     let params = req.query::<Params>();
     assert!(params.is_err());
-    assert_eq!(params.err().unwrap().to_string(), "missing field `msg`");
+    assert_eq!(
+        params.err().unwrap().to_string(),
+        "failed with reason: missing field `msg`"
+    );
 }
 
 #[test]
@@ -42,7 +45,10 @@ fn malformatted_query() {
 
     let params = req.query::<Params>();
     assert!(params.is_err());
-    assert_eq!(params.err().unwrap().to_string(), "missing field `msg`");
+    assert_eq!(
+        params.err().unwrap().to_string(),
+        "failed with reason: missing field `msg`"
+    );
 }
 
 #[test]


### PR DESCRIPTION
This resolves a regression in tide: http-rs/tide#605

although serde_urlencoded is sufficient for key=value queries, it does not support the full range of queries that serde_qs does