### PR TITLE
Make statuscode from u16 in error

### DIFF
--- a/tests/error.rs
+++ b/tests/error.rs
@@ -96,3 +96,31 @@ fn normal_error_into_http_types_error() {
     );
     assert_eq!(http_types_error.status(), StatusCode::ImATeapot);
 }
+
+#[test]
+fn u16_into_status_code_in_http_types_error() {
+    let http_types_error = Error::new(404, io::Error::new(io::ErrorKind::Other, "Not Found"));
+    let http_types_error2 = Error::new(
+        StatusCode::NotFound,
+        io::Error::new(io::ErrorKind::Other, "Not Found"),
+    );
+    assert_eq!(http_types_error.status(), http_types_error2.status());
+
+    let http_types_error = Error::from_str(404, "Not Found");
+    assert_eq!(http_types_error.status(), StatusCode::NotFound);
+}
+
+#[test]
+#[should_panic]
+fn fail_test_u16_into_status_code_in_http_types_error_new() {
+    let _http_types_error = Error::new(
+        1000,
+        io::Error::new(io::ErrorKind::Other, "Un Existed Status Code"),
+    );
+}
+
+#[test]
+#[should_panic]
+fn fail_test_u16_into_status_code_in_http_types_error_from_str() {
+    let _http_types_error = Error::from_str(1000, "Un Existed");
+}

--- a/tests/error.rs
+++ b/tests/error.rs
@@ -115,12 +115,12 @@ fn u16_into_status_code_in_http_types_error() {
 fn fail_test_u16_into_status_code_in_http_types_error_new() {
     let _http_types_error = Error::new(
         1000,
-        io::Error::new(io::ErrorKind::Other, "Un Existed Status Code"),
+        io::Error::new(io::ErrorKind::Other, "Incorrect status code"),
     );
 }
 
 #[test]
 #[should_panic]
 fn fail_test_u16_into_status_code_in_http_types_error_from_str() {
-    let _http_types_error = Error::from_str(1000, "Un Existed");
+    let _http_types_error = Error::from_str(1000, "Incorrect status code");
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Enable `http-types::Error::new(u16, Error)`, `http-types::Error::from_str(u16, &str)`

## Description
<!--- Describe your changes in detail -->
Change `Error::new(StatusCode, impl Into<anyhow::Error>)` to `Error::new(impl TryInto<StatusCode>, impl Into<anyhow::Error>)`.

Maybe, new tests I added are needless.
Before this pull request merge, please tell me. I`ll remove them.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
A Part of [tide#649](https://github.com/http-rs/tide/issues/649)

This enable `Error::new(u16, error) like Response::new(u16)`.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Add tests.
But, maybe these tests are needless after marge.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [CONTRIBUTING](https://github.com/rustasync/tide/blob/master/.github/CONTRIBUTING.md) document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.