### PR TITLE
dont deny warnings during dev

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -97,7 +97,6 @@
 #![warn(missing_docs, unreachable_pub)]
 #![allow(clippy::new_without_default)]
 #![cfg_attr(backtrace, feature(backtrace))]
-#![cfg_attr(test, deny(warnings))]
 #![cfg_attr(feature = "docs", feature(doc_cfg))]
 #![doc(html_favicon_url = "https://yoshuawuyts.com/assets/http-rs/favicon.ico")]
 #![doc(html_logo_url = "https://yoshuawuyts.com/assets/http-rs/logo-rounded.png")]


### PR DESCRIPTION
We already have `-Dwarnings` during CI; warnings shouldn't block compilation during development.