### PR TITLE
Cargo.toml: Bump version to 3.0.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "http-types"
-version = "2.10.0"
+version = "3.0.0"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/http-rs/http-types"
 documentation = "https://docs.rs/http-types"


### PR DESCRIPTION
The http-types 3.0 development process will make various semver-major
changes. Having the version number bumped at the start of the
development cycle makes it easier to test those changes locally with
other crates, without treating the latest bits from git as still
compatible with the last 2.x version.