### PR TITLE
run ci on stable as well as nightly

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macOS-latest]
-        rust: [nightly]
+        rust: [stable, nightly]
 
     steps:
     - uses: actions/checkout@master


### PR DESCRIPTION
failing because of #228, not because of stable