### PR TITLE
Add `content::{ContentEncoding,EncodingDirective}`

### DIFF
--- a/src/content/content_encoding.rs
+++ b/src/content/content_encoding.rs
@@ -1,0 +1,218 @@
+//! Specify the compression algorithm.
+
+use crate::content::EncodingDirective;
+use crate::headers::{HeaderName, HeaderValue, Headers, ToHeaderValues, CONTENT_ENCODING};
+
+use std::fmt::{self, Debug, Write};
+use std::iter::Iterator;
+use std::option;
+use std::slice;
+
+/// Specify the compression algorithm.
+///
+/// # Specifications
+///
+/// - [RFC 7231, section 3.1.2.2: Content-Encoding](https://tools.ietf.org/html/rfc7231#section-3.1.2.2)
+///
+/// # Examples
+///
+/// ```
+/// # fn main() -> http_types::Result<()> {
+/// #
+/// use http_types::Response;
+/// use http_types::content::{ContentEncoding, EncodingDirective};
+/// let mut entries = ContentEncoding::new();
+/// entries.push(EncodingDirective::Gzip);
+/// entries.push(EncodingDirective::Identity);
+///
+/// let mut res = Response::new(200);
+/// entries.apply(&mut res);
+///
+/// let entries = ContentEncoding::from_headers(res)?.unwrap();
+/// let mut entries = entries.iter();
+/// assert_eq!(entries.next().unwrap(), &EncodingDirective::Gzip);
+/// assert_eq!(entries.next().unwrap(), &EncodingDirective::Identity);
+/// #
+/// # Ok(()) }
+/// ```
+pub struct ContentEncoding {
+    entries: Vec<EncodingDirective>,
+}
+
+impl ContentEncoding {
+    /// Create a new instance of `CacheControl`.
+    pub fn new() -> Self {
+        Self { entries: vec![] }
+    }
+
+    /// Create a new instance from headers.
+    pub fn from_headers(headers: impl AsRef<Headers>) -> crate::Result<Option<Self>> {
+        let mut entries = vec![];
+        let headers = match headers.as_ref().get(CONTENT_ENCODING) {
+            Some(headers) => headers,
+            None => return Ok(None),
+        };
+
+        for value in headers {
+            for part in value.as_str().trim().split(',') {
+                // Try and parse a directive from a str. If the directive is
+                // unkown we skip it.
+                if let Some(entry) = EncodingDirective::from_str(part) {
+                    entries.push(entry);
+                }
+            }
+        }
+
+        Ok(Some(Self { entries }))
+    }
+
+    /// Sets the `Server-Timing` header.
+    pub fn apply(&self, mut headers: impl AsMut<Headers>) {
+        headers.as_mut().insert(CONTENT_ENCODING, self.value());
+    }
+
+    /// Get the `HeaderName`.
+    pub fn name(&self) -> HeaderName {
+        CONTENT_ENCODING
+    }
+
+    /// Get the `HeaderValue`.
+    pub fn value(&self) -> HeaderValue {
+        let mut output = String::new();
+        for (n, directive) in self.entries.iter().enumerate() {
+            let directive: HeaderValue = directive.clone().into();
+            match n {
+                0 => write!(output, "{}", directive).unwrap(),
+                _ => write!(output, ", {}", directive).unwrap(),
+            };
+        }
+
+        // SAFETY: the internal string is validated to be ASCII.
+        unsafe { HeaderValue::from_bytes_unchecked(output.into()) }
+    }
+    /// Push a directive into the list of entries.
+    pub fn push(&mut self, directive: EncodingDirective) {
+        self.entries.push(directive);
+    }
+
+    /// An iterator visiting all server entries.
+    pub fn iter(&self) -> Iter<'_> {
+        Iter {
+            inner: self.entries.iter(),
+        }
+    }
+
+    /// An iterator visiting all server entries.
+    pub fn iter_mut(&mut self) -> IterMut<'_> {
+        IterMut {
+            inner: self.entries.iter_mut(),
+        }
+    }
+}
+
+impl IntoIterator for ContentEncoding {
+    type Item = EncodingDirective;
+    type IntoIter = IntoIter;
+
+    #[inline]
+    fn into_iter(self) -> Self::IntoIter {
+        IntoIter {
+            inner: self.entries.into_iter(),
+        }
+    }
+}
+
+impl<'a> IntoIterator for &'a ContentEncoding {
+    type Item = &'a EncodingDirective;
+    type IntoIter = Iter<'a>;
+
+    #[inline]
+    fn into_iter(self) -> Self::IntoIter {
+        self.iter()
+    }
+}
+
+impl<'a> IntoIterator for &'a mut ContentEncoding {
+    type Item = &'a mut EncodingDirective;
+    type IntoIter = IterMut<'a>;
+
+    #[inline]
+    fn into_iter(self) -> Self::IntoIter {
+        self.iter_mut()
+    }
+}
+
+/// A borrowing iterator over entries in `CacheControl`.
+#[derive(Debug)]
+pub struct IntoIter {
+    inner: std::vec::IntoIter<EncodingDirective>,
+}
+
+impl Iterator for IntoIter {
+    type Item = EncodingDirective;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.inner.next()
+    }
+
+    #[inline]
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        self.inner.size_hint()
+    }
+}
+
+/// A lending iterator over entries in `CacheControl`.
+#[derive(Debug)]
+pub struct Iter<'a> {
+    inner: slice::Iter<'a, EncodingDirective>,
+}
+
+impl<'a> Iterator for Iter<'a> {
+    type Item = &'a EncodingDirective;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.inner.next()
+    }
+
+    #[inline]
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        self.inner.size_hint()
+    }
+}
+
+/// A mutable iterator over entries in `CacheControl`.
+#[derive(Debug)]
+pub struct IterMut<'a> {
+    inner: slice::IterMut<'a, EncodingDirective>,
+}
+
+impl<'a> Iterator for IterMut<'a> {
+    type Item = &'a mut EncodingDirective;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.inner.next()
+    }
+
+    #[inline]
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        self.inner.size_hint()
+    }
+}
+
+impl ToHeaderValues for ContentEncoding {
+    type Iter = option::IntoIter<HeaderValue>;
+    fn to_header_values(&self) -> crate::Result<Self::Iter> {
+        // A HeaderValue will always convert into itself.
+        Ok(self.value().to_header_values().unwrap())
+    }
+}
+
+impl Debug for ContentEncoding {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let mut list = f.debug_list();
+        for directive in &self.entries {
+            list.entry(directive);
+        }
+        list.finish()
+    }
+}

--- a/src/content/encoding_directive.rs
+++ b/src/content/encoding_directive.rs
@@ -1,0 +1,52 @@
+use crate::headers::HeaderValue;
+
+/// Available compression algorithms.
+#[non_exhaustive]
+#[derive(Debug, Clone, Copy, Eq, PartialEq)]
+pub enum EncodingDirective {
+    /// The Gzip encoding.
+    Gzip,
+    /// The Deflate encoding.
+    Deflate,
+    /// The Brotli encoding.
+    Brotli,
+    /// The Zstd encoding.
+    Zstd,
+    /// No encoding.
+    Identity,
+}
+
+impl EncodingDirective {
+    /// Parses a given string into its corresponding encoding.
+    pub(crate) fn from_str(s: &str) -> Option<EncodingDirective> {
+        let s = s.trim();
+
+        // We're dealing with an empty string.
+        if s.is_empty() {
+            return None;
+        }
+
+        match s {
+            "gzip" => Some(EncodingDirective::Gzip),
+            "deflate" => Some(EncodingDirective::Deflate),
+            "br" => Some(EncodingDirective::Brotli),
+            "zstd" => Some(EncodingDirective::Zstd),
+            "identity" => Some(EncodingDirective::Identity),
+            _ => None,
+        }
+    }
+}
+
+impl From<EncodingDirective> for HeaderValue {
+    fn from(directive: EncodingDirective) -> Self {
+        let h = |s: &str| unsafe { HeaderValue::from_bytes_unchecked(s.to_string().into_bytes()) };
+
+        match directive {
+            EncodingDirective::Gzip => h("gzip"),
+            EncodingDirective::Deflate => h("deflate"),
+            EncodingDirective::Brotli => h("br"),
+            EncodingDirective::Zstd => h("zstd"),
+            EncodingDirective::Identity => h("identity"),
+        }
+    }
+}

--- a/src/content/mod.rs
+++ b/src/content/mod.rs
@@ -1,0 +1,9 @@
+//! HTTP Content headers.
+
+pub mod content_encoding;
+
+mod encoding_directive;
+
+#[doc(inline)]
+pub use content_encoding::ContentEncoding;
+pub use encoding_directive::EncodingDirective;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -120,6 +120,7 @@ mod utils;
 
 pub mod cache;
 pub mod conditional;
+pub mod content;
 pub mod headers;
 pub mod mime;
 pub mod proxies;


### PR DESCRIPTION
Ref #99; [mdn](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Encoding#Directives); adds structured `Content-Encoding` headers under the `content` submodule. Thanks!

## Further work

This needs a follow-up PR to specify the `Accept-Encoding` header which uses weighted encoding directives. This may require adjustments to the `EncodingDirective` (or a separate structure alltogether) so we should hold off on publishing this patch until we have both working.

## Screenshots

![Screenshot_2020-08-20 http_types content - Rust](https://user-images.githubusercontent.com/2467194/90824822-45fb6b00-e338-11ea-9208-d75003a19672.png)
