### PR TITLE
add forwarded header

### DIFF
--- a/src/headers/constants.rs
+++ b/src/headers/constants.rs
@@ -93,6 +93,9 @@ pub const EXPECT: HeaderName = HeaderName::from_lowercase_str("expect");
 ///  The `Expires` Header
 pub const EXPIRES: HeaderName = HeaderName::from_lowercase_str("expires");
 
+/// The `Forwarded` Header
+pub const FORWARDED: HeaderName = HeaderName::from_lowercase_str("forwarded");
+
 ///  The `From` Header
 pub const FROM: HeaderName = HeaderName::from_lowercase_str("from");
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -121,12 +121,14 @@ pub mod cache;
 pub mod conditional;
 pub mod headers;
 pub mod mime;
+pub mod proxies;
 
 mod body;
 mod error;
 mod extensions;
 mod macros;
 mod method;
+mod parse_utils;
 mod request;
 mod response;
 mod status;

--- a/src/parse_utils.rs
+++ b/src/parse_utils.rs
@@ -1,0 +1,172 @@
+use std::borrow::Cow;
+
+/// https://tools.ietf.org/html/rfc7230#section-3.2.6
+pub(crate) fn parse_token(input: &str) -> (Option<&str>, &str) {
+    let mut end_of_token = 0;
+    for (i, c) in input.char_indices() {
+        if tchar(c) {
+            end_of_token = i;
+        } else {
+            break;
+        }
+    }
+
+    if end_of_token == 0 {
+        (None, input)
+    } else {
+        (Some(&input[..end_of_token + 1]), &input[end_of_token + 1..])
+    }
+}
+
+/// https://tools.ietf.org/html/rfc7230#section-3.2.6
+fn tchar(c: char) -> bool {
+    matches!(
+        c, 'a'..='z'
+            | 'A'..='Z'
+            | '0'..='9'
+            | '!'
+            | '#'
+            | '$'
+            | '%'
+            | '&'
+            | '\''
+            | '*'
+            | '+'
+            | '-'
+            | '.'
+            | '^'
+            | '_'
+            | '`'
+            | '|'
+            | '~'
+    )
+}
+
+/// https://tools.ietf.org/html/rfc7230#section-3.2.6
+fn vchar(c: char) -> bool {
+    matches!(c as u8, b'\t' | 32..=126 | 128..=255)
+}
+
+/// https://tools.ietf.org/html/rfc7230#section-3.2.6
+pub(crate) fn parse_quoted_string(input: &str) -> (Option<Cow<'_, str>>, &str) {
+    // quoted-string must start with a DQUOTE
+    if !input.starts_with('"') {
+        return (None, input);
+    }
+
+    let mut end_of_string = None;
+    let mut backslashes: Vec<usize> = vec![];
+
+    for (i, c) in input.char_indices().skip(1) {
+        if i > 1 && backslashes.last() == Some(&(i - 2)) {
+            if !vchar(c) {
+                // only VCHARs can be escaped
+                return (None, input);
+            }
+        // otherwise, we skip over this character while parsing
+        } else {
+            match c as u8 {
+                // we have reached a quoted-pair
+                b'\\' => {
+                    backslashes.push(i - 1);
+                }
+
+                // end of the string, DQUOTE
+                b'"' => {
+                    end_of_string = Some(i + 1);
+                    break;
+                }
+
+                // qdtext
+                b'\t' | b' ' | 15 | 35..=91 | 93..=126 | 128..=255 => {}
+
+                // unexpected character, bail
+                _ => return (None, input),
+            }
+        }
+    }
+
+    if let Some(end_of_string) = end_of_string {
+        let value = &input[1..end_of_string - 1]; // strip DQUOTEs from start and end
+
+        let value = if backslashes.is_empty() {
+            // no backslashes means we don't need to allocate
+            value.into()
+        } else {
+            backslashes.reverse(); // so that we can use pop. goes from low-to-high to high-to-low sorting
+
+            value
+                .char_indices()
+                .filter_map(|(i, c)| {
+                    if Some(&i) == backslashes.last() {
+                        // they're already sorted highest to lowest, so we only need to check the last one
+                        backslashes.pop();
+                        None // remove the backslash from the output
+                    } else {
+                        Some(c)
+                    }
+                })
+                .collect::<String>()
+                .into()
+        };
+
+        (Some(value), &input[end_of_string..])
+    } else {
+        // we never reached a closing DQUOTE, so we do not have a valid quoted-string
+        (None, input)
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    #[test]
+    fn token_successful_parses() {
+        assert_eq!(parse_token("key=value"), (Some("key"), "=value"));
+        assert_eq!(parse_token("KEY=value"), (Some("KEY"), "=value"));
+        assert_eq!(parse_token("0123)=value"), (Some("0123"), ")=value"));
+
+        assert_eq!(
+            parse_token("!#$%&'*+-.^_`|~=value"),
+            (Some("!#$%&'*+-.^_`|~"), "=value",)
+        );
+    }
+
+    #[test]
+    fn token_unsuccessful_parses() {
+        assert_eq!(parse_token(""), (None, ""));
+        assert_eq!(parse_token("=value"), (None, "=value"));
+        for c in r#"(),/:;<=>?@[\]{}"#.chars() {
+            let s = c.to_string();
+            assert_eq!(parse_token(&s), (None, &*s));
+
+            let s = format!("match{}rest", s);
+            assert_eq!(parse_token(&s), (Some("match"), &*format!("{}rest", c)));
+        }
+    }
+
+    #[test]
+    fn qstring_successful_parses() {
+        assert_eq!(
+            parse_quoted_string(r#""key"=value"#),
+            (Some(Cow::Borrowed("key")), "=value")
+        );
+
+        assert_eq!(
+            parse_quoted_string(r#""escaped \" quote \""rest"#),
+            (
+                Some(Cow::Owned(String::from(r#"escaped " quote ""#))),
+                r#"rest"#
+            )
+        );
+    }
+
+    #[test]
+    fn qstring_unsuccessful_parses() {
+        assert_eq!(parse_quoted_string(r#""abc"#), (None, "\"abc"));
+        assert_eq!(parse_quoted_string(r#"hello""#), (None, "hello\"",));
+        assert_eq!(parse_quoted_string(r#"=value\"#), (None, "=value\\"));
+        assert_eq!(parse_quoted_string(r#"\""#), (None, r#"\""#));
+        assert_eq!(parse_quoted_string(r#""\""#), (None, r#""\""#));
+    }
+}

--- a/src/proxies/forwarded.rs
+++ b/src/proxies/forwarded.rs
@@ -257,7 +257,7 @@ impl<'a> Forwarded<'a> {
         Ok(rest)
     }
 
-    /// Transform a borrowed Forwarded into an owned ('static)
+    /// Transform a borrowed Forwarded into an owned
     /// Forwarded. This is a noop if the Forwarded is already owned.
     pub fn into_owned(self) -> Forwarded<'static> {
         Forwarded {

--- a/src/proxies/forwarded.rs
+++ b/src/proxies/forwarded.rs
@@ -21,8 +21,8 @@ pub struct Forwarded<'a> {
 
 impl<'a> Forwarded<'a> {
     /// Attempts to parse a Forwarded from headers (or a request or
-    /// response). Builds a reference by default. To
-    /// build a Forwarded with a 'static lifetime, use
+    /// response). Builds a borrowed Forwarded by default. To build an
+    /// owned Forwarded, use
     /// `Forwarded::from_headers(...).into_owned()`
     ///
     /// # X-Forwarded-For, -By, and -Proto compatability
@@ -42,25 +42,29 @@ impl<'a> Forwarded<'a> {
     ///
     /// # Examples
     /// ```rust
-    /// # use http_types::{proxies::Forwarded, Method::Get, Request, Url};
-    /// let mut request = Request::new(Get, Url::parse("http://_/").unwrap());
+    /// # use http_types::{proxies::Forwarded, Method::Get, Request, Url, Result};
+    /// # fn main() -> Result<()> {
+    /// let mut request = Request::new(Get, Url::parse("http://_/")?);
     /// request.insert_header(
     ///     "Forwarded",
     ///     r#"for=192.0.2.43, for="[2001:db8:cafe::17]", for=unknown;proto=https"#
     /// );
-    /// let forwarded = Forwarded::from_headers(&request).unwrap().unwrap();
+    /// let forwarded = Forwarded::from_headers(&request)?.unwrap();
     /// assert_eq!(forwarded.proto(), Some("https"));
     /// assert_eq!(forwarded.forwarded_for(), vec!["192.0.2.43", "[2001:db8:cafe::17]", "unknown"]);
+    /// # Ok(()) }
     /// ```
     ///
     /// ```rust
-    /// # use http_types::{proxies::Forwarded, Method::Get, Request, Url};
-    /// let mut request = Request::new(Get, Url::parse("http://_/").unwrap());
+    /// # use http_types::{proxies::Forwarded, Method::Get, Request, Url, Result};
+    /// # fn main() -> Result<()> {
+    /// let mut request = Request::new(Get, Url::parse("http://_/")?);
     /// request.insert_header("X-Forwarded-For", "192.0.2.43, 2001:db8:cafe::17");
     /// request.insert_header("X-Forwarded-Proto", "https");
-    /// let forwarded = Forwarded::from_headers(&request).unwrap().unwrap();
+    /// let forwarded = Forwarded::from_headers(&request)?.unwrap();
     /// assert_eq!(forwarded.forwarded_for(), vec!["192.0.2.43", "[2001:db8:cafe::17]"]);
     /// assert_eq!(forwarded.proto(), Some("https"));
+    /// # Ok(()) }
     /// ```
 
     pub fn from_headers(headers: &'a impl AsRef<Headers>) -> Result<Option<Self>, ParseError> {
@@ -75,21 +79,25 @@ impl<'a> Forwarded<'a> {
     ///
     /// # Examples
     /// ```rust
-    /// # use http_types::{proxies::Forwarded, Method::Get, Request, Url};
-    /// let mut request = Request::new(Get, Url::parse("http://_/").unwrap());
+    /// # use http_types::{proxies::Forwarded, Method::Get, Request, Url, Result};
+    /// # fn main() -> Result<()> {
+    /// let mut request = Request::new(Get, Url::parse("http://_/")?);
     /// request.insert_header(
     ///     "Forwarded",
     ///     r#"for=192.0.2.43, for="[2001:db8:cafe::17]", for=unknown;proto=https"#
     /// );
-    /// let forwarded = Forwarded::from_forwarded_header(&request).unwrap().unwrap();
+    /// let forwarded = Forwarded::from_forwarded_header(&request)?.unwrap();
     /// assert_eq!(forwarded.proto(), Some("https"));
     /// assert_eq!(forwarded.forwarded_for(), vec!["192.0.2.43", "[2001:db8:cafe::17]", "unknown"]);
+    /// # Ok(()) }
     /// ```
     /// ```rust
-    /// # use http_types::{proxies::Forwarded, Method::Get, Request, Url};
-    /// let mut request = Request::new(Get, Url::parse("http://_/").unwrap());
+    /// # use http_types::{proxies::Forwarded, Method::Get, Request, Url, Result};
+    /// # fn main() -> Result<()> {
+    /// let mut request = Request::new(Get, Url::parse("http://_/")?);
     /// request.insert_header("X-Forwarded-For", "192.0.2.43, 2001:db8:cafe::17");
-    /// assert!(Forwarded::from_forwarded_header(&request).unwrap().is_none())
+    /// assert!(Forwarded::from_forwarded_header(&request)?.is_none());
+    /// # Ok(()) }
     /// ```
     pub fn from_forwarded_header(
         headers: &'a impl AsRef<Headers>,
@@ -107,20 +115,24 @@ impl<'a> Forwarded<'a> {
     ///
     /// # Examples
     /// ```rust
-    /// # use http_types::{proxies::Forwarded, Method::Get, Request, Url};
-    /// let mut request = Request::new(Get, Url::parse("http://_/").unwrap());
+    /// # use http_types::{proxies::Forwarded, Method::Get, Request, Url, Result};
+    /// # fn main() -> Result<()> {
+    /// let mut request = Request::new(Get, Url::parse("http://_/")?);
     /// request.insert_header("X-Forwarded-For", "192.0.2.43, 2001:db8:cafe::17");
-    /// let forwarded = Forwarded::from_headers(&request).unwrap().unwrap();
+    /// let forwarded = Forwarded::from_headers(&request)?.unwrap();
     /// assert_eq!(forwarded.forwarded_for(), vec!["192.0.2.43", "[2001:db8:cafe::17]"]);
+    /// # Ok(()) }
     /// ```
     /// ```rust
-    /// # use http_types::{proxies::Forwarded, Method::Get, Request, Url};
-    /// let mut request = Request::new(Get, Url::parse("http://_/").unwrap());
+    /// # use http_types::{proxies::Forwarded, Method::Get, Request, Url, Result};
+    /// # fn main() -> Result<()> {
+    /// let mut request = Request::new(Get, Url::parse("http://_/")?);
     /// request.insert_header(
     ///     "Forwarded",
     ///     r#"for=192.0.2.43, for="[2001:db8:cafe::17]", for=unknown;proto=https"#
     /// );
-    /// assert!(Forwarded::from_x_headers(&request).unwrap().is_none());
+    /// assert!(Forwarded::from_x_headers(&request)?.is_none());
+    /// # Ok(()) }
     /// ```
     pub fn from_x_headers(headers: &'a impl AsRef<Headers>) -> Result<Option<Self>, ParseError> {
         let headers = headers.as_ref();
@@ -456,52 +468,41 @@ impl<'a> TryFrom<&'a str> for Forwarded<'a> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{Method::Get, Request, Response};
+    use crate::{Method::Get, Request, Response, Result};
     use url::Url;
 
     #[test]
-    fn parsing_for() -> crate::Result<()> {
+    fn parsing_for() -> Result<()> {
         assert_eq!(
-            Forwarded::parse(r#"for="_gazonk""#)
-                .unwrap()
-                .forwarded_for(),
+            Forwarded::parse(r#"for="_gazonk""#)?.forwarded_for(),
             vec!["_gazonk"]
         );
         assert_eq!(
-            Forwarded::parse(r#"For="[2001:db8:cafe::17]:4711""#)
-                .unwrap()
-                .forwarded_for(),
+            Forwarded::parse(r#"For="[2001:db8:cafe::17]:4711""#)?.forwarded_for(),
             vec!["[2001:db8:cafe::17]:4711"]
         );
 
         assert_eq!(
-            Forwarded::parse("for=192.0.2.60;proto=http;by=203.0.113.43")
-                .unwrap()
-                .forwarded_for(),
+            Forwarded::parse("for=192.0.2.60;proto=http;by=203.0.113.43")?.forwarded_for(),
             vec!["192.0.2.60"]
         );
 
         assert_eq!(
-            Forwarded::parse("for=192.0.2.43,   for=198.51.100.17")
-                .unwrap()
-                .forwarded_for(),
+            Forwarded::parse("for=192.0.2.43,   for=198.51.100.17")?.forwarded_for(),
             vec!["192.0.2.43", "198.51.100.17"]
         );
 
         assert_eq!(
-            Forwarded::parse(r#"for=192.0.2.43,for="[2001:db8:cafe::17]",for=unknown"#)
-                .unwrap()
+            Forwarded::parse(r#"for=192.0.2.43,for="[2001:db8:cafe::17]",for=unknown"#)?
                 .forwarded_for(),
-            Forwarded::parse(r#"for=192.0.2.43, for="[2001:db8:cafe::17]", for=unknown"#)
-                .unwrap()
+            Forwarded::parse(r#"for=192.0.2.43, for="[2001:db8:cafe::17]", for=unknown"#)?
                 .forwarded_for()
         );
 
         assert_eq!(
             Forwarded::parse(
                 r#"for=192.0.2.43,for="this is a valid quoted-string, \" \\",for=unknown"#
-            )
-            .unwrap()
+            )?
             .forwarded_for(),
             vec![
                 "192.0.2.43",
@@ -514,25 +515,19 @@ mod tests {
     }
 
     #[test]
-    fn formatting_for() -> crate::Result<()> {
-        assert_eq!("", Forwarded::new().to_string());
-        Ok(())
-    }
-
-    #[test]
-    fn basic_parse() {
-        let forwarded =
-            Forwarded::parse("for=client.com;by=proxy.com;host=host.com;proto=https").unwrap();
+    fn basic_parse() -> Result<()> {
+        let forwarded = Forwarded::parse("for=client.com;by=proxy.com;host=host.com;proto=https")?;
 
         assert_eq!(forwarded.by(), Some("proxy.com"));
         assert_eq!(forwarded.forwarded_for(), vec!["client.com"]);
         assert_eq!(forwarded.host(), Some("host.com"));
         assert_eq!(forwarded.proto(), Some("https"));
         assert!(matches!(forwarded, Forwarded{..}));
+        Ok(())
     }
 
     #[test]
-    fn bad_parse() {
+    fn bad_parse() -> Result<()> {
         let err = Forwarded::parse("by=proxy.com;for=client;host=example.com;host").unwrap_err();
         assert_eq!(
             err.to_string(),
@@ -562,10 +557,11 @@ mod tests {
             err.to_string(),
             "unable to parse forwarded header: for= without valid value"
         );
+        Ok(())
     }
 
     #[test]
-    fn bad_parse_from_headers() {
+    fn bad_parse_from_headers() -> Result<()> {
         let mut response = Response::new(200);
         response.append_header("forwarded", "uh oh");
         assert_eq!(
@@ -574,23 +570,25 @@ mod tests {
         );
 
         let response = Response::new(200);
-        assert!(Forwarded::from_headers(&response).unwrap().is_none());
+        assert!(Forwarded::from_headers(&response)?.is_none());
+        Ok(())
     }
 
     #[test]
-    fn from_x_headers() {
-        let mut request = Request::new(Get, Url::parse("http://_/").unwrap());
+    fn from_x_headers() -> Result<()> {
+        let mut request = Request::new(Get, Url::parse("http://_/")?);
         request.append_header(X_FORWARDED_FOR, "192.0.2.43, 2001:db8:cafe::17");
         request.append_header(X_FORWARDED_PROTO, "gopher");
-        let forwarded = Forwarded::from_headers(&request).unwrap().unwrap();
+        let forwarded = Forwarded::from_headers(&request)?.unwrap();
         assert_eq!(
             forwarded.to_string(),
             r#"for=192.0.2.43, for="[2001:db8:cafe::17]";proto=gopher"#
         );
+        Ok(())
     }
 
     #[test]
-    fn formatting_edge_cases() {
+    fn formatting_edge_cases() -> Result<()> {
         let forwarded = Forwarded::new()
             .with_for(r#"quote: " backslash: \"#.into())
             .with_for(";proto=https".into());
@@ -598,48 +596,50 @@ mod tests {
             forwarded.to_string(),
             r#"for="quote: \" backslash: \\", for=";proto=https""#
         );
+        Ok(())
     }
 
     #[test]
-    fn parse_edge_cases() {
+    fn parse_edge_cases() -> Result<()> {
         let forwarded =
-            Forwarded::parse(r#"for=";", for=",", for="\"", for=unquoted;by=";proto=https""#)
-                .unwrap();
+            Forwarded::parse(r#"for=";", for=",", for="\"", for=unquoted;by=";proto=https""#)?;
         assert_eq!(forwarded.forwarded_for(), vec![";", ",", "\"", "unquoted"]);
         assert_eq!(forwarded.by(), Some(";proto=https"));
         assert!(forwarded.proto().is_none());
 
-        let forwarded = Forwarded::parse("proto=https").unwrap();
+        let forwarded = Forwarded::parse("proto=https")?;
         assert_eq!(forwarded.proto(), Some("https"));
+        Ok(())
     }
 
     #[test]
-    fn owned_parse() {
-        let forwarded = Forwarded::parse("for=client;by=proxy.com;host=example.com;proto=https")
-            .unwrap()
-            .into_owned();
+    fn owned_parse() -> Result<()> {
+        let forwarded =
+            Forwarded::parse("for=client;by=proxy.com;host=example.com;proto=https")?.into_owned();
 
         assert_eq!(forwarded.by(), Some("proxy.com"));
         assert_eq!(forwarded.forwarded_for(), vec!["client"]);
         assert_eq!(forwarded.host(), Some("example.com"));
         assert_eq!(forwarded.proto(), Some("https"));
         assert!(matches!(forwarded, Forwarded{..}));
-    }
-
-    #[test]
-    fn from_request() -> crate::Result<()> {
-        let mut request = Request::new(Get, Url::parse("http://_/").unwrap());
-        request.append_header("Forwarded", "for=for");
-
-        let forwarded = Forwarded::from_headers(&request)?.unwrap();
-        assert_eq!(forwarded.forwarded_for(), vec!["for"]);
         Ok(())
     }
 
     #[test]
-    fn owned_can_outlive_request() -> crate::Result<()> {
+    fn from_request() -> Result<()> {
+        let mut request = Request::new(Get, Url::parse("http://_/")?);
+        request.append_header("Forwarded", "for=for");
+
+        let forwarded = Forwarded::from_headers(&request)?.unwrap();
+        assert_eq!(forwarded.forwarded_for(), vec!["for"]);
+
+        Ok(())
+    }
+
+    #[test]
+    fn owned_can_outlive_request() -> Result<()> {
         let forwarded = {
-            let mut request = Request::new(Get, Url::parse("http://_/").unwrap());
+            let mut request = Request::new(Get, Url::parse("http://_/")?);
             request.append_header("Forwarded", "for=for;by=by;host=host;proto=proto");
             Forwarded::from_headers(&request)?.unwrap().into_owned()
         };

--- a/src/proxies/forwarded.rs
+++ b/src/proxies/forwarded.rs
@@ -284,11 +284,35 @@ impl<'a> Forwarded<'a> {
     }
 
     /// Insert a header that represents this Forwarded.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// let mut response = http_types::Response::new(200);
+    /// http_types::proxies::Forwarded::new()
+    ///   .with_for(String::from("192.0.2.43"))
+    ///   .with_for(String::from("[2001:db8:cafe::17]"))
+    ///   .with_proto(String::from("https"))
+    ///   .apply(&mut response);
+    /// assert_eq!(response["Forwarded"], r#"for=192.0.2.43, for="[2001:db8:cafe::17]";proto=https"#);
+    /// ```
     pub fn apply(&self, mut headers: impl AsMut<Headers>) {
         headers.as_mut().insert(FORWARDED, self);
     }
 
     /// Builds a Forwarded header as a String.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// # fn main() -> http_types::Result<()> {
+    /// let forwarded = http_types::proxies::Forwarded::new()
+    ///   .with_for(String::from("_haproxy"))
+    ///   .with_for(String::from("[2001:db8:cafe::17]"))
+    ///   .with_proto(String::from("https"));
+    /// assert_eq!(forwarded.value()?, r#"for=_haproxy, for="[2001:db8:cafe::17]";proto=https"#);
+    /// # Ok(()) }
+    /// ```
     pub fn value(&self) -> Result<String, std::fmt::Error> {
         let mut buf = String::new();
         if let Some(by) = self.by() {

--- a/src/proxies/forwarded.rs
+++ b/src/proxies/forwarded.rs
@@ -64,7 +64,10 @@ impl<'a> Forwarded<'a> {
     /// let forwarded = Forwarded::from_headers(&request)?.unwrap();
     /// assert_eq!(forwarded.forwarded_for(), vec!["192.0.2.43", "[2001:db8:cafe::17]", "unknown"]);
     /// assert_eq!(forwarded.proto(), Some("https"));
-    /// assert_eq!(forwarded.value()?, r#"for=192.0.2.43, for="[2001:db8:cafe::17]", for=unknown;proto=https"#);
+    /// assert_eq!(
+    ///     forwarded.value()?,
+    ///     r#"for=192.0.2.43, for="[2001:db8:cafe::17]", for=unknown;proto=https"#
+    /// );
     /// # Ok(()) }
     /// ```
 
@@ -184,7 +187,10 @@ impl<'a> Forwarded<'a> {
     ///     r#"for=192.0.2.43,         for="[2001:db8:cafe::17]", FOR=unknown;proto=https"#
     /// )?;
     /// assert_eq!(forwarded.forwarded_for(), vec!["192.0.2.43", "[2001:db8:cafe::17]", "unknown"]);
-    /// assert_eq!(forwarded.value()?, r#"for=192.0.2.43, for="[2001:db8:cafe::17]", for=unknown;proto=https"#);
+    /// assert_eq!(
+    ///     forwarded.value()?,
+    ///     r#"for=192.0.2.43, for="[2001:db8:cafe::17]", for=unknown;proto=https"#
+    /// );
     /// # Ok(()) }
     /// ```
     pub fn parse(input: &'a str) -> Result<Self, ParseError> {

--- a/src/proxies/forwarded.rs
+++ b/src/proxies/forwarded.rs
@@ -244,20 +244,16 @@ impl<'a> Forwarded<'a> {
                     rest = rest[1..].trim_start();
                 }
 
-                Some(';') => {
-                    rest = &rest[1..];
-                    break;
-                }
+                // we have reached the end of the for= section
+                Some(';') => return Ok(&rest[1..]),
 
-                // reached the end of the for section or the input
-                None => break,
+                // reached the end of the input
+                None => return Ok(rest),
 
                 // bail
                 _ => return Err(ParseError::new("unexpected character after for= section")),
             }
         }
-
-        Ok(rest)
     }
 
     /// Transform a borrowed Forwarded into an owned

--- a/src/proxies/forwarded.rs
+++ b/src/proxies/forwarded.rs
@@ -1,0 +1,647 @@
+use crate::{
+    headers::{HeaderName, HeaderValue, Headers, ToHeaderValues, FORWARDED},
+    parse_utils::{parse_quoted_string, parse_token},
+};
+use std::{borrow::Cow, convert::TryFrom, fmt::Write, net::IpAddr};
+
+// these constants are private because they are nonstandard
+const X_FORWARDED_FOR: HeaderName = HeaderName::from_lowercase_str("x-forwarded-for");
+const X_FORWARDED_PROTO: HeaderName = HeaderName::from_lowercase_str("x-forwarded-proto");
+const X_FORWARDED_BY: HeaderName = HeaderName::from_lowercase_str("x-forwarded-by");
+
+/// A rust representation of the [forwarded
+/// header](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Forwarded).
+#[derive(Debug, Clone, Default)]
+pub struct Forwarded<'a> {
+    by: Option<Cow<'a, str>>,
+    forwarded_for: Vec<Cow<'a, str>>,
+    host: Option<Cow<'a, str>>,
+    proto: Option<Cow<'a, str>>,
+}
+
+impl<'a> Forwarded<'a> {
+    /// Attempts to parse a Forwarded from headers (or a request or
+    /// response). Builds a reference by default. To
+    /// build a Forwarded with a 'static lifetime, use
+    /// `Forwarded::from_headers(...).into_owned()`
+    ///
+    /// # X-Forwarded-For, -By, and -Proto compatability
+    ///
+    /// This implementation includes fall-back support for the
+    /// historical unstandardized headers x-forwarded-for,
+    /// x-forwarded-by, and x-forwarded-proto. If you do not wish to
+    /// support these headers, use
+    /// [`Forwarded::from_forwarded_header`]. To _only_ support these
+    /// historical headers and _not_ the standardized Forwarded
+    /// header, use [`Forwarded::from_x_headers`].
+    ///
+    /// Please note that either way, this implementation will
+    /// normalize to the standardized Forwarded header, as recommended
+    /// in
+    /// [rfc7239§7.4](https://tools.ietf.org/html/rfc7239#section-7.4)
+    ///
+    /// # Examples
+    /// ```rust
+    /// # use http_types::{proxies::Forwarded, Method::Get, Request, Url};
+    /// let mut request = Request::new(Get, Url::parse("http://_/").unwrap());
+    /// request.insert_header(
+    ///     "Forwarded",
+    ///     r#"for=192.0.2.43, for="[2001:db8:cafe::17]", for=unknown;proto=https"#
+    /// );
+    /// let forwarded = Forwarded::from_headers(&request).unwrap().unwrap();
+    /// assert_eq!(forwarded.proto(), Some("https"));
+    /// assert_eq!(forwarded.forwarded_for(), vec!["192.0.2.43", "[2001:db8:cafe::17]", "unknown"]);
+    /// ```
+    ///
+    /// ```rust
+    /// # use http_types::{proxies::Forwarded, Method::Get, Request, Url};
+    /// let mut request = Request::new(Get, Url::parse("http://_/").unwrap());
+    /// request.insert_header("X-Forwarded-For", "192.0.2.43, 2001:db8:cafe::17");
+    /// request.insert_header("X-Forwarded-Proto", "https");
+    /// let forwarded = Forwarded::from_headers(&request).unwrap().unwrap();
+    /// assert_eq!(forwarded.forwarded_for(), vec!["192.0.2.43", "[2001:db8:cafe::17]"]);
+    /// assert_eq!(forwarded.proto(), Some("https"));
+    /// ```
+
+    pub fn from_headers(headers: &'a impl AsRef<Headers>) -> Result<Option<Self>, ParseError> {
+        if let Some(forwarded) = Self::from_forwarded_header(headers)? {
+            Ok(Some(forwarded))
+        } else {
+            Self::from_x_headers(headers)
+        }
+    }
+
+    /// Parse a borrowed Forwarded from the Forwarded header, without x-forwarded-{for,by,proto} fallback
+    ///
+    /// # Examples
+    /// ```rust
+    /// # use http_types::{proxies::Forwarded, Method::Get, Request, Url};
+    /// let mut request = Request::new(Get, Url::parse("http://_/").unwrap());
+    /// request.insert_header(
+    ///     "Forwarded",
+    ///     r#"for=192.0.2.43, for="[2001:db8:cafe::17]", for=unknown;proto=https"#
+    /// );
+    /// let forwarded = Forwarded::from_forwarded_header(&request).unwrap().unwrap();
+    /// assert_eq!(forwarded.proto(), Some("https"));
+    /// assert_eq!(forwarded.forwarded_for(), vec!["192.0.2.43", "[2001:db8:cafe::17]", "unknown"]);
+    /// ```
+    /// ```rust
+    /// # use http_types::{proxies::Forwarded, Method::Get, Request, Url};
+    /// let mut request = Request::new(Get, Url::parse("http://_/").unwrap());
+    /// request.insert_header("X-Forwarded-For", "192.0.2.43, 2001:db8:cafe::17");
+    /// assert!(Forwarded::from_forwarded_header(&request).unwrap().is_none())
+    /// ```
+    pub fn from_forwarded_header(
+        headers: &'a impl AsRef<Headers>,
+    ) -> Result<Option<Self>, ParseError> {
+        if let Some(headers) = headers.as_ref().get(FORWARDED) {
+            Ok(Some(Self::parse(headers.as_ref().as_str())?))
+        } else {
+            Ok(None)
+        }
+    }
+
+    /// Parse a borrowed Forwarded from the historical
+    /// non-standardized x-forwarded-{for,by,proto} headers, without
+    /// support for the Forwarded header.
+    ///
+    /// # Examples
+    /// ```rust
+    /// # use http_types::{proxies::Forwarded, Method::Get, Request, Url};
+    /// let mut request = Request::new(Get, Url::parse("http://_/").unwrap());
+    /// request.insert_header("X-Forwarded-For", "192.0.2.43, 2001:db8:cafe::17");
+    /// let forwarded = Forwarded::from_headers(&request).unwrap().unwrap();
+    /// assert_eq!(forwarded.forwarded_for(), vec!["192.0.2.43", "[2001:db8:cafe::17]"]);
+    /// ```
+    /// ```rust
+    /// # use http_types::{proxies::Forwarded, Method::Get, Request, Url};
+    /// let mut request = Request::new(Get, Url::parse("http://_/").unwrap());
+    /// request.insert_header(
+    ///     "Forwarded",
+    ///     r#"for=192.0.2.43, for="[2001:db8:cafe::17]", for=unknown;proto=https"#
+    /// );
+    /// assert!(Forwarded::from_x_headers(&request).unwrap().is_none());
+    /// ```
+    pub fn from_x_headers(headers: &'a impl AsRef<Headers>) -> Result<Option<Self>, ParseError> {
+        let headers = headers.as_ref();
+
+        let forwarded_for: Vec<Cow<'a, str>> = headers
+            .get(X_FORWARDED_FOR)
+            .map(|hv| {
+                hv.as_str()
+                    .split(',')
+                    .map(|v| {
+                        let v = v.trim();
+                        match v.parse::<IpAddr>().ok() {
+                            Some(IpAddr::V6(v6)) => Cow::Owned(format!(r#"[{}]"#, v6)),
+                            _ => Cow::Borrowed(v),
+                        }
+                    })
+                    .collect()
+            })
+            .unwrap_or_default();
+
+        let by = headers
+            .get(X_FORWARDED_BY)
+            .map(|hv| Cow::Borrowed(hv.as_str()));
+
+        let proto = headers
+            .get(X_FORWARDED_PROTO)
+            .map(|p| Cow::Borrowed(p.as_str()));
+
+        if !forwarded_for.is_empty() || by.is_some() || proto.is_some() {
+            Ok(Some(Self {
+                forwarded_for,
+                by,
+                proto,
+                host: None,
+            }))
+        } else {
+            Ok(None)
+        }
+    }
+
+    /// parse a &str into a borrowed Forwarded
+    pub fn parse(input: &'a str) -> Result<Self, ParseError> {
+        let mut input = input;
+        let mut forwarded = Forwarded::new();
+
+        if starts_with_ignore_case("for=", input) {
+            input = forwarded.parse_for(input)?;
+        }
+
+        loop {
+            match input.chars().next() {
+                Some(';') => {
+                    input = &input[1..];
+                }
+                None => return Ok(forwarded),
+                _ => return Err(ParseError::new("unexpected character after forwarded-pair")),
+            }
+
+            input = forwarded.parse_forwarded_pair(input)?;
+        }
+    }
+
+    fn parse_forwarded_pair(&mut self, input: &'a str) -> Result<&'a str, ParseError> {
+        let (key, value, rest) = match parse_token(input) {
+            (Some(key), rest) if rest.starts_with('=') => match parse_value(&rest[1..]) {
+                (Some(value), rest) => Some((key, value, rest)),
+                (None, _) => None,
+            },
+            _ => None,
+        }
+        .ok_or_else(|| ParseError::new("parse error in forwarded-pair"))?;
+
+        match key {
+            "by" => {
+                if self.by.is_some() {
+                    return Err(ParseError::new("parse error, duplicate `by` key"));
+                }
+                self.by = Some(value);
+            }
+
+            "host" => {
+                if self.host.is_some() {
+                    return Err(ParseError::new("parse error, duplicate `host` key"));
+                }
+                self.host = Some(value);
+            }
+
+            "proto" => {
+                if self.proto.is_some() {
+                    return Err(ParseError::new("parse error, duplicate `proto` key"));
+                }
+                self.proto = Some(value);
+            }
+
+            _ => { /* extensions are allowed in the spec */ }
+        }
+
+        Ok(rest)
+    }
+
+    fn parse_for(&mut self, input: &'a str) -> Result<&'a str, ParseError> {
+        let mut rest = input;
+
+        loop {
+            rest = match match_ignore_case("for=", rest) {
+                (true, rest) => rest,
+                (false, _) => return Err(ParseError::new("http list must start with for=")),
+            };
+
+            let (value, rest_) = parse_value(rest);
+            rest = rest_;
+
+            if let Some(value) = value {
+                // add a successful for= value
+                self.forwarded_for.push(value);
+            } else {
+                return Err(ParseError::new("for= without valid value"));
+            }
+
+            match rest.chars().next() {
+                // we have another for=
+                Some(',') => {
+                    rest = rest[1..].trim_start();
+                }
+
+                // reached the end of the for section or the input
+                None | Some(';') => break,
+
+                // bail
+                _ => return Err(ParseError::new("unexpected character after for= section")),
+            }
+        }
+
+        Ok(rest)
+    }
+
+    /// Transform a borrowed Forwarded into an owned ('static)
+    /// Forwarded. This is a noop if the Forwarded is already owned.
+    pub fn into_owned(self) -> Forwarded<'static> {
+        Forwarded {
+            by: self.by.map(|by| Cow::Owned(by.into_owned())),
+            forwarded_for: self
+                .forwarded_for
+                .into_iter()
+                .map(|ff| Cow::Owned(ff.into_owned()))
+                .collect(),
+            host: self.host.map(|h| Cow::Owned(h.into_owned())),
+            proto: self.proto.map(|p| Cow::Owned(p.into_owned())),
+        }
+    }
+
+    /// Insert a header that represents this Forwarded.
+    pub fn apply(&self, mut headers: impl AsMut<Headers>) {
+        headers.as_mut().insert(FORWARDED, self);
+    }
+
+    /// Builds a Forwarded header as a String.
+    pub fn value(&self) -> Result<String, std::fmt::Error> {
+        let mut buf = String::new();
+        if let Some(by) = self.by() {
+            write!(&mut buf, "by={};", by)?;
+        }
+
+        buf.push_str(
+            &self
+                .forwarded_for
+                .iter()
+                .map(|f| format!("for={}", format_value(f)))
+                .collect::<Vec<_>>()
+                .join(", "),
+        );
+
+        buf.push(';');
+
+        if let Some(host) = self.host() {
+            write!(&mut buf, "host={};", host)?;
+        }
+
+        if let Some(proto) = self.proto() {
+            write!(&mut buf, "proto={};", proto)?;
+        }
+
+        // remove a trailing semicolon
+        buf.pop();
+
+        Ok(buf)
+    }
+
+    /// Builds a new empty Forwarded
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Returns the `by` field of this header
+    pub fn by(&self) -> Option<&str> {
+        self.by.as_deref()
+    }
+
+    /// Returns the `for` field of this header
+    pub fn forwarded_for(&self) -> Vec<&str> {
+        self.forwarded_for.iter().map(|x| x.as_ref()).collect()
+    }
+
+    /// Returns the `host` field of this header
+    pub fn host(&self) -> Option<&str> {
+        self.host.as_deref()
+    }
+
+    /// Returns the `proto` field of this header
+    pub fn proto(&self) -> Option<&str> {
+        self.proto.as_deref()
+    }
+
+    /// sets the `host` field of this header
+    pub fn set_host(&mut self, host: String) {
+        self.host = Some(Cow::Owned(host));
+    }
+
+    /// chainable builder for the `proto` field
+    pub fn with_proto(mut self, proto: String) -> Self {
+        self.proto = Some(Cow::Owned(proto));
+        self
+    }
+
+    /// adds a `for` section to this header
+    pub fn add_for(&mut self, forwarded_for: String) {
+        self.forwarded_for.push(Cow::Owned(forwarded_for));
+    }
+
+    /// chainable builder to add a `for` section to this header
+    pub fn with_for(mut self, forwarded_for: String) -> Self {
+        self.add_for(forwarded_for);
+        self
+    }
+
+    /// chainable builder set the `host` field of this header
+    pub fn with_host(mut self, host: String) -> Self {
+        self.set_host(host);
+        self
+    }
+
+    /// sets the `by` field of this header
+    pub fn set_by(&mut self, by: String) {
+        self.by = Some(Cow::Owned(by));
+    }
+
+    /// chainable builder for the `by` field of this header
+    pub fn with_by(mut self, by: String) -> Self {
+        self.set_by(by);
+        self
+    }
+}
+
+fn parse_value(input: &str) -> (Option<Cow<'_, str>>, &str) {
+    match parse_token(input) {
+        (Some(token), rest) => (Some(Cow::Borrowed(token)), rest),
+        (None, rest) => parse_quoted_string(rest),
+    }
+}
+
+fn format_value(input: &str) -> Cow<'_, str> {
+    match parse_token(input) {
+        (_, "") => input.into(),
+        _ => {
+            let mut string = String::from("\"");
+            for ch in input.chars() {
+                if let '\\' | '"' = ch {
+                    string.push('\\');
+                }
+                string.push(ch);
+            }
+            string.push('"');
+            string.into()
+        }
+    }
+}
+
+fn match_ignore_case<'a>(start: &'static str, input: &'a str) -> (bool, &'a str) {
+    let len = start.len();
+    if input[..len].eq_ignore_ascii_case(start) {
+        (true, &input[len..])
+    } else {
+        (false, input)
+    }
+}
+
+fn starts_with_ignore_case(start: &'static str, input: &str) -> bool {
+    let len = start.len();
+    input[..len].eq_ignore_ascii_case(start)
+}
+
+impl std::fmt::Display for Forwarded<'_> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(&self.value()?)
+    }
+}
+
+impl ToHeaderValues for Forwarded<'_> {
+    type Iter = std::option::IntoIter<HeaderValue>;
+    fn to_header_values(&self) -> crate::Result<Self::Iter> {
+        Ok(self.value()?.to_header_values()?)
+    }
+}
+
+impl ToHeaderValues for &Forwarded<'_> {
+    type Iter = std::option::IntoIter<HeaderValue>;
+    fn to_header_values(&self) -> crate::Result<Self::Iter> {
+        Ok(self.value()?.to_header_values()?)
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct ParseError(&'static str);
+impl ParseError {
+    pub fn new(msg: &'static str) -> Self {
+        Self(msg)
+    }
+}
+
+impl std::error::Error for ParseError {}
+impl std::fmt::Display for ParseError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "unable to parse forwarded header: {}", self.0)
+    }
+}
+
+impl<'a> TryFrom<&'a str> for Forwarded<'a> {
+    type Error = ParseError;
+    fn try_from(value: &'a str) -> Result<Self, Self::Error> {
+        Self::parse(value)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{Method::Get, Request, Response};
+    use url::Url;
+
+    #[test]
+    fn parsing_for() -> crate::Result<()> {
+        assert_eq!(
+            Forwarded::parse(r#"for="_gazonk""#)
+                .unwrap()
+                .forwarded_for(),
+            vec!["_gazonk"]
+        );
+        assert_eq!(
+            Forwarded::parse(r#"For="[2001:db8:cafe::17]:4711""#)
+                .unwrap()
+                .forwarded_for(),
+            vec!["[2001:db8:cafe::17]:4711"]
+        );
+
+        assert_eq!(
+            Forwarded::parse("for=192.0.2.60;proto=http;by=203.0.113.43")
+                .unwrap()
+                .forwarded_for(),
+            vec!["192.0.2.60"]
+        );
+
+        assert_eq!(
+            Forwarded::parse("for=192.0.2.43,   for=198.51.100.17")
+                .unwrap()
+                .forwarded_for(),
+            vec!["192.0.2.43", "198.51.100.17"]
+        );
+
+        assert_eq!(
+            Forwarded::parse(r#"for=192.0.2.43,for="[2001:db8:cafe::17]",for=unknown"#)
+                .unwrap()
+                .forwarded_for(),
+            Forwarded::parse(r#"for=192.0.2.43, for="[2001:db8:cafe::17]", for=unknown"#)
+                .unwrap()
+                .forwarded_for()
+        );
+
+        assert_eq!(
+            Forwarded::parse(
+                r#"for=192.0.2.43,for="this is a valid quoted-string, \" \\",for=unknown"#
+            )
+            .unwrap()
+            .forwarded_for(),
+            vec![
+                "192.0.2.43",
+                r#"this is a valid quoted-string, " \"#,
+                "unknown"
+            ]
+        );
+
+        Ok(())
+    }
+
+    #[test]
+    fn formatting_for() -> crate::Result<()> {
+        assert_eq!("", Forwarded::new().to_string());
+        Ok(())
+    }
+
+    #[test]
+    fn basic_parse() {
+        let forwarded =
+            Forwarded::parse("for=client.com;by=proxy.com;host=host.com;proto=https").unwrap();
+
+        assert_eq!(forwarded.by(), Some("proxy.com"));
+        assert_eq!(forwarded.forwarded_for(), vec!["client.com"]);
+        assert_eq!(forwarded.host(), Some("host.com"));
+        assert_eq!(forwarded.proto(), Some("https"));
+        assert!(matches!(forwarded, Forwarded{..}));
+    }
+
+    #[test]
+    fn bad_parse() {
+        let err = Forwarded::parse("by=proxy.com;for=client;host=example.com;host").unwrap_err();
+        assert_eq!(
+            err.to_string(),
+            "unable to parse forwarded header: unexpected character after forwarded-pair"
+        );
+
+        let err = Forwarded::parse("by;for;host;proto").unwrap_err();
+        assert_eq!(
+            err.to_string(),
+            "unable to parse forwarded header: unexpected character after forwarded-pair"
+        );
+
+        let err = Forwarded::parse("for=for, key=value").unwrap_err();
+        assert_eq!(
+            err.to_string(),
+            "unable to parse forwarded header: http list must start with for="
+        );
+
+        let err = Forwarded::parse(r#"for="unterminated string"#).unwrap_err();
+        assert_eq!(
+            err.to_string(),
+            "unable to parse forwarded header: for= without valid value"
+        );
+
+        let err = Forwarded::parse(r#"for=, for=;"#).unwrap_err();
+        assert_eq!(
+            err.to_string(),
+            "unable to parse forwarded header: for= without valid value"
+        );
+    }
+
+    #[test]
+    fn bad_parse_from_headers() {
+        let mut response = Response::new(200);
+        response.append_header("forwarded", "uh oh");
+        assert_eq!(
+            Forwarded::from_headers(&response).unwrap_err().to_string(),
+            "unable to parse forwarded header: unexpected character after forwarded-pair"
+        );
+
+        let response = Response::new(200);
+        assert!(Forwarded::from_headers(&response).unwrap().is_none());
+    }
+
+    #[test]
+    fn from_x_headers() {
+        let mut request = Request::new(Get, Url::parse("http://_/").unwrap());
+        request.append_header(X_FORWARDED_FOR, "192.0.2.43, 2001:db8:cafe::17");
+        request.append_header(X_FORWARDED_PROTO, "gopher");
+        let forwarded = Forwarded::from_headers(&request).unwrap().unwrap();
+        assert_eq!(
+            forwarded.to_string(),
+            r#"for=192.0.2.43, for="[2001:db8:cafe::17]";proto=gopher"#
+        );
+    }
+
+    #[test]
+    fn formatting_edge_cases() {
+        let forwarded = Forwarded::new()
+            .with_for(r#"quote: " backslash: \"#.into())
+            .with_for(";proto=https".into());
+        assert_eq!(
+            forwarded.to_string(),
+            r#"for="quote: \" backslash: \\", for=";proto=https""#
+        );
+    }
+
+    #[test]
+    fn parse_edge_cases() {
+        let forwarded =
+            Forwarded::parse(r#"for=";", for=",", for="\"", for=unquoted;by=";proto=https""#)
+                .unwrap();
+        assert_eq!(forwarded.forwarded_for(), vec![";", ",", "\"", "unquoted"]);
+        assert_eq!(forwarded.by(), Some(";proto=https"));
+        assert!(forwarded.proto().is_none());
+    }
+
+    #[test]
+    fn owned_parse() {
+        let forwarded = Forwarded::parse("for=client;by=proxy.com;host=example.com;proto=https")
+            .unwrap()
+            .into_owned();
+
+        assert_eq!(forwarded.by(), Some("proxy.com"));
+        assert_eq!(forwarded.forwarded_for(), vec!["client"]);
+        assert_eq!(forwarded.host(), Some("example.com"));
+        assert_eq!(forwarded.proto(), Some("https"));
+        assert!(matches!(forwarded, Forwarded{..}));
+    }
+
+    #[test]
+    fn from_request() -> crate::Result<()> {
+        let mut request = Request::new(Get, Url::parse("http://_/").unwrap());
+        request.append_header("Forwarded", "for=for");
+
+        let forwarded = Forwarded::from_headers(&request)?.unwrap();
+        assert_eq!(forwarded.forwarded_for(), vec!["for"]);
+        Ok(())
+    }
+
+    #[test]
+    fn owned_can_outlive_request() -> crate::Result<()> {
+        let forwarded = {
+            let mut request = Request::new(Get, Url::parse("http://_/").unwrap());
+            request.append_header("Forwarded", "for=for;by=by;host=host;proto=proto");
+            Forwarded::from_headers(&request)?.unwrap().into_owned()
+        };
+        assert_eq!(forwarded.by(), Some("by"));
+        Ok(())
+    }
+}

--- a/src/proxies/mod.rs
+++ b/src/proxies/mod.rs
@@ -1,0 +1,3 @@
+//! Headers that are set by proxies
+mod forwarded;
+pub use forwarded::Forwarded;


### PR DESCRIPTION
~~Experimented a bit with a COW-like interface for the forwarded header. Let me know if you'd prefer to switch to just the Owned version. Alternatively, if y'all like this pattern, we might want to use it for other headers~~

~~**edit:** switching to draft — noticed some additional complexity in the spec that this version doesn't handle. Interested in feedback on the Cow-like interface, though~~

Ok! This pr now includes is now an efficient and correct hand-rolled parser for tokens and quoted strings as defined by https://tools.ietf.org/html/rfc7230#section-3.2.6, and for the Forwarded header, including a spec-conforming normalization from the x-forwarded-{for, proto, and by} headers. Hopefully the token and quoted-string parsers will be helpful for other header parsers in http-types

Ref #99 

![image](https://user-images.githubusercontent.com/13301/90211641-239ca700-dda6-11ea-879c-9f9b66627bd7.png)
