### PR TITLE
Revert 174

### DIFF
--- a/src/response.rs
+++ b/src/response.rs
@@ -15,7 +15,7 @@ use crate::headers::{
 };
 use crate::mime::Mime;
 use crate::trailers::{self, Trailers};
-use crate::{Body, Error, Extensions, StatusCode, Version};
+use crate::{Body, Extensions, StatusCode, Version};
 
 cfg_unstable! {
     use crate::upgrade;
@@ -50,7 +50,6 @@ pin_project_lite::pin_project! {
         ext: Extensions,
         local_addr: Option<String>,
         peer_addr: Option<String>,
-        error: Option<Error>,
     }
 }
 
@@ -86,7 +85,6 @@ pin_project_lite::pin_project! {
         ext: Extensions,
         local_addr: Option<String>,
         peer_addr: Option<String>,
-        error: Option<Error>,
     }
 }
 
@@ -113,7 +111,6 @@ impl Response {
             ext: Extensions::new(),
             peer_addr: None,
             local_addr: None,
-            error: None,
         }
     }
 
@@ -143,7 +140,6 @@ impl Response {
             ext: Extensions::new(),
             peer_addr: None,
             local_addr: None,
-            error: None,
         }
     }
 
@@ -473,16 +469,6 @@ impl Response {
         self.body.is_empty()
     }
 
-    /// Returns an optional reference to the `Error` if the response was created from one, or else `None`.
-    pub fn error(&self) -> Option<&Error> {
-        self.error.as_ref()
-    }
-
-    /// Takes the `Error` from the response if one exists, replacing it with `None`.
-    pub fn take_error(&mut self) -> Option<Error> {
-        self.error.take()
-    }
-
     /// Get the HTTP version, if one has been set.
     ///
     /// # Examples
@@ -655,10 +641,8 @@ impl Response {
 }
 
 impl Clone for Response {
-    /// Clone the response, with some exceptions:
-    /// - The body is resolved to `Body::empty()`.
-    /// - Any attached extensions are not cloned.
-    /// - Any attached error is not cloned.
+    /// Clone the response, resolving the body to `Body::empty()` and removing
+    /// extensions.
     fn clone(&self) -> Self {
         Self {
             status: self.status,
@@ -677,7 +661,6 @@ impl Clone for Response {
             ext: Extensions::new(),
             peer_addr: self.peer_addr.clone(),
             local_addr: self.local_addr.clone(),
-            error: None,
         }
     }
 }
@@ -747,58 +730,6 @@ impl Index<&str> for Response {
     #[inline]
     fn index(&self, name: &str) -> &HeaderValues {
         self.headers.index(name)
-    }
-}
-
-#[cfg(not(feature = "unstable"))]
-impl From<Error> for Response {
-    /// Create a new response from an `http_types::Error`.
-    ///
-    /// This will store the error in the `Response`, allowing it to later be
-    /// checked via `Response::error()`.
-    fn from(error: Error) -> Self {
-        let (trailers_sender, trailers_receiver) = sync::channel(1);
-        Self {
-            status: error.status(),
-            headers: Headers::new(),
-            version: None,
-            body: Body::empty(),
-            trailers_sender: Some(trailers_sender),
-            trailers_receiver: Some(trailers_receiver),
-            has_trailers: false,
-            ext: Extensions::new(),
-            peer_addr: None,
-            local_addr: None,
-            error: Some(error),
-        }
-    }
-}
-
-#[cfg(feature = "unstable")]
-impl From<Error> for Response {
-    /// Create a new response from an `http_types::Error`.
-    ///
-    /// This will store the error in the `Response`, allowing it to later be
-    /// checked via `Response::error()`.
-    fn from(error: Error) -> Self {
-        let (trailers_sender, trailers_receiver) = sync::channel(1);
-        let (upgrade_sender, upgrade_receiver) = sync::channel(1);
-        Self {
-            status: error.status(),
-            headers: Headers::new(),
-            version: None,
-            body: Body::empty(),
-            trailers_sender: Some(trailers_sender),
-            trailers_receiver: Some(trailers_receiver),
-            has_trailers: false,
-            upgrade_sender: Some(upgrade_sender),
-            upgrade_receiver: Some(upgrade_receiver),
-            has_upgrade: false,
-            ext: Extensions::new(),
-            peer_addr: None,
-            local_addr: None,
-            error: Some(error),
-        }
     }
 }
 

--- a/src/response.rs
+++ b/src/response.rs
@@ -483,11 +483,6 @@ impl Response {
         self.error.take()
     }
 
-    /// Sets an `Error` on the response, accessible via `error()` and `take_error()`.
-    pub fn set_error(&mut self, error: Error) {
-        self.error = Some(error);
-    }
-
     /// Get the HTTP version, if one has been set.
     ///
     /// # Examples

--- a/tests/error.rs
+++ b/tests/error.rs
@@ -1,4 +1,4 @@
-use http_types::{bail, ensure, ensure_eq, Error, Response, StatusCode};
+use http_types::{bail, ensure, ensure_eq, Error, StatusCode};
 use std::io;
 
 #[test]
@@ -69,22 +69,4 @@ fn option_ext() {
 
     let err = res.unwrap_err();
     assert_eq!(err.status(), StatusCode::NotFound);
-}
-
-#[test]
-fn to_response() {
-    let msg = "This is an error";
-
-    let error = Error::from_str(StatusCode::NotFound, msg);
-    let mut res: Response = error.into();
-
-    assert!(res.error().is_some());
-    // Ensure we did not consume the error
-    assert!(res.error().is_some());
-
-    assert_eq!(res.error().unwrap().status(), StatusCode::NotFound);
-    assert_eq!(res.error().unwrap().to_string(), msg);
-
-    res.take_error();
-    assert!(res.error().is_none());
 }


### PR DESCRIPTION
On further thought I think the error storage should be kept entirely in tide (in https://github.com/http-rs/tide/pull/570).

This is because I am not sure this will actually work well for Surf. I suspect surf may be better served by having error hold an optional response, unlike tide. This is due to responses in Surf being incoming rather than outgoing, and it being the client rather than the listener.

Note: AFAIK this is currently safe to do as this feature has not been in a release yet.