### PR TITLE
Upgrade pin-project-lite to 0.2.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,7 @@ http = { version = "0.2.0", optional = true }
 anyhow = "1.0.26"
 cookie = { version = "0.14.0", features = ["percent-encode"] }
 infer = "0.2.3"
-pin-project-lite = "0.1.0"
+pin-project-lite = "0.2.0"
 url = { version = "2.1.1", features = ["serde"] }
 serde_json = "1.0.51"
 serde = { version = "1.0.106", features = ["derive"] }


### PR DESCRIPTION
Ran into this when looking for duplicate crate dependencies with
different versions.

I've confirmed that this change builds and passes all tests.