### PR TITLE
Add `conditional::{IfMatch, IfNoneMatch}`

### DIFF
--- a/src/conditional/etag.rs
+++ b/src/conditional/etag.rs
@@ -64,7 +64,7 @@ impl ETag {
 
         // If a header is returned we can assume at least one exists.
         let s = headers.iter().last().unwrap().as_str();
-        Self::from_str(s).map(|etag| Some(etag))
+        Self::from_str(s).map(Some)
     }
 
     /// Sets the `ETag` header.

--- a/src/conditional/if_match.rs
+++ b/src/conditional/if_match.rs
@@ -1,0 +1,236 @@
+use crate::conditional::MatchDirective;
+use crate::headers::{HeaderName, HeaderValue, Headers, ToHeaderValues, IF_MATCH};
+
+use std::fmt::{self, Debug, Write};
+use std::iter::Iterator;
+use std::option;
+use std::slice;
+
+/// A Match-Control header.
+///
+/// # Examples
+///
+/// ```
+/// # fn main() -> http_types::Result<()> {
+/// #
+/// use http_types::Response;
+/// use http_types::conditional::{IfMatch, ETag};
+///
+/// let mut entries = IfMatch::new();
+/// entries.push(ETag::new("0xcafebeef".to_string()));
+/// entries.push(ETag::new("0xbeefcafe".to_string()));
+///
+/// let mut res = Response::new(200);
+/// entries.apply(&mut res);
+///
+/// let entries = IfMatch::from_headers(res)?.unwrap();
+/// let mut entries = entries.iter();
+/// assert_eq!(entries.next().unwrap(), ETag::new("0xcafebeef".to_string()));
+/// assert_eq!(entries.next().unwrap(), ETag::new("0xbeefcafe".to_string()));
+/// #
+/// # Ok(()) }
+/// ```
+pub struct IfMatch {
+    entries: Vec<MatchDirective>,
+}
+
+impl IfMatch {
+    /// Create a new instance of `IfMatch`.
+    pub fn new() -> Self {
+        Self { entries: vec![] }
+    }
+
+    /// Create a new instance from headers.
+    pub fn from_headers(headers: impl AsRef<Headers>) -> crate::Result<Option<Self>> {
+        let mut entries = vec![];
+        let headers = match headers.as_ref().get(IF_MATCH) {
+            Some(headers) => headers,
+            None => return Ok(None),
+        };
+
+        for value in headers {
+            for part in value.as_str().trim().split(',') {
+                // Try and parse a directive from a str. If the directive is
+                // unkown we skip it.
+                if let Some(entry) = MatchDirective::from_str(part)? {
+                    entries.push(entry);
+                }
+            }
+        }
+
+        Ok(Some(Self { entries }))
+    }
+
+    /// Sets the `If-Match` header.
+    pub fn apply(&self, mut headers: impl AsMut<Headers>) {
+        headers.as_mut().insert(IF_MATCH, self.value());
+    }
+
+    /// Get the `HeaderName`.
+    pub fn name(&self) -> HeaderName {
+        IF_MATCH
+    }
+
+    /// Get the `HeaderValue`.
+    pub fn value(&self) -> HeaderValue {
+        let mut output = String::new();
+        for (n, directive) in self.entries.iter().enumerate() {
+            let directive: HeaderValue = directive.clone().into();
+            match n {
+                0 => write!(output, "{}", directive).unwrap(),
+                _ => write!(output, ", {}", directive).unwrap(),
+            };
+        }
+
+        // SAFETY: the internal string is validated to be ASCII.
+        unsafe { HeaderValue::from_bytes_unchecked(output.into()) }
+    }
+
+    /// Push a directive into the list of entries.
+    pub fn push(&mut self, directive: impl Into<MatchDirective>) {
+        self.entries.push(directive.into());
+    }
+
+    /// An iterator visiting all server entries.
+    pub fn iter(&self) -> Iter<'_> {
+        Iter {
+            inner: self.entries.iter(),
+        }
+    }
+
+    /// An iterator visiting all server entries.
+    pub fn iter_mut(&mut self) -> IterMut<'_> {
+        IterMut {
+            inner: self.entries.iter_mut(),
+        }
+    }
+}
+
+impl IntoIterator for IfMatch {
+    type Item = MatchDirective;
+    type IntoIter = IntoIter;
+
+    #[inline]
+    fn into_iter(self) -> Self::IntoIter {
+        IntoIter {
+            inner: self.entries.into_iter(),
+        }
+    }
+}
+
+impl<'a> IntoIterator for &'a IfMatch {
+    type Item = &'a MatchDirective;
+    type IntoIter = Iter<'a>;
+
+    #[inline]
+    fn into_iter(self) -> Self::IntoIter {
+        self.iter()
+    }
+}
+
+impl<'a> IntoIterator for &'a mut IfMatch {
+    type Item = &'a mut MatchDirective;
+    type IntoIter = IterMut<'a>;
+
+    #[inline]
+    fn into_iter(self) -> Self::IntoIter {
+        self.iter_mut()
+    }
+}
+
+/// A borrowing iterator over entries in `IfMatch`.
+#[derive(Debug)]
+pub struct IntoIter {
+    inner: std::vec::IntoIter<MatchDirective>,
+}
+
+impl Iterator for IntoIter {
+    type Item = MatchDirective;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.inner.next()
+    }
+
+    #[inline]
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        self.inner.size_hint()
+    }
+}
+
+/// A lending iterator over entries in `IfMatch`.
+#[derive(Debug)]
+pub struct Iter<'a> {
+    inner: slice::Iter<'a, MatchDirective>,
+}
+
+impl<'a> Iterator for Iter<'a> {
+    type Item = &'a MatchDirective;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.inner.next()
+    }
+
+    #[inline]
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        self.inner.size_hint()
+    }
+}
+
+/// A mutable iterator over entries in `IfMatch`.
+#[derive(Debug)]
+pub struct IterMut<'a> {
+    inner: slice::IterMut<'a, MatchDirective>,
+}
+
+impl<'a> Iterator for IterMut<'a> {
+    type Item = &'a mut MatchDirective;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.inner.next()
+    }
+
+    #[inline]
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        self.inner.size_hint()
+    }
+}
+
+impl ToHeaderValues for IfMatch {
+    type Iter = option::IntoIter<HeaderValue>;
+    fn to_header_values(&self) -> crate::Result<Self::Iter> {
+        // A HeaderValue will always convert into itself.
+        Ok(self.value().to_header_values().unwrap())
+    }
+}
+
+impl Debug for IfMatch {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let mut list = f.debug_list();
+        for directive in &self.entries {
+            list.entry(directive);
+        }
+        list.finish()
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use crate::conditional::{ETag, IfMatch};
+    use crate::Response;
+
+    #[test]
+    fn smoke() -> crate::Result<()> {
+        let mut entries = IfMatch::new();
+        entries.push(ETag::new("0xcafebeef".to_string()));
+        entries.push(ETag::new("0xbeefcafe".to_string()));
+
+        let mut res = Response::new(200);
+        entries.apply(&mut res);
+
+        let entries = IfMatch::from_headers(res)?.unwrap();
+        let mut entries = entries.iter();
+        assert_eq!(entries.next().unwrap(), ETag::new("0xcafebeef".to_string()));
+        assert_eq!(entries.next().unwrap(), ETag::new("0xbeefcafe".to_string()));
+        Ok(())
+    }
+}

--- a/src/conditional/if_match.rs
+++ b/src/conditional/if_match.rs
@@ -1,3 +1,5 @@
+//! Apply the HTTP method if the ETag matches.
+
 use crate::conditional::MatchDirective;
 use crate::headers::{HeaderName, HeaderValue, Headers, ToHeaderValues, IF_MATCH};
 
@@ -6,7 +8,7 @@ use std::iter::Iterator;
 use std::option;
 use std::slice;
 
-/// HTTP `If-Match` header.
+/// Apply the HTTP method if the ETag matches.
 ///
 /// # Specifications
 ///

--- a/src/conditional/if_modified_since.rs
+++ b/src/conditional/if_modified_since.rs
@@ -5,7 +5,8 @@ use std::fmt::Debug;
 use std::option;
 use std::time::SystemTime;
 
-/// HTTP `IfModifiedSince` header
+/// Apply the HTTP method if the entity has been modified after the given
+/// date.
 ///
 /// # Specifications
 ///

--- a/src/conditional/if_none_match.rs
+++ b/src/conditional/if_none_match.rs
@@ -1,3 +1,8 @@
+//! Apply the HTTP method if the ETags do not match.
+//!
+//! This is used to update caches or to prevent uploading a new resource when
+//! one already exists.
+
 use crate::conditional::MatchDirective;
 use crate::headers::{HeaderName, HeaderValue, Headers, ToHeaderValues, IF_NONE_MATCH};
 
@@ -6,7 +11,10 @@ use std::iter::Iterator;
 use std::option;
 use std::slice;
 
-/// HTTP `If-None-Match` header.
+/// Apply the HTTP method if the ETags do not match.
+///
+/// This is used to update caches or to prevent uploading a new resource when
+/// one already exists.
 ///
 /// # Specifications
 ///

--- a/src/conditional/if_unmodified_since.rs
+++ b/src/conditional/if_unmodified_since.rs
@@ -5,7 +5,8 @@ use std::fmt::Debug;
 use std::option;
 use std::time::SystemTime;
 
-/// HTTP `IfUnmodifiedSince` header
+/// Apply the HTTP method if the entity has not been modified after the
+/// given date.
 ///
 /// # Specifications
 ///

--- a/src/conditional/last_modified.rs
+++ b/src/conditional/last_modified.rs
@@ -5,7 +5,7 @@ use std::fmt::Debug;
 use std::option;
 use std::time::SystemTime;
 
-/// HTTP `LastModified` header
+/// The last modification date of a resource.
 ///
 /// # Specifications
 ///

--- a/src/conditional/match_directive.rs
+++ b/src/conditional/match_directive.rs
@@ -1,0 +1,68 @@
+use crate::conditional::ETag;
+use crate::headers::HeaderValue;
+
+/// An HTTP `If-{None-,}Match` directive.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum MatchDirective {
+    /// An ETag.
+    ETag(ETag),
+    /// Match any resource.
+    Wildcard,
+}
+
+impl MatchDirective {
+    /// Create an instance from a string slice.
+    //
+    // This is a private method rather than a trait because we assume the
+    // input string is a single-value only. This is upheld by the calling
+    // function, but we cannot guarantee this to be true in the general
+    // sense.
+    pub(crate) fn from_str(s: &str) -> crate::Result<Option<Self>> {
+        let s = s.trim();
+
+        // We're dealing with an empty string.
+        if s.is_empty() {
+            return Ok(None);
+        }
+
+        match s {
+            "*" => Ok(Some(MatchDirective::Wildcard)),
+            s => ETag::from_str(s).map(|etag| Some(MatchDirective::ETag(etag))),
+        }
+    }
+}
+
+impl From<ETag> for MatchDirective {
+    fn from(etag: ETag) -> Self {
+        Self::ETag(etag)
+    }
+}
+
+impl PartialEq<ETag> for MatchDirective {
+    fn eq(&self, other: &ETag) -> bool {
+        match self {
+            Self::ETag(etag) => etag.eq(other),
+            Self::Wildcard => false,
+        }
+    }
+}
+
+impl<'a> PartialEq<ETag> for &'a MatchDirective {
+    fn eq(&self, other: &ETag) -> bool {
+        match self {
+            MatchDirective::ETag(etag) => etag.eq(other),
+            MatchDirective::Wildcard => false,
+        }
+    }
+}
+
+impl From<MatchDirective> for HeaderValue {
+    fn from(directive: MatchDirective) -> Self {
+        match directive {
+            MatchDirective::ETag(etag) => etag.value(),
+            MatchDirective::Wildcard => unsafe {
+                HeaderValue::from_bytes_unchecked("*".to_string().into_bytes())
+            },
+        }
+    }
+}

--- a/src/conditional/match_directive.rs
+++ b/src/conditional/match_directive.rs
@@ -1,7 +1,7 @@
 use crate::conditional::ETag;
 use crate::headers::HeaderValue;
 
-/// An HTTP `If-{None-,}Match` directive.
+/// An Entity Tag based match directive.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum MatchDirective {
     /// An ETag.

--- a/src/conditional/match_directive.rs
+++ b/src/conditional/match_directive.rs
@@ -1,7 +1,7 @@
 use crate::conditional::ETag;
 use crate::headers::HeaderValue;
 
-/// An Entity Tag based match directive.
+/// An ETag-based match directive.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum MatchDirective {
     /// An ETag.

--- a/src/conditional/mod.rs
+++ b/src/conditional/mod.rs
@@ -9,17 +9,24 @@
 //! - [MDN: HTTP Conditional Requests](https://developer.mozilla.org/en-US/docs/Web/HTTP/Conditional_requests)
 
 mod etag;
-mod if_match;
 mod if_modified_since;
-mod if_none_match;
 mod if_unmodified_since;
 mod last_modified;
 mod match_directive;
 
+pub mod if_match;
+pub mod if_none_match;
+
 pub use etag::ETag;
-pub use if_match::IfMatch;
-pub use if_modified_since::IfModifiedSince;
-pub use if_none_match::IfNoneMatch;
-pub use if_unmodified_since::IfUnmodifiedSince;
-pub use last_modified::LastModified;
 pub use match_directive::MatchDirective;
+
+#[doc(inline)]
+pub use if_match::IfMatch;
+#[doc(inline)]
+pub use if_modified_since::IfModifiedSince;
+#[doc(inline)]
+pub use if_none_match::IfNoneMatch;
+#[doc(inline)]
+pub use if_unmodified_since::IfUnmodifiedSince;
+#[doc(inline)]
+pub use last_modified::LastModified;

--- a/src/conditional/mod.rs
+++ b/src/conditional/mod.rs
@@ -11,6 +11,7 @@
 mod etag;
 mod if_match;
 mod if_modified_since;
+mod if_none_match;
 mod if_unmodified_since;
 mod last_modified;
 mod match_directive;
@@ -18,6 +19,7 @@ mod match_directive;
 pub use etag::ETag;
 pub use if_match::IfMatch;
 pub use if_modified_since::IfModifiedSince;
+pub use if_none_match::IfNoneMatch;
 pub use if_unmodified_since::IfUnmodifiedSince;
 pub use last_modified::LastModified;
 pub use match_directive::MatchDirective;

--- a/src/conditional/mod.rs
+++ b/src/conditional/mod.rs
@@ -9,11 +9,15 @@
 //! - [MDN: HTTP Conditional Requests](https://developer.mozilla.org/en-US/docs/Web/HTTP/Conditional_requests)
 
 mod etag;
+mod if_match;
 mod if_modified_since;
 mod if_unmodified_since;
 mod last_modified;
+mod match_directive;
 
 pub use etag::ETag;
+pub use if_match::IfMatch;
 pub use if_modified_since::IfModifiedSince;
 pub use if_unmodified_since::IfUnmodifiedSince;
 pub use last_modified::LastModified;
+pub use match_directive::MatchDirective;


### PR DESCRIPTION
Adds `conditional::{IfMatch, IfNoneMatch}`. Depends on #220 and #222. Ref #99.

This is the last one for the `conditional` submodule. Merging this will allow us to build high-level caching middleware for Tide. Probably the first step would be to integrate Etag and timestamp generation with the `serve_dir` method.

__edit:__ I forgot about the `Vary` header. But other than that we should have all the conditionals already!

## Screenshots

![Screenshot_2020-08-08 http_types conditional - Rust(2)](https://user-images.githubusercontent.com/2467194/89713368-9c12fa80-d997-11ea-87fb-1821d7a97d5b.png)
