### PR TITLE
Add `client_hints::SaveData` header

### DIFF
--- a/src/client_hints/mod.rs
+++ b/src/client_hints/mod.rs
@@ -1,0 +1,8 @@
+//! HTTP client hint headers.
+//!
+//! These headers are intended for proactive content negotiation allowing
+//! clients to indicate a list of device and agent specific preferences.
+
+mod save_data;
+
+pub use save_data::SaveData;

--- a/src/client_hints/save_data.rs
+++ b/src/client_hints/save_data.rs
@@ -1,0 +1,117 @@
+use crate::bail_status;
+use crate::headers::{HeaderName, HeaderValue, Headers, ToHeaderValues, SAVE_DATA};
+
+use std::fmt::Debug;
+use std::option;
+
+/// HTTP `SaveData` header
+///
+/// This header is considered "experimental" and may be subject to change as the
+/// spec evolves.
+///
+/// [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Save-Data)
+///
+/// # Specifications
+///
+/// - [draft-grigorik-http-client-hints-03, section 7: Save-Data](https://tools.ietf.org/html/draft-grigorik-http-client-hints-03#section-7)
+///
+/// # Examples
+///
+/// ```
+/// # fn main() -> http_types::Result<()> {
+/// #
+/// use http_types::Response;
+/// use http_types::client_hints::SaveData;
+///
+/// let expect = SaveData::new(true);
+///
+/// let mut res = Response::new(200);
+/// expect.apply(&mut res);
+///
+/// let expect = SaveData::from_headers(res)?.unwrap();
+/// assert_eq!(expect, SaveData::new(true));
+/// #
+/// # Ok(()) }
+/// ```
+#[derive(Debug, Ord, PartialOrd, Eq, PartialEq)]
+pub struct SaveData {
+    enabled: bool,
+}
+
+impl SaveData {
+    /// Create a new instance of `SaveData`.
+    pub fn new(enabled: bool) -> Self {
+        Self { enabled }
+    }
+
+    /// Create an instance of `SaveData` from a `Headers` instance.
+    pub fn from_headers(headers: impl AsRef<Headers>) -> crate::Result<Option<Self>> {
+        let headers = match headers.as_ref().get(SAVE_DATA) {
+            Some(headers) => headers,
+            None => return Ok(None),
+        };
+
+        // If we successfully parsed the header then there's always at least one
+        // entry. We want the last entry.
+        let header = headers.iter().last().unwrap();
+        let enabled = match header.as_str() {
+            "1" => true,
+            "0" => false,
+            _ => bail_status!(400, "malformed `SaveData` header"),
+        };
+
+        Ok(Some(Self { enabled }))
+    }
+
+    /// Insert a `HeaderName` + `HeaderValue` pair into a `Headers` instance.
+    pub fn apply(&self, mut headers: impl AsMut<Headers>) {
+        headers.as_mut().insert(SAVE_DATA, self.value());
+    }
+
+    /// Get the `HeaderName`.
+    pub fn name(&self) -> HeaderName {
+        SAVE_DATA
+    }
+
+    /// Get the `HeaderValue`.
+    pub fn value(&self) -> HeaderValue {
+        let value = if self.enabled { "1" } else { "0" };
+        // SAFETY: the internal string is validated to be ASCII.
+        unsafe { HeaderValue::from_bytes_unchecked(value.into()) }
+    }
+}
+
+impl ToHeaderValues for SaveData {
+    type Iter = option::IntoIter<HeaderValue>;
+    fn to_header_values(&self) -> crate::Result<Self::Iter> {
+        // A HeaderValue will always convert into itself.
+        Ok(self.value().to_header_values().unwrap())
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use crate::headers::Headers;
+
+    #[test]
+    fn smoke() -> crate::Result<()> {
+        let expect = SaveData::new(true);
+
+        let mut headers = Headers::new();
+        expect.apply(&mut headers);
+
+        let expect = SaveData::from_headers(headers)?.unwrap();
+        assert_eq!(expect, SaveData::new(true));
+        Ok(())
+    }
+
+    #[test]
+    fn bad_request_on_parse_error() -> crate::Result<()> {
+        let mut headers = Headers::new();
+        headers.insert(SAVE_DATA, "<nori ate the tag. yum.>");
+        let err = SaveData::from_headers(headers).unwrap_err();
+        assert_eq!(err.status(), 400);
+        Ok(())
+    }
+}

--- a/src/headers/constants.rs
+++ b/src/headers/constants.rs
@@ -138,6 +138,9 @@ pub const REFERER: HeaderName = HeaderName::from_lowercase_str("referer");
 ///  The `Retry-After` Header
 pub const RETRY_AFTER: HeaderName = HeaderName::from_lowercase_str("retry-after");
 
+///  The `Save-Data` Header
+pub const SAVE_DATA: HeaderName = HeaderName::from_lowercase_str("save-data");
+
 ///  The `Server` Header
 pub const SERVER: HeaderName = HeaderName::from_lowercase_str("server");
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -119,6 +119,7 @@ mod utils;
 
 pub mod auth;
 pub mod cache;
+pub mod client_hints;
 pub mod conditional;
 pub mod content;
 pub mod headers;


### PR DESCRIPTION
Adds the `client_hints::SaveData` header. Ref #99. Thanks!