### PR TITLE
Stabilize upgrade

### DIFF
--- a/src/headers/constants.rs
+++ b/src/headers/constants.rs
@@ -135,6 +135,9 @@ pub const PROXY_AUTHENTICATE: HeaderName = HeaderName::from_lowercase_str("proxy
 ///  The `Proxy-Authorization` Header
 pub const PROXY_AUTHORIZATION: HeaderName = HeaderName::from_lowercase_str("proxy-authorization");
 
+/// The `Proxy-Connection` Header
+pub const PROXY_CONNECTION: HeaderName = HeaderName::from_lowercase_str("proxy-connection");
+
 ///  The `Referer` Header
 pub const REFERER: HeaderName = HeaderName::from_lowercase_str("referer");
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -140,9 +140,7 @@ mod status_code;
 mod version;
 
 pub mod trace;
-cfg_unstable! {
-    pub mod upgrade;
-}
+pub mod upgrade;
 
 pub use body::Body;
 pub use error::{Error, Result};


### PR DESCRIPTION
Proposes to stabilize the `upgrade` submodule. I've included the changes suggested in https://github.com/http-rs/http-types/pull/287#discussion_r530688787, simplifying the internals. One downside of this, however, is that we remove the `Clone` derive. I'm not sure if this leads to a loss of functionality though, since derives are conditional, and we're now always boxing.

@jbr giving this a test run with your websockets tide patch would be much appreciated. That's what this API was designed for, and it allows us to gage whether this actually works as expected. Thanks!