### PR TITLE
feat: impl ToHeader for all typed headers

### DIFF
--- a/src/auth/authorization.rs
+++ b/src/auth/authorization.rs
@@ -110,6 +110,12 @@ impl Authorization {
     }
 }
 
+impl crate::headers::ToHeader for Authorization {
+    fn to_header(self) -> crate::Result<(HeaderName, HeaderValue)> {
+        Ok((self.name(), self.value()))
+    }
+}
+
 #[cfg(test)]
 mod test {
     use super::*;

--- a/src/auth/basic_auth.rs
+++ b/src/auth/basic_auth.rs
@@ -113,6 +113,12 @@ impl BasicAuth {
     }
 }
 
+impl crate::headers::ToHeader for BasicAuth {
+    fn to_header(self) -> crate::Result<(HeaderName, HeaderValue)> {
+        Ok((self.name(), self.value()))
+    }
+}
+
 #[cfg(test)]
 mod test {
     use super::*;

--- a/src/auth/www_authenticate.rs
+++ b/src/auth/www_authenticate.rs
@@ -132,6 +132,12 @@ impl WwwAuthenticate {
     }
 }
 
+impl crate::headers::ToHeader for WwwAuthenticate {
+    fn to_header(self) -> crate::Result<(HeaderName, HeaderValue)> {
+        Ok((self.name(), self.value()))
+    }
+}
+
 #[cfg(test)]
 mod test {
     use super::*;

--- a/src/cache/age.rs
+++ b/src/cache/age.rs
@@ -87,6 +87,12 @@ impl Age {
     }
 }
 
+impl crate::headers::ToHeader for Age {
+    fn to_header(self) -> crate::Result<(HeaderName, HeaderValue)> {
+        Ok((self.name(), self.value()))
+    }
+}
+
 impl ToHeaderValues for Age {
     type Iter = option::IntoIter<HeaderValue>;
     fn to_header_values(&self) -> crate::Result<Self::Iter> {

--- a/src/cache/cache_control/cache_control.rs
+++ b/src/cache/cache_control/cache_control.rs
@@ -104,6 +104,12 @@ impl CacheControl {
     }
 }
 
+impl crate::headers::ToHeader for CacheControl {
+    fn to_header(self) -> crate::Result<(HeaderName, HeaderValue)> {
+        Ok((self.name(), self.value()))
+    }
+}
+
 impl IntoIterator for CacheControl {
     type Item = CacheDirective;
     type IntoIter = IntoIter;

--- a/src/cache/clear_site_data/mod.rs
+++ b/src/cache/clear_site_data/mod.rs
@@ -142,6 +142,12 @@ impl ClearSiteData {
     }
 }
 
+impl crate::headers::ToHeader for ClearSiteData {
+    fn to_header(self) -> crate::Result<(HeaderName, HeaderValue)> {
+        Ok((self.name(), self.value()))
+    }
+}
+
 impl IntoIterator for ClearSiteData {
     type Item = ClearDirective;
     type IntoIter = IntoIter;

--- a/src/cache/expires.rs
+++ b/src/cache/expires.rs
@@ -90,6 +90,12 @@ impl Expires {
     }
 }
 
+impl crate::headers::ToHeader for Expires {
+    fn to_header(self) -> crate::Result<(HeaderName, HeaderValue)> {
+        Ok((self.name(), self.value()))
+    }
+}
+
 impl ToHeaderValues for Expires {
     type Iter = option::IntoIter<HeaderValue>;
     fn to_header_values(&self) -> crate::Result<Self::Iter> {

--- a/src/conditional/etag.rs
+++ b/src/conditional/etag.rs
@@ -130,6 +130,12 @@ impl ETag {
     }
 }
 
+impl crate::headers::ToHeader for ETag {
+    fn to_header(self) -> crate::Result<(HeaderName, HeaderValue)> {
+        Ok((self.name(), self.value()))
+    }
+}
+
 impl Display for ETag {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {

--- a/src/conditional/if_match.rs
+++ b/src/conditional/if_match.rs
@@ -134,6 +134,12 @@ impl IfMatch {
     }
 }
 
+impl crate::headers::ToHeader for IfMatch {
+    fn to_header(self) -> crate::Result<(HeaderName, HeaderValue)> {
+        Ok((self.name(), self.value()))
+    }
+}
+
 impl IntoIterator for IfMatch {
     type Item = ETag;
     type IntoIter = IntoIter;

--- a/src/conditional/if_modified_since.rs
+++ b/src/conditional/if_modified_since.rs
@@ -85,6 +85,12 @@ impl IfModifiedSince {
     }
 }
 
+impl crate::headers::ToHeader for IfModifiedSince {
+    fn to_header(self) -> crate::Result<(HeaderName, HeaderValue)> {
+        Ok((self.name(), self.value()))
+    }
+}
+
 impl ToHeaderValues for IfModifiedSince {
     type Iter = option::IntoIter<HeaderValue>;
     fn to_header_values(&self) -> crate::Result<Self::Iter> {

--- a/src/conditional/if_none_match.rs
+++ b/src/conditional/if_none_match.rs
@@ -140,6 +140,12 @@ impl IfNoneMatch {
     }
 }
 
+impl crate::headers::ToHeader for IfNoneMatch {
+    fn to_header(self) -> crate::Result<(HeaderName, HeaderValue)> {
+        Ok((self.name(), self.value()))
+    }
+}
+
 impl IntoIterator for IfNoneMatch {
     type Item = ETag;
     type IntoIter = IntoIter;

--- a/src/conditional/if_unmodified_since.rs
+++ b/src/conditional/if_unmodified_since.rs
@@ -85,6 +85,12 @@ impl IfUnmodifiedSince {
     }
 }
 
+impl crate::headers::ToHeader for IfUnmodifiedSince {
+    fn to_header(self) -> crate::Result<(HeaderName, HeaderValue)> {
+        Ok((self.name(), self.value()))
+    }
+}
+
 impl ToHeaderValues for IfUnmodifiedSince {
     type Iter = option::IntoIter<HeaderValue>;
     fn to_header_values(&self) -> crate::Result<Self::Iter> {

--- a/src/conditional/last_modified.rs
+++ b/src/conditional/last_modified.rs
@@ -84,6 +84,12 @@ impl LastModified {
     }
 }
 
+impl crate::headers::ToHeader for LastModified {
+    fn to_header(self) -> crate::Result<(HeaderName, HeaderValue)> {
+        Ok((self.name(), self.value()))
+    }
+}
+
 impl ToHeaderValues for LastModified {
     type Iter = option::IntoIter<HeaderValue>;
     fn to_header_values(&self) -> crate::Result<Self::Iter> {

--- a/src/conditional/vary.rs
+++ b/src/conditional/vary.rs
@@ -140,6 +140,12 @@ impl Vary {
     }
 }
 
+impl crate::headers::ToHeader for Vary {
+    fn to_header(self) -> crate::Result<(HeaderName, HeaderValue)> {
+        Ok((self.name(), self.value()))
+    }
+}
+
 impl IntoIterator for Vary {
     type Item = HeaderName;
     type IntoIter = IntoIter;

--- a/src/content/accept_encoding.rs
+++ b/src/content/accept_encoding.rs
@@ -182,6 +182,12 @@ impl AcceptEncoding {
     }
 }
 
+impl crate::headers::ToHeader for AcceptEncoding {
+    fn to_header(self) -> crate::Result<(HeaderName, HeaderValue)> {
+        Ok((self.name(), self.value()))
+    }
+}
+
 impl IntoIterator for AcceptEncoding {
     type Item = EncodingProposal;
     type IntoIter = IntoIter;

--- a/src/content/content_encoding.rs
+++ b/src/content/content_encoding.rs
@@ -80,6 +80,12 @@ impl ContentEncoding {
     }
 }
 
+impl crate::headers::ToHeader for ContentEncoding {
+    fn to_header(self) -> crate::Result<(HeaderName, HeaderValue)> {
+        Ok((self.name(), self.value()))
+    }
+}
+
 impl ToHeaderValues for ContentEncoding {
     type Iter = option::IntoIter<HeaderValue>;
     fn to_header_values(&self) -> crate::Result<Self::Iter> {

--- a/src/content/content_length.rs
+++ b/src/content/content_length.rs
@@ -80,6 +80,12 @@ impl ContentLength {
     }
 }
 
+impl crate::headers::ToHeader for ContentLength {
+    fn to_header(self) -> crate::Result<(HeaderName, HeaderValue)> {
+        Ok((self.name(), self.value()))
+    }
+}
+
 #[cfg(test)]
 mod test {
     use super::*;

--- a/src/content/content_location.rs
+++ b/src/content/content_location.rs
@@ -99,6 +99,12 @@ impl ContentLocation {
     }
 }
 
+impl crate::headers::ToHeader for ContentLocation {
+    fn to_header(self) -> crate::Result<(HeaderName, HeaderValue)> {
+        Ok((self.name(), self.value()))
+    }
+}
+
 #[cfg(test)]
 mod test {
     use super::*;

--- a/src/headers/constants.rs
+++ b/src/headers/constants.rs
@@ -12,6 +12,12 @@ pub const CONTENT_LOCATION: HeaderName = HeaderName::from_lowercase_str("content
 pub const CONTENT_MD5: HeaderName = HeaderName::from_lowercase_str("content-md5");
 /// The `Content-Range` Header
 pub const CONTENT_RANGE: HeaderName = HeaderName::from_lowercase_str("content-range");
+/// The `Content-Security-Policy` Header
+pub const CONTENT_SECURITY_POLICY: HeaderName =
+    HeaderName::from_lowercase_str("content-security-policy");
+/// The `Content-Security-Policy-Report-Only` Header
+pub const CONTENT_SECURITY_POLICY_REPORT_ONLY: HeaderName =
+    HeaderName::from_lowercase_str("content-security-policy-report-only");
 /// The `Content-Type` Header
 pub const CONTENT_TYPE: HeaderName = HeaderName::from_lowercase_str("content-type");
 

--- a/src/headers/mod.rs
+++ b/src/headers/mod.rs
@@ -10,6 +10,7 @@ mod into_iter;
 mod iter;
 mod iter_mut;
 mod names;
+mod to_header;
 mod to_header_values;
 mod values;
 
@@ -22,5 +23,6 @@ pub use into_iter::IntoIter;
 pub use iter::Iter;
 pub use iter_mut::IterMut;
 pub use names::Names;
+pub use to_header::ToHeader;
 pub use to_header_values::ToHeaderValues;
 pub use values::Values;

--- a/src/headers/to_header.rs
+++ b/src/headers/to_header.rs
@@ -1,0 +1,24 @@
+use std::convert::TryInto;
+
+use crate::headers::{HeaderName, HeaderValue};
+
+/// A trait for objects which can be converted or resolved to a `HeaderName` and `HeaderValue` pair.
+pub trait ToHeader {
+    /// Converts this object to a `HeaderName` and `HeaderValue` pair.
+    fn to_header(self) -> crate::Result<(HeaderName, HeaderValue)>;
+}
+
+impl<N, V> ToHeader for (N, V)
+where
+    N: TryInto<HeaderName>,
+    V: TryInto<HeaderValue>,
+    <N as TryInto<HeaderName>>::Error: Into<crate::Error>,
+    <V as TryInto<HeaderValue>>::Error: Into<crate::Error>,
+{
+    fn to_header(self) -> crate::Result<(HeaderName, HeaderValue)> {
+        Ok((
+            self.0.try_into().map_err(Into::into)?,
+            self.1.try_into().map_err(Into::into)?,
+        ))
+    }
+}

--- a/src/other/date.rs
+++ b/src/other/date.rs
@@ -92,6 +92,12 @@ impl Date {
     }
 }
 
+impl crate::headers::ToHeader for Date {
+    fn to_header(self) -> crate::Result<(HeaderName, HeaderValue)> {
+        Ok((self.name(), self.value()))
+    }
+}
+
 impl From<Date> for SystemTime {
     fn from(date: Date) -> Self {
         date.at

--- a/src/proxies/forwarded.rs
+++ b/src/proxies/forwarded.rs
@@ -318,6 +318,11 @@ impl<'a> Forwarded<'a> {
         headers.as_mut().insert(FORWARDED, self);
     }
 
+    /// Get the `HeaderName`.
+    pub fn name(&self) -> HeaderName {
+        FORWARDED
+    }
+
     /// Builds a Forwarded header as a String.
     ///
     /// # Example
@@ -405,6 +410,12 @@ impl<'a> Forwarded<'a> {
     /// Returns the `by` field of this header
     pub fn by(&self) -> Option<&str> {
         self.by.as_deref()
+    }
+}
+
+impl<'a> crate::headers::ToHeader for Forwarded<'a> {
+    fn to_header(self) -> crate::Result<(HeaderName, HeaderValue)> {
+        Ok((self.name(), self.value()?.parse()?))
     }
 }
 

--- a/src/security/timing_allow_origin.rs
+++ b/src/security/timing_allow_origin.rs
@@ -162,6 +162,12 @@ impl TimingAllowOrigin {
     }
 }
 
+impl crate::headers::ToHeader for TimingAllowOrigin {
+    fn to_header(self) -> crate::Result<(HeaderName, HeaderValue)> {
+        Ok((self.name(), self.value()))
+    }
+}
+
 impl IntoIterator for TimingAllowOrigin {
     type Item = Url;
     type IntoIter = IntoIter;

--- a/src/server/allow.rs
+++ b/src/server/allow.rs
@@ -108,6 +108,12 @@ impl Allow {
     }
 }
 
+impl crate::headers::ToHeader for Allow {
+    fn to_header(self) -> crate::Result<(HeaderName, HeaderValue)> {
+        Ok((self.name(), self.value()))
+    }
+}
+
 impl IntoIterator for Allow {
     type Item = Method;
     type IntoIter = IntoIter;

--- a/src/trace/server_timing/mod.rs
+++ b/src/trace/server_timing/mod.rs
@@ -131,6 +131,12 @@ impl ServerTiming {
     }
 }
 
+impl crate::headers::ToHeader for ServerTiming {
+    fn to_header(self) -> crate::Result<(HeaderName, HeaderValue)> {
+        Ok((self.name(), self.value()))
+    }
+}
+
 impl IntoIterator for ServerTiming {
     type Item = Metric;
     type IntoIter = IntoIter;

--- a/src/trace/trace_context.rs
+++ b/src/trace/trace_context.rs
@@ -246,6 +246,12 @@ impl TraceContext {
     }
 }
 
+impl crate::headers::ToHeader for TraceContext {
+    fn to_header(self) -> crate::Result<(HeaderName, HeaderValue)> {
+        Ok((self.name(), self.value()))
+    }
+}
+
 impl fmt::Display for TraceContext {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(


### PR DESCRIPTION
This adds a `to_header(self) -> Result<(HeaderName, HeaderValue)>` for every Typed header, as well as anything that can `TryInto` a `(HeaderName, HeaderValue)` pair.

This should make typed headers nice to use with builds such as Surf's `RequestBuilder`, where `.header(name, value)` could be changed to `.header(ToHeader)` and also still work with a raw tuple.

----

I'm not 100% happy with this though - notably to have atrait like this either we need it to be consuming (i.e. consume a typed header) or it has to clone if a tuple is passed.

----

This also uncovers some unpleasantness with the current typed headers - not all of the implement the same methods, one _mutates_ in `.value()`, some return `String` or `Result<String>` instead of `HeaderValue`, one didn't implement `name()` either.

I think we should probably consider rolling that all into a trait.