### PR TITLE
Allow omitting cookie support, with a new "cookies" feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,8 @@ docs = ["unstable"]
 unstable = []
 hyperium_http = ["http"]
 async_std = ["fs"]
-cookie-secure = ["cookie/secure"]
+cookies = ["cookie"]
+cookie-secure = ["cookies", "cookie/secure"]
 fs = ["async-std"]
 
 [dependencies]
@@ -34,7 +35,9 @@ async-channel = "1.5.1"
 http = { version = "0.2.0", optional = true }
 
 anyhow = "1.0.26"
-cookie = { version = "0.14.0", features = ["percent-encode"] }
+
+# features: cookies
+cookie = { version = "0.14.0", features = ["percent-encode"], optional = true }
 infer = "0.2.3"
 pin-project-lite = "0.2.0"
 url = { version = "2.1.1", features = ["serde"] }

--- a/src/headers/header_value.rs
+++ b/src/headers/header_value.rs
@@ -3,8 +3,10 @@ use std::fmt::{self, Debug, Display};
 use std::str::FromStr;
 
 use crate::headers::HeaderValues;
+#[cfg(feature = "cookies")]
+use crate::Cookie;
 use crate::Error;
-use crate::{Cookie, Mime};
+use crate::Mime;
 
 /// A header value.
 #[derive(Clone, Eq, PartialEq, Hash)]
@@ -54,6 +56,7 @@ impl From<Mime> for HeaderValue {
     }
 }
 
+#[cfg(feature = "cookies")]
 impl From<Cookie<'_>> for HeaderValue {
     fn from(cookie: Cookie<'_>) -> Self {
         HeaderValue {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -102,6 +102,7 @@
 #![doc(html_logo_url = "https://yoshuawuyts.com/assets/http-rs/logo-rounded.png")]
 
 /// HTTP cookies.
+#[cfg(feature = "cookies")]
 pub mod cookies {
     pub use cookie::*;
 }
@@ -163,6 +164,7 @@ pub use headers::Headers;
 #[doc(inline)]
 pub use crate::url::Url;
 
+#[cfg(feature = "cookies")]
 #[doc(inline)]
 pub use crate::cookies::Cookie;
 


### PR DESCRIPTION
The "cookie" crate introduces a substantial dependency tree. Allow
people to omit that dependency if they don't need it.