### PR TITLE
add Body::make_head and AsMut<Body> for Response

### DIFF
--- a/src/body.rs
+++ b/src/body.rs
@@ -405,6 +405,11 @@ impl Body {
         self.length.map(|length| length == 0)
     }
 
+    /// Transform the body into a HEAD body, which potentially has a length but no content
+    pub fn make_head(&mut self) {
+        self.reader = Box::new(io::empty());
+    }
+
     pub(crate) fn mime(&self) -> &Mime {
         &self.mime
     }
@@ -526,5 +531,14 @@ mod test {
         let body = Body::empty();
         let res = body.into_form::<Foo>().await;
         assert_eq!(res.unwrap_err().status(), 422);
+    }
+
+    #[async_std::test]
+    async fn make_head() {
+        let mut body = Body::from_string("hello".into());
+        body.make_head();
+
+        assert_eq!(body.len(), Some(5));
+        assert_eq!(body.into_string().await.unwrap(), "");
     }
 }

--- a/src/response.rs
+++ b/src/response.rs
@@ -722,6 +722,12 @@ impl AsMut<Headers> for Response {
     }
 }
 
+impl AsMut<Body> for Response {
+    fn as_mut(&mut self) -> &mut Body {
+        &mut self.body
+    }
+}
+
 impl From<()> for Response {
     fn from(_: ()) -> Self {
         Response::new(StatusCode::NoContent)


### PR DESCRIPTION
When responding to a HEAD request, body content should not be sent. Currently there is no way to retain the content length, but remove the actual content.

This PR:
* provides an affordance to strip out the content of the body but retain the content length.
* provides an `AsMut<Body>` for Response, which makes the use of make_head more convenient

I'm not happy with the name `make_head`, so please suggest improvements

refs: http-rs/tide#623
