### PR TITLE
Add `content::ContentLocation` header

### DIFF
--- a/src/content/content_location.rs
+++ b/src/content/content_location.rs
@@ -1,0 +1,107 @@
+use crate::headers::{HeaderName, HeaderValue, Headers, CONTENT_LOCATION};
+use crate::{Status, Url};
+
+///
+/// # Specifications
+///
+/// - [RFC 7230, section 3.3.2: Content-Length](https://tools.ietf.org/html/rfc7230#section-3.3.2)
+///
+/// # Examples
+///
+/// ```
+/// # fn main() -> http_types::Result<()> {
+/// #
+/// use http_types::Response;
+/// use http_types::content::{ContentLocation};
+///
+/// let content_location = ContentLocation::new("https://example.net/".to_string());
+///
+/// let mut res = Response::new(200);
+/// content_location.apply(&mut res);
+///
+/// let content_location = ContentLocation::from_headers(res)?.unwrap();
+/// assert_eq!(content_location.location(), "https://example.net/");
+/// #
+/// # Ok(()) }
+/// ```
+#[derive(Debug)]
+pub struct ContentLocation {
+    url: String,
+}
+
+#[allow(clippy::len_without_is_empty)]
+impl ContentLocation {
+    /// Create a new instance of `Content-Location` header.
+    pub fn new(url: String) -> Self {
+        Self { url }
+    }
+
+    /// Create a new instance from headers.
+    pub fn from_headers(headers: impl AsRef<Headers>) -> crate::Result<Option<Self>> {
+        let headers = match headers.as_ref().get(CONTENT_LOCATION) {
+            Some(headers) => headers,
+            None => return Ok(None),
+        };
+
+        // If we successfully parsed the header then there's always at least one
+        // entry. We want the last entry.
+        let value = headers.iter().last().unwrap();
+        let url = Url::parse(value.as_str().trim()).status(400)?;
+        Ok(Some(Self { url : url.into_string() }))
+    }
+
+    /// Sets the header.
+    pub fn apply(&self, mut headers: impl AsMut<Headers>) {
+        headers.as_mut().insert(self.name(), self.value());
+    }
+
+    /// Get the `HeaderName`.
+    pub fn name(&self) -> HeaderName {
+        CONTENT_LOCATION
+    }
+
+    /// Get the `HeaderValue`.
+    pub fn value(&self) -> HeaderValue {
+        let output = format!("{}", self.url);
+
+        // SAFETY: the internal string is validated to be ASCII.
+        unsafe { HeaderValue::from_bytes_unchecked(output.into()) }
+    }
+
+    /// Get the url.
+    pub fn location(&self) -> String {
+        String::from(&self.url)
+    }
+
+    /// Set the url.
+    pub fn set_location(&mut self, location: &str) {
+        self.url = location.to_string();
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use crate::headers::Headers;
+
+    #[test]
+    fn smoke() -> crate::Result<()> {
+        let content_location = ContentLocation::new("https://example.net/test".to_string());
+
+        let mut headers = Headers::new();
+        content_location.apply(&mut headers);
+
+        let content_location = ContentLocation::from_headers(headers)?.unwrap();
+        assert_eq!(content_location.location(), "https://example.net/test");
+        Ok(())
+    }
+
+    #[test]
+    fn bad_request_on_parse_error() -> crate::Result<()> {
+        let mut headers = Headers::new();
+        headers.insert(CONTENT_LOCATION, "<nori ate the tag. yum.>");
+        let err = ContentLocation::from_headers(headers).unwrap_err();
+        assert_eq!(err.status(), 400);
+        Ok(())
+    }
+}

--- a/src/content/content_location.rs
+++ b/src/content/content_location.rs
@@ -22,7 +22,8 @@ use std::convert::TryInto;
 /// let mut res = Response::new(200);
 /// content_location.apply(&mut res);
 ///
-/// let content_location = ContentLocation::from_headers(Url::parse("https://example.net/").unwrap(),res)?.unwrap();
+/// let url = Url::parse("https://example.net/")?;
+/// let content_location = ContentLocation::from_headers(url, res)?.unwrap();
 /// assert_eq!(content_location.location(), "https://example.net/");
 /// #
 /// # Ok(()) }

--- a/src/content/content_location.rs
+++ b/src/content/content_location.rs
@@ -52,7 +52,7 @@ impl ContentLocation {
         // If we successfully parsed the header then there's always at least one
         // entry. We want the last entry.
         let value = headers.iter().last().unwrap();
-        let base = base_url.try_into().expect("Could not convert into a valid url");
+        let base = base_url.try_into()?;
         let url = base.join(value.as_str().trim()).status(400)?;
         Ok(Some(Self { url }))
     }

--- a/src/content/content_location.rs
+++ b/src/content/content_location.rs
@@ -1,6 +1,5 @@
 use crate::headers::{HeaderName, HeaderValue, Headers, CONTENT_LOCATION};
-use crate::{Error, StatusCode};
-use crate::{Status, Url};
+use crate::{bail_status as bail, Status, Url};
 
 use std::convert::TryInto;
 
@@ -54,11 +53,10 @@ impl ContentLocation {
         // If we successfully parsed the header then there's always at least one
         // entry. We want the last entry.
         let value = headers.iter().last().unwrap();
-        let base = base_url.try_into().map_err(|_| {
-            let mut err = Error::new_adhoc("Invalid base url provided");
-            err.set_status(StatusCode::BadRequest);
-            err
-        })?;
+        let base = match base_url.try_into() {
+            Ok(b) => b,
+            Err(_) => bail!(400, "Invalid base url provided"),
+        };
 
         let url = base.join(value.as_str().trim()).status(400)?;
         Ok(Some(Self { url }))

--- a/src/content/content_location.rs
+++ b/src/content/content_location.rs
@@ -14,7 +14,7 @@ use std::convert::TryInto;
 /// ```
 /// # fn main() -> http_types::Result<()> {
 /// #
-/// use http_types::Response;
+/// use http_types::{Response,Url};
 /// use http_types::content::{ContentLocation};
 ///
 /// let content_location = ContentLocation::new("https://example.net/".to_string());
@@ -22,7 +22,7 @@ use std::convert::TryInto;
 /// let mut res = Response::new(200);
 /// content_location.apply(&mut res);
 ///
-/// let content_location = ContentLocation::from_headers(res)?.unwrap();
+/// let content_location = ContentLocation::from_headers(Url::parse("https://example.net/").unwrap(),res)?.unwrap();
 /// assert_eq!(content_location.location(), "https://example.net/");
 /// #
 /// # Ok(()) }

--- a/src/content/content_location.rs
+++ b/src/content/content_location.rs
@@ -52,9 +52,14 @@ impl ContentLocation {
         // If we successfully parsed the header then there's always at least one
         // entry. We want the last entry.
         let value = headers.iter().last().unwrap();
-        let base = base_url.try_into()?;
-        let url = base.join(value.as_str().trim()).status(400)?;
-        Ok(Some(Self { url }))
+        let base = base_url.try_into().ok();
+        match base {
+            Some(base) => {
+                let url = base.join(value.as_str().trim()).status(400)?;
+                Ok(Some(Self { url }))
+            }
+            None => Ok(None),
+        }
     }
 
     /// Sets the header.

--- a/src/content/content_location.rs
+++ b/src/content/content_location.rs
@@ -4,7 +4,7 @@ use crate::{Status, Url};
 ///
 /// # Specifications
 ///
-/// - [RFC 7230, section 3.3.2: Content-Length](https://tools.ietf.org/html/rfc7230#section-3.3.2)
+/// - [RFC 7230, section 3.3.2: Content-Length](https://tools.ietf.org/html/rfc7231#section-3.1.4.2)
 ///
 /// # Examples
 ///
@@ -70,7 +70,7 @@ impl ContentLocation {
 
     /// Get the url.
     pub fn location(&self) -> String {
-        String::from(&self.url)
+        self.url.to_string()
     }
 
     /// Set the url.

--- a/src/content/content_location.rs
+++ b/src/content/content_location.rs
@@ -69,7 +69,7 @@ impl ContentLocation {
 
     /// Get the `HeaderValue`.
     pub fn value(&self) -> HeaderValue {
-        let output = format!("{}", self.url.as_str());
+        let output = self.url.to_string();
 
         // SAFETY: the internal string is validated to be ASCII.
         unsafe { HeaderValue::from_bytes_unchecked(output.into()) }

--- a/src/content/content_location.rs
+++ b/src/content/content_location.rs
@@ -52,7 +52,7 @@ impl ContentLocation {
         // If we successfully parsed the header then there's always at least one
         // entry. We want the last entry.
         let value = headers.iter().last().unwrap();
-        let base = base_url.try_into().unwrap();
+        let base = base_url.try_into()?;
         let url = base.join(value.as_str().trim()).status(400)?;
         Ok(Some(Self { url }))
     }

--- a/src/content/mod.rs
+++ b/src/content/mod.rs
@@ -10,6 +10,7 @@ pub mod content_encoding;
 
 mod encoding;
 mod encoding_proposal;
+mod content_location;
 
 #[doc(inline)]
 pub use accept_encoding::AcceptEncoding;
@@ -17,3 +18,4 @@ pub use accept_encoding::AcceptEncoding;
 pub use content_encoding::ContentEncoding;
 pub use encoding::Encoding;
 pub use encoding_proposal::EncodingProposal;
+pub use content_location::ContentLocation;

--- a/src/content/mod.rs
+++ b/src/content/mod.rs
@@ -8,14 +8,14 @@
 pub mod accept_encoding;
 pub mod content_encoding;
 
+mod content_location;
 mod encoding;
 mod encoding_proposal;
-mod content_location;
 
 #[doc(inline)]
 pub use accept_encoding::AcceptEncoding;
 #[doc(inline)]
 pub use content_encoding::ContentEncoding;
+pub use content_location::ContentLocation;
 pub use encoding::Encoding;
 pub use encoding_proposal::EncodingProposal;
-pub use content_location::ContentLocation;


### PR DESCRIPTION
Hi All, this is an attempt to make my small contribution to this awesome project 🙌 . This PR is inspired by https://github.com/http-rs/http-types/pull/253 ( I try to following the same approach ) and also ref to one of the headers listed on #99.

I have some question related to the field for the `ContentLocation` struct. Is ok to be a `String` and parse with the `Url` crate or is better to use another type ( like to be directly an `url` and just format in the `value` ) ? 

I'm new to rust and my code could be partial ( or totally 😄  ) wrong, so any feedback is welcome.
