### PR TITLE
Implement `ToHeaderValues` for more string types

### DIFF
--- a/src/headers/to_header_values.rs
+++ b/src/headers/to_header_values.rs
@@ -54,10 +54,7 @@ impl ToHeaderValues for String {
     type Iter = option::IntoIter<HeaderValue>;
 
     fn to_header_values(&self) -> crate::Result<Self::Iter> {
-        let value = self
-            .parse()
-            .map_err(|err| io::Error::new(io::ErrorKind::Other, err))?;
-        Ok(Some(value).into_iter())
+        self.as_str().to_header_values()
     }
 }
 
@@ -65,10 +62,7 @@ impl ToHeaderValues for &String {
     type Iter = option::IntoIter<HeaderValue>;
 
     fn to_header_values(&self) -> crate::Result<Self::Iter> {
-        let value = self
-            .parse()
-            .map_err(|err| io::Error::new(io::ErrorKind::Other, err))?;
-        Ok(Some(value).into_iter())
+        self.as_str().to_header_values()
     }
 }
 

--- a/src/headers/to_header_values.rs
+++ b/src/headers/to_header_values.rs
@@ -2,6 +2,7 @@ use std::io;
 use std::iter;
 use std::option;
 use std::slice;
+use std::borrow::Cow;
 
 use crate::headers::{HeaderValue, HeaderValues, Values};
 
@@ -50,6 +51,28 @@ impl<'a> ToHeaderValues for &'a str {
 }
 
 impl ToHeaderValues for String {
+    type Iter = option::IntoIter<HeaderValue>;
+
+    fn to_header_values(&self) -> crate::Result<Self::Iter> {
+        let value = self
+            .parse()
+            .map_err(|err| io::Error::new(io::ErrorKind::Other, err))?;
+        Ok(Some(value).into_iter())
+    }
+}
+
+impl ToHeaderValues for &String {
+    type Iter = option::IntoIter<HeaderValue>;
+
+    fn to_header_values(&self) -> crate::Result<Self::Iter> {
+        let value = self
+            .parse()
+            .map_err(|err| io::Error::new(io::ErrorKind::Other, err))?;
+        Ok(Some(value).into_iter())
+    }
+}
+
+impl ToHeaderValues for Cow<'_, str> {
     type Iter = option::IntoIter<HeaderValue>;
 
     fn to_header_values(&self) -> crate::Result<Self::Iter> {

--- a/src/headers/to_header_values.rs
+++ b/src/headers/to_header_values.rs
@@ -1,8 +1,8 @@
+use std::borrow::Cow;
 use std::io;
 use std::iter;
 use std::option;
 use std::slice;
-use std::borrow::Cow;
 
 use crate::headers::{HeaderValue, HeaderValues, Values};
 


### PR DESCRIPTION
Implements `ToHeaderValues` for more string types. Noticed that passing `&format!("{}", "value")` as the header value didn't work, but `format!("{}", "value").as_str()` does. This fixes that. Thanks!