### PR TITLE
Mark `Method` as non-exhaustive

### DIFF
--- a/src/method.rs
+++ b/src/method.rs
@@ -11,6 +11,7 @@ use std::str::FromStr;
 /// [Mozilla docs]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Methods
 /// [RFC7231, Section 4]: https://tools.ietf.org/html/rfc7231#section-4
 /// [HTTP Method Registry]: https://www.iana.org/assignments/http-methods/http-methods.xhtml
+#[non_exhaustive]
 #[derive(Debug, Clone, Copy, Eq, PartialEq, Hash)]
 pub enum Method {
     /// The ACL method modifies the access control list (which can be read via the DAV:acl


### PR DESCRIPTION
https://github.com/http-rs/http-types/pull/332 has shown that new HTTP methods can be added by RFC, which is tracked in a [registry](https://www.iana.org/assignments/http-methods/http-methods.xhtml). We should acknowledge that this value may be extended in the future and mark the `Method` enum as `non_exhaustive`.