### PR TITLE
Add `auth::{Authorization, AuthenticationScheme, BasicAuth, WwwAuthenticate, ProxyAuthorization, ProxyAuthenticate}`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,6 +41,7 @@ serde = { version = "1.0.106", features = ["derive"] }
 serde_urlencoded = "0.7.0"
 rand = "0.7.3"
 serde_qs = "0.7.0"
+base64 = "0.13.0"
 
 [dev-dependencies]
 http = "0.2.0"

--- a/src/auth/authentication_scheme.rs
+++ b/src/auth/authentication_scheme.rs
@@ -7,25 +7,25 @@ use crate::bail;
 #[derive(Debug, PartialEq, Eq)]
 #[non_exhaustive]
 pub enum AuthenticationScheme {
-    /// Basic auth
+    /// [RFC7617](https://tools.ietf.org/html/rfc7617) Basic auth
     Basic,
-    /// Bearer auth
+    /// [RFC6750](https://tools.ietf.org/html/rfc6750) Bearer auth
     Bearer,
-    /// Digest auth
+    /// [RFC7616](https://tools.ietf.org/html/rfc7616) Digest auth
     Digest,
-    /// HOBA
+    /// [RFC7486](https://tools.ietf.org/html/rfc7486) HTTP Origin-Bound Authentication
     Hoba,
-    /// Mutual auth
+    /// [RFC8120](https://tools.ietf.org/html/rfc8120) Mutual auth
     Mutual,
-    /// Negotiate auth
+    /// [RFC4559](https://tools.ietf.org/html/rfc4559) Negotiate auth
     Negotiate,
-    /// Oauth
+    /// [RFC5849](https://tools.ietf.org/html/rfc5849) Oauth
     OAuth,
-    /// SCRAM SHA1 auth
+    /// [RFC7804](https://tools.ietf.org/html/rfc7804) SCRAM SHA1 auth
     ScramSha1,
-    /// SCRAM SHA256 auth
+    /// [RFC7804](https://tools.ietf.org/html/rfc7804) SCRAM SHA256 auth
     ScramSha256,
-    /// Vapid auth
+    /// [RFC8292](https://tools.ietf.org/html/rfc8292) Vapid auth
     Vapid,
 }
 

--- a/src/auth/authentication_scheme.rs
+++ b/src/auth/authentication_scheme.rs
@@ -1,0 +1,67 @@
+use std::fmt::{self, Display};
+use std::str::FromStr;
+
+use crate::bail;
+
+/// HTTP Mutual Authentication Algorithms
+#[derive(Debug, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum AuthenticationScheme {
+    /// Basic auth
+    Basic,
+    /// Bearer auth
+    Bearer,
+    /// Digest auth
+    Digest,
+    /// HOBA
+    Hoba,
+    /// Mutual auth
+    Mutual,
+    /// Negotiate auth
+    Negotiate,
+    /// Oauth
+    OAuth,
+    /// SCRAM SHA1 auth
+    ScramSha1,
+    /// SCRAM SHA256 auth
+    ScramSha256,
+    /// Vapid auth
+    Vapid,
+}
+
+impl Display for AuthenticationScheme {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Basic => write!(f, "Basic"),
+            Self::Bearer => write!(f, "Bearer"),
+            Self::Digest => write!(f, "Digest"),
+            Self::Hoba => write!(f, "HOBA"),
+            Self::Mutual => write!(f, "Mutual"),
+            Self::Negotiate => write!(f, "Negotiate"),
+            Self::OAuth => write!(f, "OAuth"),
+            Self::ScramSha1 => write!(f, "SCRAM-SHA-1"),
+            Self::ScramSha256 => write!(f, "SCRAM-SHA-256"),
+            Self::Vapid => write!(f, "vapid"),
+        }
+    }
+}
+
+impl FromStr for AuthenticationScheme {
+    type Err = crate::Error;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "Basic" => Ok(Self::Basic),
+            "Bearer" => Ok(Self::Bearer),
+            "Digest" => Ok(Self::Digest),
+            "HOBA" => Ok(Self::Hoba),
+            "Mutual" => Ok(Self::Mutual),
+            "Negotiate" => Ok(Self::Negotiate),
+            "OAuth" => Ok(Self::OAuth),
+            "SCRAM-SHA-1" => Ok(Self::ScramSha1),
+            "SCRAM-SHA-256" => Ok(Self::ScramSha256),
+            "vapid" => Ok(Self::Vapid),
+            s => bail!("`{}` is not a recognized authentication scheme", s),
+        }
+    }
+}

--- a/src/auth/authentication_scheme.rs
+++ b/src/auth/authentication_scheme.rs
@@ -50,16 +50,19 @@ impl FromStr for AuthenticationScheme {
     type Err = crate::Error;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        match s {
-            "Basic" => Ok(Self::Basic),
-            "Bearer" => Ok(Self::Bearer),
-            "Digest" => Ok(Self::Digest),
-            "HOBA" => Ok(Self::Hoba),
-            "Mutual" => Ok(Self::Mutual),
-            "Negotiate" => Ok(Self::Negotiate),
-            "OAuth" => Ok(Self::OAuth),
-            "SCRAM-SHA-1" => Ok(Self::ScramSha1),
-            "SCRAM-SHA-256" => Ok(Self::ScramSha256),
+        // NOTE(yosh): matching here is lowercase as specified by RFC2617#section-1.2
+        // > [...] case-insensitive token to identify the authentication scheme [...]
+        // https://tools.ietf.org/html/rfc2617#section-1.2
+        match s.to_lowercase().as_str() {
+            "basic" => Ok(Self::Basic),
+            "bearer" => Ok(Self::Bearer),
+            "digest" => Ok(Self::Digest),
+            "hoba" => Ok(Self::Hoba),
+            "mutual" => Ok(Self::Mutual),
+            "negotiate" => Ok(Self::Negotiate),
+            "oauth" => Ok(Self::OAuth),
+            "scram-sha-1" => Ok(Self::ScramSha1),
+            "scram-sha-256" => Ok(Self::ScramSha256),
             "vapid" => Ok(Self::Vapid),
             s => bail!("`{}` is not a recognized authentication scheme", s),
         }

--- a/src/auth/authentication_scheme.rs
+++ b/src/auth/authentication_scheme.rs
@@ -1,10 +1,10 @@
 use std::fmt::{self, Display};
 use std::str::FromStr;
 
-use crate::bail;
+use crate::format_err;
 
 /// HTTP Mutual Authentication Algorithms
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Debug, PartialEq, Eq, Clone, Copy)]
 #[non_exhaustive]
 pub enum AuthenticationScheme {
     /// [RFC7617](https://tools.ietf.org/html/rfc7617) Basic auth
@@ -13,13 +13,13 @@ pub enum AuthenticationScheme {
     Bearer,
     /// [RFC7616](https://tools.ietf.org/html/rfc7616) Digest auth
     Digest,
-    /// [RFC7486](https://tools.ietf.org/html/rfc7486) HTTP Origin-Bound Authentication
+    /// [RFC7486](https://tools.ietf.org/html/rfc7486) HTTP Origin-Bound Authentication (HOBA)
     Hoba,
     /// [RFC8120](https://tools.ietf.org/html/rfc8120) Mutual auth
     Mutual,
     /// [RFC4559](https://tools.ietf.org/html/rfc4559) Negotiate auth
     Negotiate,
-    /// [RFC5849](https://tools.ietf.org/html/rfc5849) Oauth
+    /// [RFC5849](https://tools.ietf.org/html/rfc5849) OAuth
     OAuth,
     /// [RFC7804](https://tools.ietf.org/html/rfc7804) SCRAM SHA1 auth
     ScramSha1,
@@ -64,7 +64,11 @@ impl FromStr for AuthenticationScheme {
             "scram-sha-1" => Ok(Self::ScramSha1),
             "scram-sha-256" => Ok(Self::ScramSha256),
             "vapid" => Ok(Self::Vapid),
-            s => bail!("`{}` is not a recognized authentication scheme", s),
+            s => {
+                let mut err = format_err!("`{}` is not a recognized authentication scheme", s);
+                err.set_status(400);
+                Err(err)
+            }
         }
     }
 }

--- a/src/auth/authentication_scheme.rs
+++ b/src/auth/authentication_scheme.rs
@@ -1,7 +1,7 @@
 use std::fmt::{self, Display};
 use std::str::FromStr;
 
-use crate::format_err;
+use crate::bail2 as bail;
 
 /// HTTP Mutual Authentication Algorithms
 #[derive(Debug, PartialEq, Eq, Clone, Copy)]
@@ -64,11 +64,7 @@ impl FromStr for AuthenticationScheme {
             "scram-sha-1" => Ok(Self::ScramSha1),
             "scram-sha-256" => Ok(Self::ScramSha256),
             "vapid" => Ok(Self::Vapid),
-            s => {
-                let mut err = format_err!("`{}` is not a recognized authentication scheme", s);
-                err.set_status(400);
-                Err(err)
-            }
+            s => bail!(400, "`{}` is not a recognized authentication scheme", s),
         }
     }
 }

--- a/src/auth/authentication_scheme.rs
+++ b/src/auth/authentication_scheme.rs
@@ -1,7 +1,7 @@
 use std::fmt::{self, Display};
 use std::str::FromStr;
 
-use crate::bail2 as bail;
+use crate::bail_status as bail;
 
 /// HTTP Mutual Authentication Algorithms
 #[derive(Debug, PartialEq, Eq, Clone, Copy)]

--- a/src/auth/authorization.rs
+++ b/src/auth/authorization.rs
@@ -1,3 +1,132 @@
+use crate::auth::AuthenticationScheme;
+use crate::bail;
+use crate::headers::{HeaderName, HeaderValue, Headers, AUTHORIZATION};
+
 /// Credentials to authenticate a user agent with a server.
+///
+/// # Specifications
+///
+/// - [RFC 7235, section 4.2: Authorization](https://tools.ietf.org/html/rfc7232#section-3.4)
+///
+/// # Examples
+///
+/// ```
+/// # fn main() -> http_types::Result<()> {
+/// #
+/// use http_types::Response;
+/// use http_types::auth::{AuthenticationScheme, Authorization};
+///
+/// let scheme = AuthenticationScheme::Basic;
+/// let credentials = "0xdeadbeef202020";
+/// let authz = Authorization::new(scheme, credentials.into());
+///
+/// let mut res = Response::new(200);
+/// authz.apply(&mut res);
+///
+/// let authz = Authorization::from_headers(res)?.unwrap();
+///
+/// assert_eq!(authz.scheme(), AuthenticationScheme::Basic);
+/// assert_eq!(authz.credentials(), credentials);
+/// #
+/// # Ok(()) }
+/// ```
 #[derive(Debug)]
-pub struct Authorization;
+pub struct Authorization {
+    scheme: AuthenticationScheme,
+    credentials: String,
+}
+
+impl Authorization {
+    /// Create a new instance of `Authorization`.
+    pub fn new(scheme: AuthenticationScheme, credentials: String) -> Self {
+        Self {
+            scheme,
+            credentials,
+        }
+    }
+
+    /// Create a new instance from headers.
+    pub fn from_headers(headers: impl AsRef<Headers>) -> crate::Result<Option<Self>> {
+        let headers = match headers.as_ref().get(AUTHORIZATION) {
+            Some(headers) => headers,
+            None => return Ok(None),
+        };
+
+        // If we successfully parsed the header then there's always at least one
+        // entry. We want the last entry.
+        let value = headers.iter().last().unwrap();
+
+        let mut iter = value.as_str().splitn(2, ' ');
+        let scheme = iter.next();
+        let credential = iter.next();
+        let (scheme, credentials) = match (scheme, credential) {
+            (None, _) => bail!("Could not find scheme"),
+            (Some(_), None) => bail!("Could not find credentials"),
+            (Some(scheme), Some(credentials)) => (scheme.parse()?, credentials.to_owned()),
+        };
+
+        Ok(Some(Self {
+            scheme,
+            credentials,
+        }))
+    }
+
+    /// Sets the `If-Match` header.
+    pub fn apply(&self, mut headers: impl AsMut<Headers>) {
+        headers.as_mut().insert(self.name(), self.value());
+    }
+
+    /// Get the `HeaderName`.
+    pub fn name(&self) -> HeaderName {
+        AUTHORIZATION
+    }
+
+    /// Get the `HeaderValue`.
+    pub fn value(&self) -> HeaderValue {
+        let output = format!("{} {}", self.scheme, self.credentials);
+
+        // SAFETY: the internal string is validated to be ASCII.
+        unsafe { HeaderValue::from_bytes_unchecked(output.into()) }
+    }
+
+    /// Get the authorization scheme.
+    pub fn scheme(&self) -> AuthenticationScheme {
+        self.scheme
+    }
+
+    /// Get the authorization credentials.
+    pub fn credentials(&self) -> &str {
+        self.credentials.as_str()
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use crate::headers::Headers;
+
+    #[test]
+    fn smoke() -> crate::Result<()> {
+        let scheme = AuthenticationScheme::Basic;
+        let credentials = "0xdeadbeef202020";
+        let authz = Authorization::new(scheme, credentials.into());
+
+        let mut headers = Headers::new();
+        authz.apply(&mut headers);
+
+        let authz = Authorization::from_headers(headers)?.unwrap();
+
+        assert_eq!(authz.scheme(), AuthenticationScheme::Basic);
+        assert_eq!(authz.credentials(), credentials);
+        Ok(())
+    }
+
+    #[test]
+    fn bad_request_on_parse_error() -> crate::Result<()> {
+        let mut headers = Headers::new();
+        headers.insert(AUTHORIZATION, "<nori ate the tag. yum.>");
+        let err = Authorization::from_headers(headers).unwrap_err();
+        assert_eq!(err.status(), 400);
+        Ok(())
+    }
+}

--- a/src/auth/authorization.rs
+++ b/src/auth/authorization.rs
@@ -1,5 +1,5 @@
 use crate::auth::AuthenticationScheme;
-use crate::bail;
+use crate::bail2 as bail;
 use crate::headers::{HeaderName, HeaderValue, Headers, AUTHORIZATION};
 
 /// Credentials to authenticate a user agent with a server.
@@ -60,8 +60,8 @@ impl Authorization {
         let scheme = iter.next();
         let credential = iter.next();
         let (scheme, credentials) = match (scheme, credential) {
-            (None, _) => bail!("Could not find scheme"),
-            (Some(_), None) => bail!("Could not find credentials"),
+            (None, _) => bail!(400, "Could not find scheme"),
+            (Some(_), None) => bail!(400, "Could not find credentials"),
             (Some(scheme), Some(credentials)) => (scheme.parse()?, credentials.to_owned()),
         };
 

--- a/src/auth/authorization.rs
+++ b/src/auth/authorization.rs
@@ -1,0 +1,3 @@
+/// Credentials to authenticate a user agent with a server.
+#[derive(Debug)]
+pub struct Authorization;

--- a/src/auth/authorization.rs
+++ b/src/auth/authorization.rs
@@ -71,7 +71,7 @@ impl Authorization {
         }))
     }
 
-    /// Sets the `If-Match` header.
+    /// Sets the header.
     pub fn apply(&self, mut headers: impl AsMut<Headers>) {
         headers.as_mut().insert(self.name(), self.value());
     }
@@ -94,9 +94,19 @@ impl Authorization {
         self.scheme
     }
 
+    /// Set the authorization scheme.
+    pub fn set_scheme(&mut self, scheme: AuthenticationScheme) {
+        self.scheme = scheme;
+    }
+
     /// Get the authorization credentials.
     pub fn credentials(&self) -> &str {
         self.credentials.as_str()
+    }
+
+    /// Set the authorization credentials.
+    pub fn set_credentials(&mut self, credentials: String) {
+        self.credentials = credentials;
     }
 }
 

--- a/src/auth/authorization.rs
+++ b/src/auth/authorization.rs
@@ -6,7 +6,7 @@ use crate::headers::{HeaderName, HeaderValue, Headers, AUTHORIZATION};
 ///
 /// # Specifications
 ///
-/// - [RFC 7235, section 4.2: Authorization](https://tools.ietf.org/html/rfc7232#section-3.4)
+/// - [RFC 7235, section 4.2: Authorization](https://tools.ietf.org/html/rfc7235#section-4.2)
 ///
 /// # Examples
 ///

--- a/src/auth/authorization.rs
+++ b/src/auth/authorization.rs
@@ -1,5 +1,5 @@
 use crate::auth::AuthenticationScheme;
-use crate::bail2 as bail;
+use crate::bail_status as bail;
 use crate::headers::{HeaderName, HeaderValue, Headers, AUTHORIZATION};
 
 /// Credentials to authenticate a user agent with a server.

--- a/src/auth/basic_auth.rs
+++ b/src/auth/basic_auth.rs
@@ -1,0 +1,147 @@
+use crate::auth::{AuthenticationScheme, Authorization};
+use crate::format_err;
+use crate::headers::{HeaderName, HeaderValue, Headers, AUTHORIZATION};
+use crate::Status;
+
+/// HTTP Basic authorization.
+///
+/// # Specifications
+///
+/// - [RFC7617](https://tools.ietf.org/html/rfc7617)
+///
+/// # Examples
+///
+/// ```
+/// # fn main() -> http_types::Result<()> {
+/// #
+/// use http_types::Response;
+/// use http_types::auth::{AuthenticationScheme, BasicAuth};
+///
+/// let username = "nori";
+/// let password = "secret_fish!!";
+/// let authz = BasicAuth::new(username, Some(password));
+///
+/// let mut res = Response::new(200);
+/// authz.apply(&mut res);
+///
+/// let authz = BasicAuth::from_headers(res)?.unwrap();
+///
+/// assert_eq!(authz.username(), username);
+/// assert_eq!(authz.password(), Some(password));
+/// #
+/// # Ok(()) }
+/// ```
+#[derive(Debug)]
+pub struct BasicAuth {
+    username: String,
+    password: Option<String>,
+}
+
+impl BasicAuth {
+    /// Create a new instance of `BasicAuth`.
+    pub fn new<U, P>(username: U, password: Option<P>) -> Self
+    where
+        U: AsRef<str>,
+        P: AsRef<str>,
+    {
+        let username = username.as_ref().to_owned();
+        let password = password.map(|p| p.as_ref().to_owned());
+        Self { username, password }
+    }
+
+    /// Create a new instance from headers.
+    pub fn from_headers(headers: impl AsRef<Headers>) -> crate::Result<Option<Self>> {
+        let auth = match Authorization::from_headers(headers)? {
+            Some(auth) => auth,
+            None => return Ok(None),
+        };
+
+        let scheme = auth.scheme();
+        if !matches!(scheme, AuthenticationScheme::Basic) {
+            let mut err = format_err!("Expected basic auth scheme found `{}`", scheme);
+            err.set_status(400);
+            return Err(err);
+        }
+
+        let bytes = base64::decode(auth.credentials()).status(400)?;
+        let credentials = String::from_utf8(bytes).status(400)?;
+
+        let mut iter = credentials.splitn(2, ':');
+        let username = iter.next();
+        let password = iter.next();
+
+        let (username, password) = match (username, password) {
+            (Some(username), Some(password)) => (username.to_string(), Some(password.to_string())),
+            (Some(username), None) => (username.to_string(), None),
+            (None, _) => {
+                let mut err = format_err!("Expected basic auth to contain a username");
+                err.set_status(400);
+                return Err(err);
+            }
+        };
+
+        Ok(Some(Self { username, password }))
+    }
+
+    /// Sets the header.
+    pub fn apply(&self, mut headers: impl AsMut<Headers>) {
+        headers.as_mut().insert(self.name(), self.value());
+    }
+
+    /// Get the `HeaderName`.
+    pub fn name(&self) -> HeaderName {
+        AUTHORIZATION
+    }
+
+    /// Get the `HeaderValue`.
+    pub fn value(&self) -> HeaderValue {
+        let scheme = AuthenticationScheme::Basic;
+        let credentials = match self.password.as_ref() {
+            Some(password) => base64::encode(format!("{}:{}", self.username, password)),
+            None => base64::encode(self.username.clone()),
+        };
+        let auth = Authorization::new(scheme, credentials);
+        auth.value()
+    }
+
+    /// Get the username.
+    pub fn username(&self) -> &str {
+        self.username.as_str()
+    }
+
+    /// Get the password.
+    pub fn password(&self) -> Option<&str> {
+        self.password.as_deref()
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use crate::headers::Headers;
+
+    #[test]
+    fn smoke() -> crate::Result<()> {
+        let username = "nori";
+        let password = "secret_fish!!";
+        let authz = BasicAuth::new(username, Some(password));
+
+        let mut headers = Headers::new();
+        authz.apply(&mut headers);
+
+        let authz = BasicAuth::from_headers(headers)?.unwrap();
+
+        assert_eq!(authz.username(), username);
+        assert_eq!(authz.password(), Some(password));
+        Ok(())
+    }
+
+    #[test]
+    fn bad_request_on_parse_error() -> crate::Result<()> {
+        let mut headers = Headers::new();
+        headers.insert(AUTHORIZATION, "<nori ate the tag. yum.>");
+        let err = BasicAuth::from_headers(headers).unwrap_err();
+        assert_eq!(err.status(), 400);
+        Ok(())
+    }
+}

--- a/src/auth/basic_auth.rs
+++ b/src/auth/basic_auth.rs
@@ -1,7 +1,7 @@
 use crate::auth::{AuthenticationScheme, Authorization};
 use crate::headers::{HeaderName, HeaderValue, Headers, AUTHORIZATION};
 use crate::Status;
-use crate::{bail2 as bail, ensure2 as ensure};
+use crate::{bail_status as bail, ensure_status as ensure};
 
 /// HTTP Basic authorization.
 ///
@@ -73,7 +73,7 @@ impl BasicAuth {
 
         let (username, password) = match (username, password) {
             (Some(username), Some(password)) => (username.to_string(), password.to_string()),
-            (Some(_), None) => bail!(400, "Expected basic auth to a password"),
+            (Some(_), None) => bail!(400, "Expected basic auth to contain a password"),
             (None, _) => bail!(400, "Expected basic auth to contain a username"),
         };
 

--- a/src/auth/mod.rs
+++ b/src/auth/mod.rs
@@ -26,7 +26,9 @@
 mod authentication_scheme;
 mod authorization;
 mod basic_auth;
+mod www_authenticate;
 
 pub use authentication_scheme::AuthenticationScheme;
 pub use authorization::Authorization;
 pub use basic_auth::BasicAuth;
+pub use www_authenticate::WwwAuthenticate;

--- a/src/auth/mod.rs
+++ b/src/auth/mod.rs
@@ -1,7 +1,32 @@
 //! HTTP authentication and authorization.
+//!
+//! # Examples
+//!
+//! ```
+//! # fn main() -> http_types::Result<()> {
+//! #
+//! use http_types::Response;
+//! use http_types::auth::{AuthenticationScheme, BasicAuth};
+//!
+//! let username = "nori";
+//! let password = "secret_fish!!";
+//! let authz = BasicAuth::new(username, Some(password));
+//!
+//! let mut res = Response::new(200);
+//! authz.apply(&mut res);
+//!
+//! let authz = BasicAuth::from_headers(res)?.unwrap();
+//!
+//! assert_eq!(authz.username(), username);
+//! assert_eq!(authz.password(), Some(password));
+//! #
+//! # Ok(()) }
+//! ```
 
 mod authentication_scheme;
 mod authorization;
+mod basic_auth;
 
 pub use authentication_scheme::AuthenticationScheme;
 pub use authorization::Authorization;
+pub use basic_auth::BasicAuth;

--- a/src/auth/mod.rs
+++ b/src/auth/mod.rs
@@ -10,7 +10,7 @@
 //!
 //! let username = "nori";
 //! let password = "secret_fish!!";
-//! let authz = BasicAuth::new(username, Some(password));
+//! let authz = BasicAuth::new(username, password);
 //!
 //! let mut res = Response::new(200);
 //! authz.apply(&mut res);
@@ -18,7 +18,7 @@
 //! let authz = BasicAuth::from_headers(res)?.unwrap();
 //!
 //! assert_eq!(authz.username(), username);
-//! assert_eq!(authz.password(), Some(password));
+//! assert_eq!(authz.password(), password);
 //! #
 //! # Ok(()) }
 //! ```

--- a/src/auth/mod.rs
+++ b/src/auth/mod.rs
@@ -1,0 +1,7 @@
+//! HTTP authentication and authorization.
+
+mod authentication_scheme;
+mod authorization;
+
+pub use authentication_scheme::AuthenticationScheme;
+pub use authorization::Authorization;

--- a/src/auth/www_authenticate.rs
+++ b/src/auth/www_authenticate.rs
@@ -1,0 +1,169 @@
+use crate::auth::AuthenticationScheme;
+use crate::bail2 as bail;
+use crate::headers::{HeaderName, HeaderValue, Headers, WWW_AUTHENTICATE};
+
+/// Define the authentication method that should be used to gain access to a
+/// resource.
+///
+/// # Specifications
+///
+/// - [RFC 7235, section 4.1: WWW-Authenticate](https://tools.ietf.org/html/rfc7235#section-4.1)
+///
+/// # Implementation Notes
+///
+/// This implementation only encodes and parses a single authentication method,
+/// further authorization methods are ignored. It also always passes the utf-8 encoding flag.
+///
+/// # Examples
+///
+/// ```
+/// # fn main() -> http_types::Result<()> {
+/// #
+/// use http_types::Response;
+/// use http_types::auth::{AuthenticationScheme, WwwAuthenticate};
+///
+/// let scheme = AuthenticationScheme::Basic;
+/// let realm = "Access to the staging site";
+/// let authz = WwwAuthenticate::new(scheme, realm.into());
+///
+/// let mut res = Response::new(200);
+/// authz.apply(&mut res);
+///
+/// let authz = WwwAuthenticate::from_headers(res)?.unwrap();
+///
+/// assert_eq!(authz.scheme(), AuthenticationScheme::Basic);
+/// assert_eq!(authz.realm(), realm);
+/// #
+/// # Ok(()) }
+/// ```
+#[derive(Debug)]
+pub struct WwwAuthenticate {
+    scheme: AuthenticationScheme,
+    realm: String,
+}
+
+impl WwwAuthenticate {
+    /// Create a new instance of `WwwAuthenticate`.
+    pub fn new(scheme: AuthenticationScheme, realm: String) -> Self {
+        Self { scheme, realm }
+    }
+
+    /// Create a new instance from headers.
+    pub fn from_headers(headers: impl AsRef<Headers>) -> crate::Result<Option<Self>> {
+        let headers = match headers.as_ref().get(WWW_AUTHENTICATE) {
+            Some(headers) => headers,
+            None => return Ok(None),
+        };
+
+        // If we successfully parsed the header then there's always at least one
+        // entry. We want the last entry.
+        let value = headers.iter().last().unwrap();
+
+        let mut iter = value.as_str().splitn(2, ' ');
+        let scheme = iter.next();
+        let credential = iter.next();
+        let (scheme, realm) = match (scheme, credential) {
+            (None, _) => bail!(400, "Could not find scheme"),
+            (Some(_), None) => bail!(400, "Could not find realm"),
+            (Some(scheme), Some(realm)) => (scheme.parse()?, realm.to_owned()),
+        };
+
+        let realm = realm.trim_start();
+        let realm = match realm.strip_prefix(r#"realm=""#) {
+            Some(realm) => realm,
+            None => bail!(400, "realm not found"),
+        };
+
+        let mut chars = realm.chars();
+        let mut closing_quote = false;
+        let realm = (&mut chars)
+            .take_while(|c| {
+                if c == &'"' {
+                    closing_quote = true;
+                    false
+                } else {
+                    true
+                }
+            })
+            .collect();
+        if !closing_quote {
+            bail!(400, r"Expected a closing quote");
+        }
+
+        Ok(Some(Self { scheme, realm }))
+    }
+
+    /// Sets the header.
+    pub fn apply(&self, mut headers: impl AsMut<Headers>) {
+        headers.as_mut().insert(self.name(), self.value());
+    }
+
+    /// Get the `HeaderName`.
+    pub fn name(&self) -> HeaderName {
+        WWW_AUTHENTICATE
+    }
+
+    /// Get the `HeaderValue`.
+    pub fn value(&self) -> HeaderValue {
+        let output = format!(r#"{} realm="{}", charset="UTF-8""#, self.scheme, self.realm);
+
+        // SAFETY: the internal string is validated to be ASCII.
+        unsafe { HeaderValue::from_bytes_unchecked(output.into()) }
+    }
+
+    /// Get the authorization scheme.
+    pub fn scheme(&self) -> AuthenticationScheme {
+        self.scheme
+    }
+
+    /// Set the authorization scheme.
+    pub fn set_scheme(&mut self, scheme: AuthenticationScheme) {
+        self.scheme = scheme;
+    }
+
+    /// Get the authorization realm.
+    pub fn realm(&self) -> &str {
+        self.realm.as_str()
+    }
+
+    /// Set the authorization realm.
+    pub fn set_realm(&mut self, realm: String) {
+        self.realm = realm;
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use crate::headers::Headers;
+
+    #[test]
+    fn smoke() -> crate::Result<()> {
+        let scheme = AuthenticationScheme::Basic;
+        let realm = "Access to the staging site";
+        let authz = WwwAuthenticate::new(scheme, realm.into());
+
+        let mut headers = Headers::new();
+        authz.apply(&mut headers);
+
+        assert_eq!(
+            headers["WWW-Authenticate"],
+            r#"Basic realm="Access to the staging site", charset="UTF-8""#
+        );
+
+        let authz = WwwAuthenticate::from_headers(headers)?.unwrap();
+
+        assert_eq!(authz.scheme(), AuthenticationScheme::Basic);
+        assert_eq!(authz.realm(), realm);
+        Ok(())
+    }
+
+    #[test]
+    fn bad_request_on_parse_error() -> crate::Result<()> {
+        let mut headers = Headers::new();
+        headers.insert(WWW_AUTHENTICATE, "<nori ate the tag. yum.>");
+        let err = WwwAuthenticate::from_headers(headers).unwrap_err();
+        assert_eq!(err.status(), 400);
+        Ok(())
+    }
+}

--- a/src/auth/www_authenticate.rs
+++ b/src/auth/www_authenticate.rs
@@ -1,5 +1,5 @@
 use crate::auth::AuthenticationScheme;
-use crate::bail2 as bail;
+use crate::bail_status as bail;
 use crate::headers::{HeaderName, HeaderValue, Headers, WWW_AUTHENTICATE};
 
 /// Define the authentication method that should be used to gain access to a

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -117,6 +117,7 @@ pub mod url {
 #[macro_use]
 mod utils;
 
+pub mod auth;
 pub mod cache;
 pub mod conditional;
 pub mod content;

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -122,7 +122,7 @@ macro_rules! ensure2 {
     };
     ($cond:expr, $status:literal, $msg:expr, $($arg:tt)*) => {
         if !$cond {
-            return $crate::private::Err($crate::format_err2!($status, $fmt, $($arg)*));
+            return $crate::private::Err($crate::format_err2!($status, $msg, $($arg)*));
         }
     };
 }
@@ -175,7 +175,7 @@ macro_rules! format_err2 {
         err
     }};
     ($status:literal, $msg:expr, $($arg:tt)*) => {{
-        let mut err = $crate::private::new_adhoc(format!($msg, $($arg)*))
+        let mut err = $crate::private::new_adhoc(format!($msg, $($arg)*));
         err.set_status($status);
         err
     }};

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -88,15 +88,15 @@ macro_rules! format_err {
 /// Return early with an error and a status code.
 #[doc(hidden)]
 #[macro_export]
-macro_rules! bail2 {
+macro_rules! bail_status {
     ($status:literal, $msg:literal $(,)?) => {{
-        return $crate::private::Err($crate::format_err2!($status, $msg));
+        return $crate::private::Err($crate::format_err_status!($status, $msg));
     }};
     ($status:literal, $msg:expr $(,)?) => {
-        return $crate::private::Err($crate::format_err2!($status, $msg));
+        return $crate::private::Err($crate::format_err_status!($status, $msg));
     };
     ($status:literal, $msg:expr, $($arg:tt)*) => {
-        return $crate::private::Err($crate::format_err2!($status, $msg, $($arg)*));
+        return $crate::private::Err($crate::format_err_status!($status, $msg, $($arg)*));
     };
 }
 
@@ -109,20 +109,20 @@ macro_rules! bail2 {
 /// rather than panicking.
 #[doc(hidden)]
 #[macro_export]
-macro_rules! ensure2 {
+macro_rules! ensure_status {
     ($cond:expr, $status:literal, $msg:literal $(,)?) => {
         if !$cond {
-            return $crate::private::Err($crate::format_err2!($status, $msg));
+            return $crate::private::Err($crate::format_err_status!($status, $msg));
         }
     };
     ($cond:expr, $status:literal, $msg:expr $(,)?) => {
         if !$cond {
-            return $crate::private::Err($crate::format_err2!($status, $msg));
+            return $crate::private::Err($crate::format_err_status!($status, $msg));
         }
     };
     ($cond:expr, $status:literal, $msg:expr, $($arg:tt)*) => {
         if !$cond {
-            return $crate::private::Err($crate::format_err2!($status, $msg, $($arg)*));
+            return $crate::private::Err($crate::format_err_status!($status, $msg, $($arg)*));
         }
     };
 }
@@ -136,20 +136,20 @@ macro_rules! ensure2 {
 /// rather than panicking.
 #[doc(hidden)]
 #[macro_export]
-macro_rules! ensure_eq2 {
+macro_rules! ensure_eq_status {
     ($left:expr, $right:expr, $status:literal, $msg:literal $(,)?) => {
         if $left != $right {
-            return $crate::private::Err($crate::format_err2!($status, $msg));
+            return $crate::private::Err($crate::format_err_status!($status, $msg));
         }
     };
     ($left:expr, $right:expr, $status:literal, $msg:expr $(,)?) => {
         if $left != $right {
-            return $crate::private::Err($crate::format_err2!($status, $msg));
+            return $crate::private::Err($crate::format_err_status!($status, $msg));
         }
     };
     ($left:expr, $right:expr, $status:literal, $msg:expr, $($arg:tt)*) => {
         if $left != $right {
-            return $crate::private::Err($crate::format_err2!($status, $msg, $($arg)*));
+            return $crate::private::Err($crate::format_err_status!($status, $msg, $($arg)*));
         }
     };
 }
@@ -161,7 +161,7 @@ macro_rules! ensure_eq2 {
 /// `Debug` and `Display`.
 #[doc(hidden)]
 #[macro_export]
-macro_rules! format_err2 {
+macro_rules! format_err_status {
     ($status:literal, $msg:literal $(,)?) => {{
         // Handle $:literal as a special case to make cargo-expanded code more
         // concise in the common case.


### PR DESCRIPTION
Ref #99 

Adds HTTP basic auth and related structs for authentication.

BasicAuth is a specialization of `Authorization`; because schemes like oauth are rather elaborate, we've chosen to put them into separate structs.

Thanks!

## Screenshots

![Screenshot_2020-10-01 http_types auth - Rust](https://user-images.githubusercontent.com/2467194/94826732-e8af0b00-0407-11eb-9982-e11ec9fc0426.png)
