### PR TITLE
add support for anyhow::Error into http_types::Error

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -23,13 +23,10 @@ impl Error {
     /// The error type must be threadsafe and 'static, so that the Error will be
     /// as well. If the error type does not provide a backtrace, a backtrace will
     /// be created here to ensure that a backtrace exists.
-    pub fn new<E>(status: StatusCode, error: E) -> Self
-    where
-        E: StdError + Send + Sync + 'static,
-    {
+    pub fn new(status: StatusCode, error: impl Into<anyhow::Error>) -> Self {
         Self {
             status,
-            error: anyhow::Error::new(error),
+            error: error.into(),
         }
     }
 
@@ -119,15 +116,9 @@ impl Debug for Error {
     }
 }
 
-impl<E> From<E> for Error
-where
-    E: StdError + Send + Sync + 'static,
-{
+impl<E: Into<anyhow::Error>> From<E> for Error {
     fn from(error: E) -> Self {
-        Self {
-            error: anyhow::Error::new(error),
-            status: StatusCode::InternalServerError,
-        }
+        Self::new(StatusCode::InternalServerError, error)
     }
 }
 

--- a/tests/error.rs
+++ b/tests/error.rs
@@ -70,3 +70,29 @@ fn option_ext() {
     let err = res.unwrap_err();
     assert_eq!(err.status(), StatusCode::NotFound);
 }
+
+#[test]
+fn anyhow_error_into_http_types_error() {
+    let anyhow_error =
+        anyhow::Error::new(std::io::Error::new(std::io::ErrorKind::Other, "irrelevant"));
+    let http_types_error: Error = anyhow_error.into();
+    assert_eq!(http_types_error.status(), StatusCode::InternalServerError);
+
+    let anyhow_error =
+        anyhow::Error::new(std::io::Error::new(std::io::ErrorKind::Other, "irrelevant"));
+    let http_types_error: Error = Error::new(StatusCode::ImATeapot, anyhow_error);
+    assert_eq!(http_types_error.status(), StatusCode::ImATeapot);
+}
+
+#[test]
+fn normal_error_into_http_types_error() {
+    let http_types_error: Error =
+        std::io::Error::new(std::io::ErrorKind::Other, "irrelevant").into();
+    assert_eq!(http_types_error.status(), StatusCode::InternalServerError);
+
+    let http_types_error = Error::new(
+        StatusCode::ImATeapot,
+        std::io::Error::new(std::io::ErrorKind::Other, "irrelevant"),
+    );
+    assert_eq!(http_types_error.status(), StatusCode::ImATeapot);
+}


### PR DESCRIPTION
currently there is no way to convert an anyhow::Error into a http_types::Error because anyhow::Error is not std::error::Error. Instead of propagating the bounds from anyhow's conversion, this pr says "if you can turn it into an anyhow error, you can turn it into an http types error"