### PR TITLE
add Body::set_mime and make Body::mime public

### DIFF
--- a/src/body.rs
+++ b/src/body.rs
@@ -405,8 +405,14 @@ impl Body {
         self.length.map(|length| length == 0)
     }
 
-    pub(crate) fn mime(&self) -> &Mime {
+    /// Returns the mime type of this Body.
+    pub fn mime(&self) -> &Mime {
         &self.mime
+    }
+
+    /// Sets the mime type of this Body.
+    pub fn set_mime(&mut self, mime: impl Into<Mime>) {
+        self.mime = mime.into();
     }
 }
 


### PR DESCRIPTION
This is instead of #198, and facilitates the creation of bodies from external libraries. A tide-askama integration pr (for templating) is blocked on merging and releasing this