### PR TITLE
make `Method` parse case insensitively

### DIFF
--- a/src/method.rs
+++ b/src/method.rs
@@ -70,7 +70,7 @@ impl FromStr for Method {
     type Err = crate::Error;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        match s {
+        match &*s.to_ascii_uppercase() {
             "GET" => Ok(Self::Get),
             "HEAD" => Ok(Self::Head),
             "POST" => Ok(Self::Post),


### PR DESCRIPTION
this is a small performance regression but other than that there's no reason _not_ to accept lowercase methods