### PR TITLE
Implement the `Header` trait

### DIFF
--- a/src/auth/authorization.rs
+++ b/src/auth/authorization.rs
@@ -1,6 +1,6 @@
 use crate::auth::AuthenticationScheme;
 use crate::bail_status as bail;
-use crate::headers::{HeaderName, HeaderValue, Headers, AUTHORIZATION};
+use crate::headers::{Header, HeaderName, HeaderValue, Headers, AUTHORIZATION};
 
 /// Credentials to authenticate a user agent with a server.
 ///
@@ -78,7 +78,7 @@ impl Authorization {
 
     /// Get the `HeaderName`.
     pub fn name(&self) -> HeaderName {
-        AUTHORIZATION
+        self.header_name()
     }
 
     /// Get the `HeaderValue`.
@@ -107,6 +107,16 @@ impl Authorization {
     /// Set the authorization credentials.
     pub fn set_credentials(&mut self, credentials: String) {
         self.credentials = credentials;
+    }
+}
+
+impl Header for Authorization {
+    fn header_name(&self) -> HeaderName {
+        AUTHORIZATION
+    }
+
+    fn header_value(&self) -> HeaderValue {
+        self.value()
     }
 }
 

--- a/src/auth/basic_auth.rs
+++ b/src/auth/basic_auth.rs
@@ -1,5 +1,3 @@
-use anyhow::bail;
-
 use crate::auth::{AuthenticationScheme, Authorization};
 use crate::headers::{HeaderName, HeaderValue, Headers, AUTHORIZATION};
 use crate::Status;

--- a/src/auth/basic_auth.rs
+++ b/src/auth/basic_auth.rs
@@ -1,3 +1,5 @@
+use anyhow::bail;
+
 use crate::auth::{AuthenticationScheme, Authorization};
 use crate::headers::{HeaderName, HeaderValue, Headers, AUTHORIZATION};
 use crate::Status;
@@ -110,6 +112,16 @@ impl BasicAuth {
     /// Get the password.
     pub fn password(&self) -> &str {
         self.password.as_str()
+    }
+}
+
+impl crate::headers::Header for BasicAuth {
+    fn header_name(&self) -> HeaderName {
+        AUTHORIZATION
+    }
+
+    fn header_value(&self) -> HeaderValue {
+        self.value()
     }
 }
 

--- a/src/auth/www_authenticate.rs
+++ b/src/auth/www_authenticate.rs
@@ -132,6 +132,16 @@ impl WwwAuthenticate {
     }
 }
 
+impl crate::headers::Header for WwwAuthenticate {
+    fn header_name(&self) -> HeaderName {
+        WWW_AUTHENTICATE
+    }
+
+    fn header_value(&self) -> HeaderValue {
+        self.value()
+    }
+}
+
 #[cfg(test)]
 mod test {
     use super::*;

--- a/src/cache/age.rs
+++ b/src/cache/age.rs
@@ -95,6 +95,16 @@ impl ToHeaderValues for Age {
     }
 }
 
+impl crate::headers::Header for Age {
+    fn header_name(&self) -> HeaderName {
+        AGE
+    }
+
+    fn header_value(&self) -> HeaderValue {
+        self.value()
+    }
+}
+
 #[cfg(test)]
 mod test {
     use super::*;

--- a/src/cache/cache_control/cache_control.rs
+++ b/src/cache/cache_control/cache_control.rs
@@ -104,6 +104,15 @@ impl CacheControl {
     }
 }
 
+impl crate::headers::Header for CacheControl {
+    fn header_name(&self) -> HeaderName {
+        CACHE_CONTROL
+    }
+    fn header_value(&self) -> HeaderValue {
+        self.value()
+    }
+}
+
 impl IntoIterator for CacheControl {
     type Item = CacheDirective;
     type IntoIter = IntoIter;

--- a/src/cache/clear_site_data/mod.rs
+++ b/src/cache/clear_site_data/mod.rs
@@ -249,6 +249,15 @@ impl Debug for ClearSiteData {
     }
 }
 
+impl crate::headers::Header for ClearSiteData {
+    fn header_name(&self) -> HeaderName {
+        CLEAR_SITE_DATA
+    }
+    fn header_value(&self) -> HeaderValue {
+        self.value()
+    }
+}
+
 #[cfg(test)]
 mod test {
     use crate::cache::{ClearDirective, ClearSiteData};

--- a/src/cache/expires.rs
+++ b/src/cache/expires.rs
@@ -90,6 +90,15 @@ impl Expires {
     }
 }
 
+impl crate::headers::Header for Expires {
+    fn header_name(&self) -> HeaderName {
+        EXPIRES
+    }
+    fn header_value(&self) -> HeaderValue {
+        self.value()
+    }
+}
+
 impl ToHeaderValues for Expires {
     type Iter = option::IntoIter<HeaderValue>;
     fn to_header_values(&self) -> crate::Result<Self::Iter> {

--- a/src/conditional/etag.rs
+++ b/src/conditional/etag.rs
@@ -130,6 +130,15 @@ impl ETag {
     }
 }
 
+impl crate::headers::Header for ETag {
+    fn header_name(&self) -> HeaderName {
+        ETAG
+    }
+    fn header_value(&self) -> HeaderValue {
+        self.value()
+    }
+}
+
 impl Display for ETag {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {

--- a/src/conditional/if_match.rs
+++ b/src/conditional/if_match.rs
@@ -1,5 +1,7 @@
 //! Apply the HTTP method if the ETag matches.
 
+use http::header::IF_MATCH;
+
 use crate::conditional::ETag;
 use crate::headers::{HeaderName, HeaderValue, Headers, ToHeaderValues, IF_MATCH};
 
@@ -131,6 +133,15 @@ impl IfMatch {
         IterMut {
             inner: self.entries.iter_mut(),
         }
+    }
+}
+
+impl crate::headers::Header for IfMatch {
+    fn header_name(&self) -> HeaderName {
+        IF_MATCH
+    }
+    fn header_value(&self) -> HeaderValue {
+        self.value()
     }
 }
 

--- a/src/conditional/if_match.rs
+++ b/src/conditional/if_match.rs
@@ -1,7 +1,5 @@
 //! Apply the HTTP method if the ETag matches.
 
-use http::header::IF_MATCH;
-
 use crate::conditional::ETag;
 use crate::headers::{HeaderName, HeaderValue, Headers, ToHeaderValues, IF_MATCH};
 

--- a/src/conditional/if_modified_since.rs
+++ b/src/conditional/if_modified_since.rs
@@ -1,3 +1,5 @@
+use http::header::IF_MODIFIED_SINCE;
+
 use crate::headers::{HeaderName, HeaderValue, Headers, ToHeaderValues, IF_MODIFIED_SINCE};
 use crate::utils::{fmt_http_date, parse_http_date};
 
@@ -90,6 +92,15 @@ impl ToHeaderValues for IfModifiedSince {
     fn to_header_values(&self) -> crate::Result<Self::Iter> {
         // A HeaderValue will always convert into itself.
         Ok(self.value().to_header_values().unwrap())
+    }
+}
+
+impl crate::headers::Header for IfModifiedSince {
+    fn header_name(&self) -> HeaderName {
+        IF_MODIFIED_SINCE
+    }
+    fn header_value(&self) -> HeaderValue {
+        self.value()
     }
 }
 

--- a/src/conditional/if_modified_since.rs
+++ b/src/conditional/if_modified_since.rs
@@ -1,5 +1,3 @@
-use http::header::IF_MODIFIED_SINCE;
-
 use crate::headers::{HeaderName, HeaderValue, Headers, ToHeaderValues, IF_MODIFIED_SINCE};
 use crate::utils::{fmt_http_date, parse_http_date};
 

--- a/src/conditional/if_none_match.rs
+++ b/src/conditional/if_none_match.rs
@@ -3,8 +3,6 @@
 //! This is used to update caches or to prevent uploading a new resource when
 //! one already exists.
 
-use http::header::IF_NONE_MATCH;
-
 use crate::conditional::ETag;
 use crate::headers::{HeaderName, HeaderValue, Headers, ToHeaderValues, IF_NONE_MATCH};
 

--- a/src/conditional/if_none_match.rs
+++ b/src/conditional/if_none_match.rs
@@ -3,6 +3,8 @@
 //! This is used to update caches or to prevent uploading a new resource when
 //! one already exists.
 
+use http::header::IF_NONE_MATCH;
+
 use crate::conditional::ETag;
 use crate::headers::{HeaderName, HeaderValue, Headers, ToHeaderValues, IF_NONE_MATCH};
 
@@ -137,6 +139,15 @@ impl IfNoneMatch {
         IterMut {
             inner: self.entries.iter_mut(),
         }
+    }
+}
+
+impl crate::headers::Header for IfNoneMatch {
+    fn header_name(&self) -> HeaderName {
+        IF_NONE_MATCH
+    }
+    fn header_value(&self) -> HeaderValue {
+        self.value()
     }
 }
 

--- a/src/conditional/if_unmodified_since.rs
+++ b/src/conditional/if_unmodified_since.rs
@@ -1,5 +1,3 @@
-use http::header::IF_UNMODIFIED_SINCE;
-
 use crate::headers::{HeaderName, HeaderValue, Headers, ToHeaderValues, IF_UNMODIFIED_SINCE};
 use crate::utils::{fmt_http_date, parse_http_date};
 

--- a/src/conditional/if_unmodified_since.rs
+++ b/src/conditional/if_unmodified_since.rs
@@ -1,3 +1,5 @@
+use http::header::IF_UNMODIFIED_SINCE;
+
 use crate::headers::{HeaderName, HeaderValue, Headers, ToHeaderValues, IF_UNMODIFIED_SINCE};
 use crate::utils::{fmt_http_date, parse_http_date};
 
@@ -82,6 +84,15 @@ impl IfUnmodifiedSince {
 
         // SAFETY: the internal string is validated to be ASCII.
         unsafe { HeaderValue::from_bytes_unchecked(output.into()) }
+    }
+}
+
+impl crate::headers::Header for IfUnmodifiedSince {
+    fn header_name(&self) -> HeaderName {
+        IF_UNMODIFIED_SINCE
+    }
+    fn header_value(&self) -> HeaderValue {
+        self.value()
     }
 }
 

--- a/src/conditional/last_modified.rs
+++ b/src/conditional/last_modified.rs
@@ -1,3 +1,5 @@
+use http::header::LAST_MODIFIED;
+
 use crate::headers::{HeaderName, HeaderValue, Headers, ToHeaderValues, LAST_MODIFIED};
 use crate::utils::{fmt_http_date, parse_http_date};
 
@@ -81,6 +83,15 @@ impl LastModified {
 
         // SAFETY: the internal string is validated to be ASCII.
         unsafe { HeaderValue::from_bytes_unchecked(output.into()) }
+    }
+}
+
+impl crate::headers::Header for LastModified {
+    fn header_name(&self) -> HeaderName {
+        LAST_MODIFIED
+    }
+    fn header_value(&self) -> HeaderValue {
+        self.value()
     }
 }
 

--- a/src/conditional/last_modified.rs
+++ b/src/conditional/last_modified.rs
@@ -1,5 +1,3 @@
-use http::header::LAST_MODIFIED;
-
 use crate::headers::{HeaderName, HeaderValue, Headers, ToHeaderValues, LAST_MODIFIED};
 use crate::utils::{fmt_http_date, parse_http_date};
 

--- a/src/conditional/vary.rs
+++ b/src/conditional/vary.rs
@@ -140,6 +140,15 @@ impl Vary {
     }
 }
 
+impl crate::headers::Header for Vary {
+    fn header_name(&self) -> HeaderName {
+        VARY
+    }
+    fn header_value(&self) -> HeaderValue {
+        self.value()
+    }
+}
+
 impl IntoIterator for Vary {
     type Item = HeaderName;
     type IntoIter = IntoIter;

--- a/src/content/accept.rs
+++ b/src/content/accept.rs
@@ -9,6 +9,8 @@ use std::fmt::{self, Debug, Write};
 use std::option;
 use std::slice;
 
+use super::AcceptEncoding;
+
 /// Client header advertising which media types the client is able to understand.
 ///
 /// Using content negotiation, the server then selects one of the proposals, uses
@@ -186,6 +188,15 @@ impl Accept {
         IterMut {
             inner: self.entries.iter_mut(),
         }
+    }
+}
+
+impl crate::headers::Header for Accept {
+    fn header_name(&self) -> HeaderName {
+        ACCEPT
+    }
+    fn header_value(&self) -> HeaderValue {
+        self.value()
     }
 }
 

--- a/src/content/accept.rs
+++ b/src/content/accept.rs
@@ -9,8 +9,6 @@ use std::fmt::{self, Debug, Write};
 use std::option;
 use std::slice;
 
-use super::AcceptEncoding;
-
 /// Client header advertising which media types the client is able to understand.
 ///
 /// Using content negotiation, the server then selects one of the proposals, uses

--- a/src/content/accept_encoding.rs
+++ b/src/content/accept_encoding.rs
@@ -182,6 +182,15 @@ impl AcceptEncoding {
     }
 }
 
+impl crate::headers::Header for AcceptEncoding {
+    fn header_name(&self) -> HeaderName {
+        ACCEPT_ENCODING
+    }
+    fn header_value(&self) -> HeaderValue {
+        self.value()
+    }
+}
+
 impl IntoIterator for AcceptEncoding {
     type Item = EncodingProposal;
     type IntoIter = IntoIter;

--- a/src/content/content_encoding.rs
+++ b/src/content/content_encoding.rs
@@ -80,6 +80,15 @@ impl ContentEncoding {
     }
 }
 
+impl crate::headers::Header for ContentEncoding {
+    fn header_name(&self) -> HeaderName {
+        CONTENT_ENCODING
+    }
+    fn header_value(&self) -> HeaderValue {
+        self.value()
+    }
+}
+
 impl ToHeaderValues for ContentEncoding {
     type Iter = option::IntoIter<HeaderValue>;
     fn to_header_values(&self) -> crate::Result<Self::Iter> {

--- a/src/content/content_length.rs
+++ b/src/content/content_length.rs
@@ -80,6 +80,15 @@ impl ContentLength {
     }
 }
 
+impl crate::headers::Header for ContentLength {
+    fn header_name(&self) -> HeaderName {
+        CONTENT_LENGTH
+    }
+    fn header_value(&self) -> HeaderValue {
+        self.value()
+    }
+}
+
 #[cfg(test)]
 mod test {
     use super::*;

--- a/src/content/content_location.rs
+++ b/src/content/content_location.rs
@@ -99,6 +99,15 @@ impl ContentLocation {
     }
 }
 
+impl crate::headers::Header for ContentLocation {
+    fn header_name(&self) -> HeaderName {
+        CONTENT_LOCATION
+    }
+    fn header_value(&self) -> HeaderValue {
+        self.value()
+    }
+}
+
 #[cfg(test)]
 mod test {
     use super::*;

--- a/src/content/content_type.rs
+++ b/src/content/content_type.rs
@@ -91,6 +91,15 @@ impl ContentType {
     }
 }
 
+impl crate::headers::Header for ContentType {
+    fn header_name(&self) -> HeaderName {
+        CONTENT_TYPE
+    }
+    fn header_value(&self) -> HeaderValue {
+        self.value()
+    }
+}
+
 impl PartialEq<Mime> for ContentType {
     fn eq(&self, other: &Mime) -> bool {
         &self.media_type == other

--- a/src/headers/header.rs
+++ b/src/headers/header.rs
@@ -16,3 +16,26 @@ pub trait Header {
         headers.as_mut().insert(name, value);
     }
 }
+
+impl<'a, 'b> Header for (&'a str, &'b str) {
+    fn header_name(&self) -> HeaderName {
+        HeaderName::from(self.0)
+    }
+
+    fn header_value(&self) -> HeaderValue {
+        HeaderValue::from_bytes(self.1.to_owned().into_bytes())
+            .expect("String slice should be valid ASCII")
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn header_from_strings() {
+        let strings = ("Content-Length", "12");
+        assert_eq!(strings.header_name(), "Content-Length");
+        assert_eq!(strings.header_value(), "12");
+    }
+}

--- a/src/headers/header.rs
+++ b/src/headers/header.rs
@@ -1,0 +1,18 @@
+use crate::headers::{HeaderName, HeaderValue, Headers};
+
+/// A trait representing a [`HeaderName`] and [`HeaderValue`] pair.
+pub trait Header {
+    /// Access the header's name.
+    fn header_name(&self) -> HeaderName;
+
+    /// Access the header's value.
+    fn header_value(&self) -> HeaderValue;
+
+    /// Insert the header name and header value into something that looks like a
+    /// [`Headers`] map.
+    fn apply_header<H: AsMut<Headers>>(&self, mut headers: H) {
+        let name = self.header_name();
+        let value = self.header_value();
+        headers.as_mut().insert(name, value);
+    }
+}

--- a/src/headers/mod.rs
+++ b/src/headers/mod.rs
@@ -1,6 +1,7 @@
 //! HTTP headers.
 
 mod constants;
+mod header;
 mod header_name;
 mod header_value;
 mod header_values;
@@ -14,6 +15,7 @@ mod to_header_values;
 mod values;
 
 pub use constants::*;
+pub use header::Header;
 pub use header_name::HeaderName;
 pub use header_value::HeaderValue;
 pub use header_values::HeaderValues;

--- a/src/other/date.rs
+++ b/src/other/date.rs
@@ -92,6 +92,15 @@ impl Date {
     }
 }
 
+impl crate::headers::Header for Date {
+    fn header_name(&self) -> HeaderName {
+        DATE
+    }
+    fn header_value(&self) -> HeaderValue {
+        self.value()
+    }
+}
+
 impl From<Date> for SystemTime {
     fn from(date: Date) -> Self {
         date.at

--- a/src/other/expect.rs
+++ b/src/other/expect.rs
@@ -74,6 +74,15 @@ impl Expect {
     }
 }
 
+impl crate::headers::Header for Expect {
+    fn header_name(&self) -> HeaderName {
+        EXPECT
+    }
+    fn header_value(&self) -> HeaderValue {
+        self.value()
+    }
+}
+
 impl ToHeaderValues for Expect {
     type Iter = option::IntoIter<HeaderValue>;
     fn to_header_values(&self) -> crate::Result<Self::Iter> {

--- a/src/other/referer.rs
+++ b/src/other/referer.rs
@@ -104,6 +104,15 @@ impl Referer {
     }
 }
 
+impl crate::headers::Header for Referer {
+    fn header_name(&self) -> HeaderName {
+        REFERER
+    }
+    fn header_value(&self) -> HeaderValue {
+        self.value()
+    }
+}
+
 #[cfg(test)]
 mod test {
     use super::*;

--- a/src/other/source_map.rs
+++ b/src/other/source_map.rs
@@ -101,6 +101,15 @@ impl SourceMap {
     }
 }
 
+impl crate::headers::Header for SourceMap {
+    fn header_name(&self) -> HeaderName {
+        SOURCE_MAP
+    }
+    fn header_value(&self) -> HeaderValue {
+        self.value()
+    }
+}
+
 #[cfg(test)]
 mod test {
     use super::*;

--- a/src/proxies/forwarded.rs
+++ b/src/proxies/forwarded.rs
@@ -408,6 +408,18 @@ impl<'a> Forwarded<'a> {
     }
 }
 
+impl<'a> crate::headers::Header for Forwarded<'a> {
+    fn header_name(&self) -> HeaderName {
+        FORWARDED
+    }
+    fn header_value(&self) -> HeaderValue {
+        // NOTE(yosh): This will never panic because we always write into a string.
+        let output = self.value().unwrap();
+        // SAFETY: the internal string is validated to be ASCII.
+        unsafe { HeaderValue::from_bytes_unchecked(output.into()) }
+    }
+}
+
 fn parse_value(input: &str) -> (Option<Cow<'_, str>>, &str) {
     match parse_token(input) {
         (Some(token), rest) => (Some(Cow::Borrowed(token)), rest),

--- a/src/security/timing_allow_origin.rs
+++ b/src/security/timing_allow_origin.rs
@@ -162,6 +162,15 @@ impl TimingAllowOrigin {
     }
 }
 
+impl crate::headers::Header for TimingAllowOrigin {
+    fn header_name(&self) -> HeaderName {
+        TIMING_ALLOW_ORIGIN
+    }
+    fn header_value(&self) -> HeaderValue {
+        self.value()
+    }
+}
+
 impl IntoIterator for TimingAllowOrigin {
     type Item = Url;
     type IntoIter = IntoIter;

--- a/src/server/allow.rs
+++ b/src/server/allow.rs
@@ -108,6 +108,15 @@ impl Allow {
     }
 }
 
+impl crate::headers::Header for Allow {
+    fn header_name(&self) -> HeaderName {
+        ALLOW
+    }
+    fn header_value(&self) -> HeaderValue {
+        self.value()
+    }
+}
+
 impl IntoIterator for Allow {
     type Item = Method;
     type IntoIter = IntoIter;

--- a/src/trace/server_timing/mod.rs
+++ b/src/trace/server_timing/mod.rs
@@ -131,6 +131,15 @@ impl ServerTiming {
     }
 }
 
+impl crate::headers::Header for ServerTiming {
+    fn header_name(&self) -> HeaderName {
+        SERVER_TIMING
+    }
+    fn header_value(&self) -> HeaderValue {
+        self.value()
+    }
+}
+
 impl IntoIterator for ServerTiming {
     type Item = Metric;
     type IntoIter = IntoIter;

--- a/src/trace/trace_context.rs
+++ b/src/trace/trace_context.rs
@@ -246,6 +246,15 @@ impl TraceContext {
     }
 }
 
+impl crate::headers::Header for TraceContext {
+    fn header_name(&self) -> HeaderName {
+        TRACEPARENT
+    }
+    fn header_value(&self) -> HeaderValue {
+        self.value()
+    }
+}
+
 impl fmt::Display for TraceContext {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(

--- a/src/transfer/te.rs
+++ b/src/transfer/te.rs
@@ -33,7 +33,7 @@ use std::slice;
 /// let encoding = te.negotiate(&[Encoding::Brotli, Encoding::Gzip])?;
 /// encoding.apply(&mut res);
 ///
-/// assert_eq!(res["Content-Encoding"], "br");
+/// assert_eq!(res["Transfer-Encoding"], "br");
 /// #
 /// # Ok(()) }
 /// ```

--- a/src/transfer/te.rs
+++ b/src/transfer/te.rs
@@ -1,4 +1,4 @@
-use crate::headers::{HeaderName, HeaderValue, Headers, ToHeaderValues, ACCEPT_ENCODING};
+use crate::headers::{self, HeaderName, HeaderValue, Headers, ToHeaderValues};
 use crate::transfer::{Encoding, EncodingProposal, TransferEncoding};
 use crate::utils::sort_by_weight;
 use crate::{Error, StatusCode};
@@ -54,7 +54,7 @@ impl TE {
     /// Create an instance of `TE` from a `Headers` instance.
     pub fn from_headers(headers: impl AsRef<Headers>) -> crate::Result<Option<Self>> {
         let mut entries = vec![];
-        let headers = match headers.as_ref().get(ACCEPT_ENCODING) {
+        let headers = match headers.as_ref().get(headers::TE) {
             Some(headers) => headers,
             None => return Ok(None),
         };
@@ -138,12 +138,12 @@ impl TE {
 
     /// Sets the `Accept-Encoding` header.
     pub fn apply(&self, mut headers: impl AsMut<Headers>) {
-        headers.as_mut().insert(ACCEPT_ENCODING, self.value());
+        headers.as_mut().insert(headers::TE, self.value());
     }
 
     /// Get the `HeaderName`.
     pub fn name(&self) -> HeaderName {
-        ACCEPT_ENCODING
+        headers::TE
     }
 
     /// Get the `HeaderValue`.
@@ -180,6 +180,15 @@ impl TE {
         IterMut {
             inner: self.entries.iter_mut(),
         }
+    }
+}
+
+impl crate::headers::Header for TE {
+    fn header_name(&self) -> HeaderName {
+        headers::TE
+    }
+    fn header_value(&self) -> HeaderValue {
+        self.value()
     }
 }
 

--- a/src/transfer/transfer_encoding.rs
+++ b/src/transfer/transfer_encoding.rs
@@ -1,4 +1,4 @@
-use crate::headers::{HeaderName, HeaderValue, Headers, ToHeaderValues, CONTENT_ENCODING};
+use crate::headers::{HeaderName, HeaderValue, Headers, ToHeaderValues, TRANSFER_ENCODING};
 use crate::transfer::{Encoding, EncodingProposal};
 
 use std::fmt::{self, Debug};
@@ -42,7 +42,7 @@ impl TransferEncoding {
 
     /// Create a new instance from headers.
     pub fn from_headers(headers: impl AsRef<Headers>) -> crate::Result<Option<Self>> {
-        let headers = match headers.as_ref().get(CONTENT_ENCODING) {
+        let headers = match headers.as_ref().get(TRANSFER_ENCODING) {
             Some(headers) => headers,
             None => return Ok(None),
         };
@@ -61,12 +61,12 @@ impl TransferEncoding {
 
     /// Sets the `Content-Encoding` header.
     pub fn apply(&self, mut headers: impl AsMut<Headers>) {
-        headers.as_mut().insert(CONTENT_ENCODING, self.value());
+        headers.as_mut().insert(TRANSFER_ENCODING, self.value());
     }
 
     /// Get the `HeaderName`.
     pub fn name(&self) -> HeaderName {
-        CONTENT_ENCODING
+        TRANSFER_ENCODING
     }
 
     /// Get the `HeaderValue`.
@@ -77,6 +77,15 @@ impl TransferEncoding {
     /// Access the encoding kind.
     pub fn encoding(&self) -> Encoding {
         self.inner
+    }
+}
+
+impl crate::headers::Header for TransferEncoding {
+    fn header_name(&self) -> HeaderName {
+        TRANSFER_ENCODING
+    }
+    fn header_value(&self) -> HeaderValue {
+        self.value()
     }
 }
 


### PR DESCRIPTION
_Closes #286_

This PR implements the `Header` trait, creating a unified interface for the convention we had of `TypedHeader::{value, name, apply}`. This instead enables an interface of:

```rust
pub trait Header {
    fn header_name(&self) -> HeaderName;
    fn header_value(&self) -> HeaderValue;
    fn apply_header<H: AsMut<Headers>>(&self, mut headers: H);
}
```

Because `header_name` and `header_value` have to be implemented, `apply_header` has a default implementation. This should make it easier to keep up to date.

## Breaking changes

This patch doesn't break anything, but it does set us up for the 3.0.0 release. When we're ready to implement the 3.0.0 changes we should remove the `name`, `value` and `apply` methods in favor of keeping the trait only. This patch also explicitly chose to keep the `value` method implementation where it is in order to not create a massive merge conflict with #313.

## Bug fixes
This patch also fixes two bugs: a wrong header name in `TE` and in `TransferEncoding`. These have been adjusted and now use the right header name.

## Prior work
This patch serves as an alternative to https://github.com/http-rs/http-types/pull/285, implementing the design I referenced in https://github.com/http-rs/http-types/pull/285#issuecomment-750891612.

## Future directions
We should consider taking a look at the `headers` submodule in general. A few changes I think would be worthwhile:
- Move the header name constants from the crate root to be associated constants on `HeaderName` instead.
- Rename `Headers` to `HeaderMap`, matching the `hyperium/hyper` naming convention
- Consider changing the return type of `ToHeaderValues` from an associated iterator to be an instance of `HeaderValues` instead. The trait precedes the concrete type, and having a trait and a type with similar names be completely unrelated feels awkward.
- Do a pass on the typed headers to ensure the right `AsRef` and `AsMut` implementations are provided.
- Do a pass on the typed headers to clean up the examples, making them practical.
- Do a pass on the typed headers to link each header to their respective MDN documentation.
- Implement per-method examples on the typed headers.
- Create `http_types::headers` crate-level docs with an explainer of the different types in the crate.