### PR TITLE
Track type name on error before losing that info

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -16,7 +16,7 @@ pub type Result<T> = std::result::Result<T, Error>;
 pub struct Error {
     error: anyhow::Error,
     status: crate::StatusCode,
-    type_name: Option<String>,
+    type_name: Option<&'static str>,
 }
 
 impl Error {
@@ -36,7 +36,7 @@ impl Error {
                 .try_into()
                 .expect("Could not convert into a valid `StatusCode`"),
             error: error.into(),
-            type_name: Some(std::any::type_name::<E>().to_string()),
+            type_name: Some(std::any::type_name::<E>()),
         }
     }
 


### PR DESCRIPTION
If this turns out to have meaningful performance implications, we could feature flag this or just do it conditionally when debug_assertions are on.

This combines well with #212 to allow for this sort of development-mode error handler in tide:
![image](https://user-images.githubusercontent.com/13301/89442791-4377ff00-d704-11ea-9ff6-107734ba3cc7.png)
