### PR TITLE
Fix clippy warning

### DIFF
--- a/src/proxies/forwarded.rs
+++ b/src/proxies/forwarded.rs
@@ -243,10 +243,9 @@ impl<'a> Forwarded<'a> {
             _ => { /* extensions are allowed in the spec */ }
         }
 
-        if rest.starts_with(';') {
-            Ok(&rest[1..])
-        } else {
-            Ok(rest)
+        match rest.strip_prefix(';') {
+            Some(rest) => Ok(rest),
+            None => Ok(rest),
         }
     }
 


### PR DESCRIPTION
Fixes the clippy warning that caused https://github.com/http-rs/http-types/pull/249/checks?check_run_id=1172403843 to fail. Thanks!