### PR TITLE
add Body::from_reader_with_mime

### DIFF
--- a/src/body.rs
+++ b/src/body.rs
@@ -105,10 +105,35 @@ impl Body {
         reader: impl BufRead + Unpin + Send + Sync + 'static,
         len: Option<usize>,
     ) -> Self {
+        Self::from_reader_with_mime(reader, mime::BYTE_STREAM, len)
+    }
+
+    /// Create a `Body` from a reader with a mime type and optional length.
+    ///
+    /// If a `Body` has no length, HTTP implementations will often switch over to
+    /// framed messages such as [Chunked
+    /// Encoding](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Transfer-Encoding).
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use http_types::{Body, Response, StatusCode, mime};
+    /// use async_std::io::Cursor;
+    ///
+    /// let mut req = Response::new(StatusCode::Ok);
+    ///
+    /// let cursor = Cursor::new("<h1>Hello Nori</h1>");
+    /// req.set_body(Body::from_reader_with_mime(cursor, mime::HTML, None));
+    /// ```
+    pub fn from_reader_with_mime(
+        reader: impl BufRead + Unpin + Send + Sync + 'static,
+        mime: Mime,
+        length: Option<usize>,
+    ) -> Self {
         Self {
             reader: Box::new(reader),
-            mime: mime::BYTE_STREAM,
-            length: len,
+            mime,
+            length,
         }
     }
 


### PR DESCRIPTION
This allows external integrations to build a Body that includes a mime type, which is otherwise impossible. An alternative would be exposing a `Body::set_mime`