### PR TITLE
Update headers copy

### DIFF
--- a/src/cache/age.rs
+++ b/src/cache/age.rs
@@ -9,7 +9,7 @@ use std::time::Duration;
 ///
 /// # Specifications
 ///
-/// - [RFC 7234  Hypertext Transfer Protocol (HTTP/1.1): Caching](https://tools.ietf.org/html/rfc7234#section-5.1)
+/// - [RFC 7234, section 5.1: Age](https://tools.ietf.org/html/rfc7234#section-5.1)
 ///
 /// # Examples
 ///
@@ -52,10 +52,6 @@ impl Age {
     }
 
     /// Create an instance of `Age` from a `Headers` instance.
-    ///
-    /// # Implementation note
-    ///
-    /// A header value of `"null"` is treated the same as if no header was sent.
     pub fn from_headers(headers: impl AsRef<Headers>) -> crate::Result<Option<Self>> {
         let headers = match headers.as_ref().get(AGE) {
             Some(headers) => headers,

--- a/src/cache/cache_control/mod.rs
+++ b/src/cache/cache_control/mod.rs
@@ -2,9 +2,9 @@
 //!
 //! # Specifications
 //!
-//! - [RFC 5861: HTTP Cache-Control Extensions for Stale Content](https://tools.ietf.org/html/rfc5861)
-//! - [RFC 7234:  Hypertext Transfer Protocol (HTTP/1.1): Caching](https://tools.ietf.org/html/rfc7234)
 //! - [RFC 8246: HTTP Immutable Responses](https://tools.ietf.org/html/rfc8246)
+//! - [RFC 7234: Hypertext Transfer Protocol (HTTP/1.1): Caching](https://tools.ietf.org/html/rfc7234)
+//! - [RFC 5861: HTTP Cache-Control Extensions for Stale Content](https://tools.ietf.org/html/rfc5861)
 
 #[allow(clippy::module_inception)]
 mod cache_control;

--- a/src/conditional/etag.rs
+++ b/src/conditional/etag.rs
@@ -11,7 +11,7 @@ use std::option;
 ///
 /// # Specifications
 ///
-/// - [RFC 7232 HTTP/1.1: Conditional Requests](https://tools.ietf.org/html/rfc7232#section-2.3)
+/// - [RFC 7232, section 2.3: ETag](https://tools.ietf.org/html/rfc7232#section-2.3)
 ///
 /// # Examples
 ///

--- a/src/trace/server_timing/mod.rs
+++ b/src/trace/server_timing/mod.rs
@@ -37,10 +37,9 @@ use crate::headers::{HeaderName, HeaderValue, Headers, ToHeaderValues, SERVER_TI
 
 /// Metrics and descriptions for the given request-response cycle.
 ///
-/// This is an implementation of the W3C [Server
-/// Timing](https://w3c.github.io/server-timing/#the-server-timing-header-field)
-/// header spec. Read more on
-/// [MDN](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Server-Timing).
+/// # Specifications
+///
+/// - [Server Timing (Working Draft)](https://w3c.github.io/server-timing/#the-server-timing-header-field)
 ///
 /// # Examples
 ///

--- a/src/trace/trace_context.rs
+++ b/src/trace/trace_context.rs
@@ -6,6 +6,10 @@ use crate::Status;
 
 /// Extract and apply [Trace-Context](https://w3c.github.io/trace-context/) headers.
 ///
+/// # Specifications
+///
+/// - [Trace-Context (Working Draft)](https://w3c.github.io/trace-context/)
+///
 /// # Examples
 ///
 /// ```


### PR DESCRIPTION
This patch makes some of the copy on the new typed headers more consistent. In particular it makes it so headers all have a `Specification` field in the docs that links to the spec where they're defined. This should make it easier to learn more about. Thanks!