### PR TITLE
satisfy new clippy: "match expression looks like `matches!` macro"

### DIFF
--- a/src/method.rs
+++ b/src/method.rs
@@ -43,10 +43,10 @@ impl Method {
     ///
     /// See [the spec](https://tools.ietf.org/html/rfc7231#section-4.2.1) for more details.
     pub fn is_safe(&self) -> bool {
-        match self {
-            Method::Get | Method::Head | Method::Options | Method::Trace => true,
-            _ => false,
-        }
+        matches!(
+            self,
+            Method::Get | Method::Head | Method::Options | Method::Trace
+        )
     }
 }
 

--- a/src/mime/parse.rs
+++ b/src/mime/parse.rs
@@ -119,7 +119,7 @@ pub(crate) fn parse(input: &str) -> crate::Result<Mime> {
 
 /// Validates [HTTP token code points](https://mimesniff.spec.whatwg.org/#http-token-code-point)
 fn is_http_token_code_point(c: char) -> bool {
-    match c {
+    matches!(c,
         '!'
         | '#'
         | '$'
@@ -137,25 +137,17 @@ fn is_http_token_code_point(c: char) -> bool {
         | '~'
         | 'a'..='z'
         | 'A'..='Z'
-        | '0'..='9' => true,
-        _ => false,
-    }
+        | '0'..='9')
 }
 
 /// Validates [HTTP quoted-string token code points](https://mimesniff.spec.whatwg.org/#http-quoted-string-token-code-point)
 fn is_http_quoted_string_token_code_point(c: char) -> bool {
-    match c {
-        '\t' | ' '..='~' | '\u{80}'..='\u{FF}' => true,
-        _ => false,
-    }
+    matches!(c, '\t' | ' '..='~' | '\u{80}'..='\u{FF}')
 }
 
 /// Is a [HTTP whitespace](https://fetch.spec.whatwg.org/#http-whitespace)
 fn is_http_whitespace_char(c: char) -> bool {
-    match c {
-        '\n' | '\r' | '\t' | ' ' => true,
-        _ => false,
-    }
+    matches!(c, '\n' | '\r' | '\t' | ' ')
 }
 
 /// [code point sequence collection](https://infra.spec.whatwg.org/#collect-a-sequence-of-code-points)


### PR DESCRIPTION
#201 failed for reasons that had nothing to do with the pr, so that fix is here. i like this clippy, `matches!(item, pattern)` is better than `match item { pattern => true, _ => false }`