### PR TITLE
Add error handling to Request methods

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,11 +6,11 @@
 //! # Example
 //!
 //! ```
-//! # fn main() -> Result<(), http_types::url::ParseError> {
+//! # fn main() -> Result<(), http_types::Error> {
 //! #
-//! use http_types::{Url, Method, Request, Response, StatusCode};
+//! use http_types::{Method, Request, Response, StatusCode};
 //!
-//! let mut req = Request::new(Method::Get, Url::parse("https://example.com")?);
+//! let mut req = Request::new(Method::Get, "https://example.com")?;
 //! req.set_body("Hello, Nori!");
 //!
 //! let mut res = Response::new(StatusCode::Ok);

--- a/src/proxies/forwarded.rs
+++ b/src/proxies/forwarded.rs
@@ -44,7 +44,7 @@ impl<'a> Forwarded<'a> {
     /// ```rust
     /// # use http_types::{proxies::Forwarded, Method::Get, Request, Url, Result};
     /// # fn main() -> Result<()> {
-    /// let mut request = Request::new(Get, Url::parse("http://_/")?);
+    /// let mut request = Request::new(Get, "http://_/")?;
     /// request.insert_header(
     ///     "Forwarded",
     ///     r#"for=192.0.2.43, for="[2001:db8:cafe::17]", for=unknown;proto=https"#
@@ -58,7 +58,7 @@ impl<'a> Forwarded<'a> {
     /// ```rust
     /// # use http_types::{proxies::Forwarded, Method::Get, Request, Url, Result};
     /// # fn main() -> Result<()> {
-    /// let mut request = Request::new(Get, Url::parse("http://_/")?);
+    /// let mut request = Request::new(Get, "http://_/")?;
     /// request.insert_header("X-Forwarded-For", "192.0.2.43, 2001:db8:cafe::17, unknown");
     /// request.insert_header("X-Forwarded-Proto", "https");
     /// let forwarded = Forwarded::from_headers(&request)?.unwrap();
@@ -85,7 +85,7 @@ impl<'a> Forwarded<'a> {
     /// ```rust
     /// # use http_types::{proxies::Forwarded, Method::Get, Request, Url, Result};
     /// # fn main() -> Result<()> {
-    /// let mut request = Request::new(Get, Url::parse("http://_/")?);
+    /// let mut request = Request::new(Get, "http://_/")?;
     /// request.insert_header(
     ///     "Forwarded",
     ///     r#"for=192.0.2.43, for="[2001:db8:cafe::17]", for=unknown;proto=https"#
@@ -98,7 +98,7 @@ impl<'a> Forwarded<'a> {
     /// ```rust
     /// # use http_types::{proxies::Forwarded, Method::Get, Request, Url, Result};
     /// # fn main() -> Result<()> {
-    /// let mut request = Request::new(Get, Url::parse("http://_/")?);
+    /// let mut request = Request::new(Get, "http://_/")?;
     /// request.insert_header("X-Forwarded-For", "192.0.2.43, 2001:db8:cafe::17");
     /// assert!(Forwarded::from_forwarded_header(&request)?.is_none());
     /// # Ok(()) }
@@ -121,7 +121,7 @@ impl<'a> Forwarded<'a> {
     /// ```rust
     /// # use http_types::{proxies::Forwarded, Method::Get, Request, Url, Result};
     /// # fn main() -> Result<()> {
-    /// let mut request = Request::new(Get, Url::parse("http://_/")?);
+    /// let mut request = Request::new(Get, "http://_/")?;
     /// request.insert_header("X-Forwarded-For", "192.0.2.43, 2001:db8:cafe::17");
     /// let forwarded = Forwarded::from_headers(&request)?.unwrap();
     /// assert_eq!(forwarded.forwarded_for(), vec!["192.0.2.43", "[2001:db8:cafe::17]"]);
@@ -130,7 +130,7 @@ impl<'a> Forwarded<'a> {
     /// ```rust
     /// # use http_types::{proxies::Forwarded, Method::Get, Request, Url, Result};
     /// # fn main() -> Result<()> {
-    /// let mut request = Request::new(Get, Url::parse("http://_/")?);
+    /// let mut request = Request::new(Get, "http://_/")?;
     /// request.insert_header(
     ///     "Forwarded",
     ///     r#"for=192.0.2.43, for="[2001:db8:cafe::17]", for=unknown;proto=https"#
@@ -492,7 +492,6 @@ impl<'a> TryFrom<&'a str> for Forwarded<'a> {
 mod tests {
     use super::*;
     use crate::{Method::Get, Request, Response, Result};
-    use url::Url;
 
     #[test]
     fn parsing_for() -> Result<()> {
@@ -545,7 +544,7 @@ mod tests {
         assert_eq!(forwarded.forwarded_for(), vec!["client.com"]);
         assert_eq!(forwarded.host(), Some("host.com"));
         assert_eq!(forwarded.proto(), Some("https"));
-        assert!(matches!(forwarded, Forwarded{..}));
+        assert!(matches!(forwarded, Forwarded { .. }));
         Ok(())
     }
 
@@ -599,7 +598,7 @@ mod tests {
 
     #[test]
     fn from_x_headers() -> Result<()> {
-        let mut request = Request::new(Get, Url::parse("http://_/")?);
+        let mut request = Request::new(Get, "http://_/")?;
         request.append_header(X_FORWARDED_FOR, "192.0.2.43, 2001:db8:cafe::17");
         request.append_header(X_FORWARDED_PROTO, "gopher");
         let forwarded = Forwarded::from_headers(&request)?.unwrap();
@@ -644,13 +643,13 @@ mod tests {
         assert_eq!(forwarded.forwarded_for(), vec!["client"]);
         assert_eq!(forwarded.host(), Some("example.com"));
         assert_eq!(forwarded.proto(), Some("https"));
-        assert!(matches!(forwarded, Forwarded{..}));
+        assert!(matches!(forwarded, Forwarded { .. }));
         Ok(())
     }
 
     #[test]
     fn from_request() -> Result<()> {
-        let mut request = Request::new(Get, Url::parse("http://_/")?);
+        let mut request = Request::new(Get, "http://_/")?;
         request.append_header("Forwarded", "for=for");
 
         let forwarded = Forwarded::from_headers(&request)?.unwrap();
@@ -662,7 +661,7 @@ mod tests {
     #[test]
     fn owned_can_outlive_request() -> Result<()> {
         let forwarded = {
-            let mut request = Request::new(Get, Url::parse("http://_/")?);
+            let mut request = Request::new(Get, "http://_/")?;
             request.append_header("Forwarded", "for=for;by=by;host=host;proto=proto");
             Forwarded::from_headers(&request)?.unwrap().into_owned()
         };

--- a/src/trace/trace_context.rs
+++ b/src/trace/trace_context.rs
@@ -129,9 +129,9 @@ impl TraceContext {
     /// # fn main() -> http_types::Result<()> {
     /// #
     /// use http_types::trace::TraceContext;
-    /// use http_types::{Request, Response, Url, Method};
+    /// use http_types::{Method, Request, Response};
     ///
-    /// let mut req = Request::new(Method::Get, Url::parse("https://example.com").unwrap());
+    /// let mut req = Request::new(Method::Get, "https://example.com")?;
     /// req.insert_header(
     ///   "traceparent",
     ///   "00-0af7651916cd43dd8448eb211c80319c-00f067aa0ba902b7-01"

--- a/src/trailers.rs
+++ b/src/trailers.rs
@@ -27,7 +27,7 @@
 //! use async_std::task;
 //! use std::str::FromStr;
 //!
-//! let mut req = Request::new(Method::Get, Url::parse("https://example.com").unwrap());
+//! let mut req = Request::new(Method::Get, "https://example.com")?;
 //!
 //! let sender = req.send_trailers();
 //! let mut trailers = Trailers::new();

--- a/tests/querystring.rs
+++ b/tests/querystring.rs
@@ -1,4 +1,4 @@
-use http_types::{url::Url, Method};
+use http_types::Method;
 use serde::Deserialize;
 
 #[derive(Deserialize)]
@@ -14,10 +14,7 @@ struct OptionalParams {
 
 #[test]
 fn successfully_deserialize_query() {
-    let req = http_types::Request::new(
-        Method::Get,
-        Url::parse("http://example.com/?msg=Hello").unwrap(),
-    );
+    let req = http_types::Request::new(Method::Get, "http://example.com/?msg=Hello").unwrap();
 
     let params = req.query::<Params>();
     assert!(params.is_ok());
@@ -26,7 +23,7 @@ fn successfully_deserialize_query() {
 
 #[test]
 fn unsuccessfully_deserialize_query() {
-    let req = http_types::Request::new(Method::Get, Url::parse("http://example.com/").unwrap());
+    let req = http_types::Request::new(Method::Get, "http://example.com/").unwrap();
 
     let params = req.query::<Params>();
     assert!(params.is_err());
@@ -38,10 +35,8 @@ fn unsuccessfully_deserialize_query() {
 
 #[test]
 fn malformatted_query() {
-    let req = http_types::Request::new(
-        Method::Get,
-        Url::parse("http://example.com/?error=should_fail").unwrap(),
-    );
+    let req =
+        http_types::Request::new(Method::Get, "http://example.com/?error=should_fail").unwrap();
 
     let params = req.query::<Params>();
     assert!(params.is_err());
@@ -53,7 +48,7 @@ fn malformatted_query() {
 
 #[test]
 fn empty_query_string_for_struct_with_no_required_fields() {
-    let req = http_types::Request::new(Method::Get, Url::parse("http://example.com").unwrap());
+    let req = http_types::Request::new(Method::Get, "http://example.com").unwrap();
 
     let params = req.query::<OptionalParams>();
     assert!(params.is_ok());

--- a/tests/req_res_body.rs
+++ b/tests/req_res_body.rs
@@ -1,9 +1,9 @@
 use futures_lite::{future, AsyncReadExt};
-use http_types::{Body, Method, Request, Response, StatusCode, Url};
+use http_types::{Body, Method, Request, Response, StatusCode};
 
 #[test]
 fn test_req_res_set_body() {
-    let mut req = Request::new(Method::Get, Url::parse("http://example.com/").unwrap());
+    let mut req = Request::new(Method::Get, "http://example.com/").unwrap();
     req.set_body(Body::empty());
     let mut res = Response::new(StatusCode::Ok);
     res.set_body(req);
@@ -17,7 +17,7 @@ fn test_req_res_set_body() {
 
 #[test]
 fn test_req_res_take_replace_body() {
-    let mut req = Request::new(Method::Get, Url::parse("http://example.com/").unwrap());
+    let mut req = Request::new(Method::Get, "http://example.com/").unwrap();
     req.take_body();
     let mut res = Response::new(StatusCode::Ok);
     res.replace_body(req);


### PR DESCRIPTION
Make all associated Request methods return a Result<Self, Error> instead of Self and panicking.
Change docs and doc-tests to reflect this, and remove manual parsing in doc-tests and unit tests

Fixes #303