### PR TITLE
Add `contains` to `HeaderValues`.

### DIFF
--- a/src/headers/header_values.rs
+++ b/src/headers/header_values.rs
@@ -29,6 +29,12 @@ impl HeaderValues {
         self.inner.get_mut(index)
     }
 
+    /// Returns `true` if there is a value corresponding to the specified `HeaderValue` in the list,
+    /// `false` otherwise.
+    pub fn contains(&self, value: &HeaderValue) -> bool {
+        self.inner.contains(value)
+    }
+
     /// Returns the last `HeaderValue`.
     pub fn last(&self) -> &HeaderValue {
         self.inner


### PR DESCRIPTION
A bit of syntax sugar to avoid having to create an iterator and loop through it to check for membership.