### PR TITLE
Rename Body::from_file, add Body::from_file

### DIFF
--- a/src/body.rs
+++ b/src/body.rs
@@ -406,15 +406,12 @@ impl Body {
     /// # Ok(()) }) }
     /// ```
     #[cfg(all(feature = "fs", not(target_os = "unknown")))]
-    pub async fn from_file(mut file: async_std::fs::File) -> io::Result<Self>
-    {
+    pub async fn from_file(mut file: async_std::fs::File) -> io::Result<Self> {
         let len = file.metadata().await?.len();
 
         // Look at magic bytes first, fall back to
         // octet stream.
-        let mime = peek_mime(&mut file)
-            .await?
-            .unwrap_or(mime::BYTE_STREAM);
+        let mime = peek_mime(&mut file).await?.unwrap_or(mime::BYTE_STREAM);
 
         Ok(Self {
             mime,

--- a/tests/mime.rs
+++ b/tests/mime.rs
@@ -4,7 +4,7 @@ use http_types::{mime, Body, Response};
 
 #[async_std::test]
 async fn guess_plain_text_mime() -> io::Result<()> {
-    let body = Body::from_file("tests/fixtures/index.html").await?;
+    let body = Body::from_path("tests/fixtures/index.html").await?;
     let mut res = Response::new(200);
     res.set_body(body);
     assert_eq!(res.content_type(), Some(mime::HTML));
@@ -13,7 +13,7 @@ async fn guess_plain_text_mime() -> io::Result<()> {
 
 #[async_std::test]
 async fn guess_binary_mime() -> http_types::Result<()> {
-    let body = Body::from_file("tests/fixtures/nori.png").await?;
+    let body = Body::from_path("tests/fixtures/nori.png").await?;
     let mut res = Response::new(200);
     res.set_body(body);
     assert_eq!(res.content_type(), Some(mime::PNG));
@@ -27,7 +27,7 @@ async fn guess_binary_mime() -> http_types::Result<()> {
 
 #[async_std::test]
 async fn guess_mime_fallback() -> io::Result<()> {
-    let body = Body::from_file("tests/fixtures/unknown.custom").await?;
+    let body = Body::from_path("tests/fixtures/unknown.custom").await?;
     let mut res = Response::new(200);
     res.set_body(body);
     assert_eq!(res.content_type(), Some(mime::BYTE_STREAM));
@@ -36,7 +36,7 @@ async fn guess_mime_fallback() -> io::Result<()> {
 
 #[async_std::test]
 async fn parse_empty_files() -> http_types::Result<()> {
-    let body = Body::from_file("tests/fixtures/empty.custom").await?;
+    let body = Body::from_path("tests/fixtures/empty.custom").await?;
     let mut res = Response::new(200);
     res.set_body(body);
     assert_eq!(res.content_type(), Some(mime::BYTE_STREAM));


### PR DESCRIPTION
This PR renames `Body::from_file` to `Body::from_path`, and adds `Body::from_file`, which takes an `async_std::fs::File` like the name would suggest.

Fixes #185.

Semver-major.