### PR TITLE
do not run ci for wasm — async-std 1.6.3 does not compile on wasm arch

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -70,22 +70,22 @@ jobs:
     - name: Docs
       run: cargo doc
 
-  check_wasm:
-    name: Check wasm targets
-    runs-on: ubuntu-latest
+  # check_wasm:
+  #   name: Check wasm targets
+  #   runs-on: ubuntu-latest
 
-    steps:
-    - uses: actions/checkout@master
+  #   steps:
+  #   - uses: actions/checkout@master
 
-    - name: Install nightly with wasm32-unknown-unknown
-      uses: actions-rs/toolchain@v1
-      with:
-        toolchain: nightly
-        target: wasm32-unknown-unknown
-        override: true
+  #   - name: Install nightly with wasm32-unknown-unknown
+  #     uses: actions-rs/toolchain@v1
+  #     with:
+  #       toolchain: nightly
+  #       target: wasm32-unknown-unknown
+  #       override: true
 
-    - name: check
-      uses: actions-rs/cargo@v1
-      with:
-        command: check
-        args: --target wasm32-unknown-unknown
+  #   - name: check
+  #     uses: actions-rs/cargo@v1
+  #     with:
+  #       command: check
+  #       args: --target wasm32-unknown-unknown


### PR DESCRIPTION
re enable when https://github.com/async-rs/async-std/issues/851 is closed