### PR TITLE
Refactor media type internals

### DIFF
--- a/src/mime/constants.rs
+++ b/src/mime/constants.rs
@@ -1,5 +1,6 @@
 use super::ParamKind;
 use crate::Mime;
+use std::borrow::Cow;
 
 macro_rules! utf8_mime_const {
     ($name:ident, $desc:expr, $base:expr, $sub:expr) => {
@@ -32,13 +33,10 @@ macro_rules! mime_const {
     (doc_expanded, $name:ident, $desc:expr, $base:expr, $sub:expr, $params:expr, $doccomment:expr) => {
         #[doc = $doccomment]
         pub const $name: Mime = Mime {
-            essence: String::new(),
-            basetype: String::new(),
-            subtype: String::new(),
+            essence: Cow::Borrowed(concat!($base, "/", $sub)),
+            basetype: Cow::Borrowed($base),
+            subtype: Cow::Borrowed($sub),
             params: $params,
-            static_essence: Some(concat!($base, "/", $sub)),
-            static_basetype: Some($base),
-            static_subtype: Some($sub),
         };
     };
 }

--- a/src/mime/constants.rs
+++ b/src/mime/constants.rs
@@ -1,4 +1,3 @@
-use super::ParamKind;
 use crate::Mime;
 use std::borrow::Cow;
 
@@ -10,18 +9,18 @@ macro_rules! utf8_mime_const {
             $desc,
             $base,
             $sub,
-            Some(ParamKind::Utf8),
+            true,
             ";charset=utf-8"
         );
     };
 }
 macro_rules! mime_const {
     ($name:ident, $desc:expr, $base:expr, $sub:expr) => {
-        mime_const!(with_params, $name, $desc, $base, $sub, None, "");
+        mime_const!(with_params, $name, $desc, $base, $sub, false, "");
     };
 
-    (with_params, $name:ident, $desc:expr, $base:expr, $sub:expr, $params:expr, $doccomment:expr) => {
-        mime_const!(doc_expanded, $name, $desc, $base, $sub, $params,
+    (with_params, $name:ident, $desc:expr, $base:expr, $sub:expr, $is_utf8:expr, $doccomment:expr) => {
+        mime_const!(doc_expanded, $name, $desc, $base, $sub, $is_utf8,
              concat!(
                 "Content-Type for ",
                 $desc,
@@ -30,13 +29,14 @@ macro_rules! mime_const {
         );
     };
 
-    (doc_expanded, $name:ident, $desc:expr, $base:expr, $sub:expr, $params:expr, $doccomment:expr) => {
+    (doc_expanded, $name:ident, $desc:expr, $base:expr, $sub:expr, $is_utf8:expr, $doccomment:expr) => {
         #[doc = $doccomment]
         pub const $name: Mime = Mime {
             essence: Cow::Borrowed(concat!($base, "/", $sub)),
             basetype: Cow::Borrowed($base),
             subtype: Cow::Borrowed($sub),
-            params: $params,
+            is_utf8: $is_utf8,
+            params: vec![],
         };
     };
 }

--- a/src/mime/parse.rs
+++ b/src/mime/parse.rs
@@ -1,3 +1,4 @@
+use std::borrow::Cow;
 use std::fmt;
 
 use super::{Mime, ParamKind, ParamName, ParamValue};
@@ -107,13 +108,10 @@ pub(crate) fn parse(input: &str) -> crate::Result<Mime> {
     }
 
     Ok(Mime {
-        essence: format!("{}/{}", &basetype, &subtype),
-        basetype,
-        subtype,
+        essence: Cow::Owned(format!("{}/{}", &basetype, &subtype)),
+        basetype: basetype.into(),
+        subtype: subtype.into(),
         params: params.map(ParamKind::Vec),
-        static_essence: None,
-        static_basetype: None,
-        static_subtype: None,
     })
 }
 
@@ -205,11 +203,7 @@ fn collect_http_quoted_string(mut input: &str) -> (String, &str) {
 
 /// Implementation of [WHATWG MIME serialization algorithm](https://mimesniff.spec.whatwg.org/#serializing-a-mime-type)
 pub(crate) fn format(mime_type: &Mime, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-    if let Some(essence) = mime_type.static_essence {
-        write!(f, "{}", essence)?
-    } else {
-        write!(f, "{}", &mime_type.essence)?
-    }
+    write!(f, "{}", &mime_type.essence)?;
     if let Some(params) = &mime_type.params {
         match params {
             ParamKind::Utf8 => write!(f, ";charset=utf-8")?,

--- a/tests/mime.rs
+++ b/tests/mime.rs
@@ -1,8 +1,8 @@
-#[cfg(features = "fs")]
+// #[cfg(features = "fs")]
 mod tests {
     use async_std::fs;
     use async_std::io;
-    use http_types::{mime, Body, Response};
+    use http_types::{mime, Body, Request, Response};
 
     #[async_std::test]
     async fn guess_plain_text_mime() -> io::Result<()> {
@@ -44,4 +44,13 @@ mod tests {
         assert_eq!(res.content_type(), Some(mime::BYTE_STREAM));
         Ok(())
     }
+
+    // #[test]
+    // fn match_mime_types() {
+    //     let req = Request::get("https://example.com");
+    //     match req.content_type() {
+    //         Some(mime::JSON) => {}
+    //         _ => {}
+    //     }
+    // }
 }

--- a/tests/mime.rs
+++ b/tests/mime.rs
@@ -1,8 +1,8 @@
-// #[cfg(features = "fs")]
+#[cfg(features = "fs")]
 mod tests {
     use async_std::fs;
     use async_std::io;
-    use http_types::{mime, Body, Request, Response};
+    use http_types::{mime, Body, Response};
 
     #[async_std::test]
     async fn guess_plain_text_mime() -> io::Result<()> {


### PR DESCRIPTION
This dedupes some internal logic of our media types, and refactors them to use `Cow`. This also moves utf-8 detection from a nested enum to a flag. Overall this simplifies the internals of our media types without any external API changes.

I was trying to address https://github.com/http-rs/tide/issues/27#issuecomment-750921221, but this is still blocked on the stdlib. However it seems that the only change we need to make now is to add `StructuralEq` to `Vec` and `Cow` so that they work in const contexts. Which should be slightly more feasible.