### PR TITLE
Add `content::ContentLength`

### DIFF
--- a/src/content/content_length.rs
+++ b/src/content/content_length.rs
@@ -30,6 +30,7 @@ pub struct ContentLength {
     length: usize,
 }
 
+#[allow(clippy::len_without_is_empty)]
 impl ContentLength {
     /// Create a new instance of `Authorization`.
     pub fn new(length: usize) -> Self {
@@ -71,6 +72,11 @@ impl ContentLength {
     /// Get the content length.
     pub fn len(&self) -> usize {
         self.length
+    }
+
+    /// Set the content length.
+    pub fn set_len(&mut self, len: usize) {
+        self.length = len;
     }
 }
 

--- a/src/content/content_length.rs
+++ b/src/content/content_length.rs
@@ -1,7 +1,7 @@
 use crate::headers::{HeaderName, HeaderValue, Headers, CONTENT_LENGTH};
 use crate::Status;
 
-/// Credentials to authenticate a user agent with a server.
+/// The size of the entity-body, in bytes, sent to the recipient.
 ///
 /// # Specifications
 ///
@@ -27,13 +27,13 @@ use crate::Status;
 /// ```
 #[derive(Debug)]
 pub struct ContentLength {
-    length: usize,
+    length: u64,
 }
 
 #[allow(clippy::len_without_is_empty)]
 impl ContentLength {
-    /// Create a new instance of `Authorization`.
-    pub fn new(length: usize) -> Self {
+    /// Create a new instance.
+    pub fn new(length: u64) -> Self {
         Self { length }
     }
 
@@ -70,12 +70,12 @@ impl ContentLength {
     }
 
     /// Get the content length.
-    pub fn len(&self) -> usize {
+    pub fn len(&self) -> u64 {
         self.length
     }
 
     /// Set the content length.
-    pub fn set_len(&mut self, len: usize) {
+    pub fn set_len(&mut self, len: u64) {
         self.length = len;
     }
 }

--- a/src/content/content_length.rs
+++ b/src/content/content_length.rs
@@ -1,0 +1,102 @@
+use crate::headers::{HeaderName, HeaderValue, Headers, CONTENT_LENGTH};
+use crate::Status;
+
+/// Credentials to authenticate a user agent with a server.
+///
+/// # Specifications
+///
+/// - [RFC 7230, section 3.3.2: Content-Length](https://tools.ietf.org/html/rfc7230#section-3.3.2)
+///
+/// # Examples
+///
+/// ```
+/// # fn main() -> http_types::Result<()> {
+/// #
+/// use http_types::Response;
+/// use http_types::content::{ContentLength};
+///
+/// let content_len = ContentLength::new(12);
+///
+/// let mut res = Response::new(200);
+/// content_len.apply(&mut res);
+///
+/// let content_len = ContentLength::from_headers(res)?.unwrap();
+/// assert_eq!(content_len.len(), 12);
+/// #
+/// # Ok(()) }
+/// ```
+#[derive(Debug)]
+pub struct ContentLength {
+    length: usize,
+}
+
+impl ContentLength {
+    /// Create a new instance of `Authorization`.
+    pub fn new(length: usize) -> Self {
+        Self { length }
+    }
+
+    /// Create a new instance from headers.
+    pub fn from_headers(headers: impl AsRef<Headers>) -> crate::Result<Option<Self>> {
+        let headers = match headers.as_ref().get(CONTENT_LENGTH) {
+            Some(headers) => headers,
+            None => return Ok(None),
+        };
+
+        // If we successfully parsed the header then there's always at least one
+        // entry. We want the last entry.
+        let value = headers.iter().last().unwrap();
+        let length = value.as_str().trim().parse().status(400)?;
+        Ok(Some(Self { length }))
+    }
+
+    /// Sets the header.
+    pub fn apply(&self, mut headers: impl AsMut<Headers>) {
+        headers.as_mut().insert(self.name(), self.value());
+    }
+
+    /// Get the `HeaderName`.
+    pub fn name(&self) -> HeaderName {
+        CONTENT_LENGTH
+    }
+
+    /// Get the `HeaderValue`.
+    pub fn value(&self) -> HeaderValue {
+        let output = format!("{}", self.length);
+
+        // SAFETY: the internal string is validated to be ASCII.
+        unsafe { HeaderValue::from_bytes_unchecked(output.into()) }
+    }
+
+    /// Get the content length.
+    pub fn len(&self) -> usize {
+        self.length
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use crate::headers::Headers;
+
+    #[test]
+    fn smoke() -> crate::Result<()> {
+        let content_len = ContentLength::new(12);
+
+        let mut headers = Headers::new();
+        content_len.apply(&mut headers);
+
+        let content_len = ContentLength::from_headers(headers)?.unwrap();
+        assert_eq!(content_len.len(), 12);
+        Ok(())
+    }
+
+    #[test]
+    fn bad_request_on_parse_error() -> crate::Result<()> {
+        let mut headers = Headers::new();
+        headers.insert(CONTENT_LENGTH, "<nori ate the tag. yum.>");
+        let err = ContentLength::from_headers(headers).unwrap_err();
+        assert_eq!(err.status(), 400);
+        Ok(())
+    }
+}

--- a/src/content/mod.rs
+++ b/src/content/mod.rs
@@ -8,6 +8,7 @@
 pub mod accept_encoding;
 pub mod content_encoding;
 
+mod content_length;
 mod encoding;
 mod encoding_proposal;
 
@@ -15,5 +16,6 @@ mod encoding_proposal;
 pub use accept_encoding::AcceptEncoding;
 #[doc(inline)]
 pub use content_encoding::ContentEncoding;
+pub use content_length::ContentLength;
 pub use encoding::Encoding;
 pub use encoding_proposal::EncodingProposal;


### PR DESCRIPTION
ref #99 adds the typed `Content-Length` header. Thanks!