### PR TITLE
Cleanup headers

### DIFF
--- a/src/auth/authorization.rs
+++ b/src/auth/authorization.rs
@@ -13,7 +13,7 @@ use crate::headers::{Header, HeaderName, HeaderValue, Headers, AUTHORIZATION};
 /// ```
 /// # fn main() -> http_types::Result<()> {
 /// #
-/// use http_types::Response;
+/// use http_types::{headers::Header, Response};
 /// use http_types::auth::{AuthenticationScheme, Authorization};
 ///
 /// let scheme = AuthenticationScheme::Basic;

--- a/src/auth/authorization.rs
+++ b/src/auth/authorization.rs
@@ -21,7 +21,7 @@ use crate::headers::{Header, HeaderName, HeaderValue, Headers, AUTHORIZATION};
 /// let authz = Authorization::new(scheme, credentials.into());
 ///
 /// let mut res = Response::new(200);
-/// authz.apply(&mut res);
+/// authz.apply_header(&mut res);
 ///
 /// let authz = Authorization::from_headers(res)?.unwrap();
 ///
@@ -71,24 +71,6 @@ impl Authorization {
         }))
     }
 
-    /// Sets the header.
-    pub fn apply(&self, mut headers: impl AsMut<Headers>) {
-        headers.as_mut().insert(self.name(), self.value());
-    }
-
-    /// Get the `HeaderName`.
-    pub fn name(&self) -> HeaderName {
-        self.header_name()
-    }
-
-    /// Get the `HeaderValue`.
-    pub fn value(&self) -> HeaderValue {
-        let output = format!("{} {}", self.scheme, self.credentials);
-
-        // SAFETY: the internal string is validated to be ASCII.
-        unsafe { HeaderValue::from_bytes_unchecked(output.into()) }
-    }
-
     /// Get the authorization scheme.
     pub fn scheme(&self) -> AuthenticationScheme {
         self.scheme
@@ -116,7 +98,10 @@ impl Header for Authorization {
     }
 
     fn header_value(&self) -> HeaderValue {
-        self.value()
+        let output = format!("{} {}", self.scheme, self.credentials);
+
+        // SAFETY: the internal string is validated to be ASCII.
+        unsafe { HeaderValue::from_bytes_unchecked(output.into()) }
     }
 }
 
@@ -132,7 +117,7 @@ mod test {
         let authz = Authorization::new(scheme, credentials.into());
 
         let mut headers = Headers::new();
-        authz.apply(&mut headers);
+        authz.apply_header(&mut headers);
 
         let authz = Authorization::from_headers(headers)?.unwrap();
 

--- a/src/auth/authorization.rs
+++ b/src/auth/authorization.rs
@@ -13,7 +13,7 @@ use crate::headers::{Header, HeaderName, HeaderValue, Headers, AUTHORIZATION};
 /// ```
 /// # fn main() -> http_types::Result<()> {
 /// #
-/// use http_types::{headers::Header, Response};
+/// use http_types::Response;
 /// use http_types::auth::{AuthenticationScheme, Authorization};
 ///
 /// let scheme = AuthenticationScheme::Basic;

--- a/src/auth/authorization.rs
+++ b/src/auth/authorization.rs
@@ -21,7 +21,7 @@ use crate::headers::{Header, HeaderName, HeaderValue, Headers, AUTHORIZATION};
 /// let authz = Authorization::new(scheme, credentials.into());
 ///
 /// let mut res = Response::new(200);
-/// authz.apply_header(&mut res);
+/// res.insert_header(&authz, &authz);
 ///
 /// let authz = Authorization::from_headers(res)?.unwrap();
 ///

--- a/src/auth/basic_auth.rs
+++ b/src/auth/basic_auth.rs
@@ -17,7 +17,7 @@ use crate::{bail_status as bail, ensure_status as ensure};
 /// ```
 /// # fn main() -> http_types::Result<()> {
 /// #
-/// use http_types::Response;
+/// use http_types::{headers::Header, Response};
 /// use http_types::auth::{AuthenticationScheme, BasicAuth};
 ///
 /// let username = "nori";

--- a/src/auth/basic_auth.rs
+++ b/src/auth/basic_auth.rs
@@ -25,7 +25,7 @@ use crate::{bail_status as bail, ensure_status as ensure};
 /// let authz = BasicAuth::new(username, password);
 ///
 /// let mut res = Response::new(200);
-/// authz.apply_header(&mut res);
+/// res.insert_header(&authz, &authz);
 ///
 /// let authz = BasicAuth::from_headers(res)?.unwrap();
 ///

--- a/src/auth/basic_auth.rs
+++ b/src/auth/basic_auth.rs
@@ -17,7 +17,7 @@ use crate::{bail_status as bail, ensure_status as ensure};
 /// ```
 /// # fn main() -> http_types::Result<()> {
 /// #
-/// use http_types::{headers::Header, Response};
+/// use http_types::Response;
 /// use http_types::auth::{AuthenticationScheme, BasicAuth};
 ///
 /// let username = "nori";

--- a/src/auth/basic_auth.rs
+++ b/src/auth/basic_auth.rs
@@ -1,6 +1,9 @@
-use crate::auth::{AuthenticationScheme, Authorization};
 use crate::headers::{HeaderName, HeaderValue, Headers, AUTHORIZATION};
 use crate::Status;
+use crate::{
+    auth::{AuthenticationScheme, Authorization},
+    headers::Header,
+};
 use crate::{bail_status as bail, ensure_status as ensure};
 
 /// HTTP Basic authorization.
@@ -22,7 +25,7 @@ use crate::{bail_status as bail, ensure_status as ensure};
 /// let authz = BasicAuth::new(username, password);
 ///
 /// let mut res = Response::new(200);
-/// authz.apply(&mut res);
+/// authz.apply_header(&mut res);
 ///
 /// let authz = BasicAuth::from_headers(res)?.unwrap();
 ///
@@ -84,24 +87,6 @@ impl BasicAuth {
         Ok(Self { username, password })
     }
 
-    /// Sets the header.
-    pub fn apply(&self, mut headers: impl AsMut<Headers>) {
-        headers.as_mut().insert(self.name(), self.value());
-    }
-
-    /// Get the `HeaderName`.
-    pub fn name(&self) -> HeaderName {
-        AUTHORIZATION
-    }
-
-    /// Get the `HeaderValue`.
-    pub fn value(&self) -> HeaderValue {
-        let scheme = AuthenticationScheme::Basic;
-        let credentials = base64::encode(format!("{}:{}", self.username, self.password));
-        let auth = Authorization::new(scheme, credentials);
-        auth.value()
-    }
-
     /// Get the username.
     pub fn username(&self) -> &str {
         self.username.as_str()
@@ -113,13 +98,16 @@ impl BasicAuth {
     }
 }
 
-impl crate::headers::Header for BasicAuth {
+impl Header for BasicAuth {
     fn header_name(&self) -> HeaderName {
         AUTHORIZATION
     }
 
     fn header_value(&self) -> HeaderValue {
-        self.value()
+        let scheme = AuthenticationScheme::Basic;
+        let credentials = base64::encode(format!("{}:{}", self.username, self.password));
+        let auth = Authorization::new(scheme, credentials);
+        auth.header_value()
     }
 }
 
@@ -135,7 +123,7 @@ mod test {
         let authz = BasicAuth::new(username, password);
 
         let mut headers = Headers::new();
-        authz.apply(&mut headers);
+        authz.apply_header(&mut headers);
 
         let authz = BasicAuth::from_headers(headers)?.unwrap();
 

--- a/src/auth/mod.rs
+++ b/src/auth/mod.rs
@@ -5,7 +5,7 @@
 //! ```
 //! # fn main() -> http_types::Result<()> {
 //! #
-//! use http_types::Response;
+//! use http_types::{headers::Header, Response};
 //! use http_types::auth::{AuthenticationScheme, BasicAuth};
 //!
 //! let username = "nori";

--- a/src/auth/mod.rs
+++ b/src/auth/mod.rs
@@ -13,7 +13,7 @@
 //! let authz = BasicAuth::new(username, password);
 //!
 //! let mut res = Response::new(200);
-//! authz.apply(&mut res);
+//! authz.apply_header(&mut res);
 //!
 //! let authz = BasicAuth::from_headers(res)?.unwrap();
 //!

--- a/src/auth/mod.rs
+++ b/src/auth/mod.rs
@@ -5,7 +5,7 @@
 //! ```
 //! # fn main() -> http_types::Result<()> {
 //! #
-//! use http_types::{headers::Header, Response};
+//! use http_types::Response;
 //! use http_types::auth::{AuthenticationScheme, BasicAuth};
 //!
 //! let username = "nori";
@@ -13,7 +13,7 @@
 //! let authz = BasicAuth::new(username, password);
 //!
 //! let mut res = Response::new(200);
-//! authz.apply_header(&mut res);
+//! res.insert_header(&authz, &authz);
 //!
 //! let authz = BasicAuth::from_headers(res)?.unwrap();
 //!

--- a/src/auth/www_authenticate.rs
+++ b/src/auth/www_authenticate.rs
@@ -27,7 +27,7 @@ use crate::{auth::AuthenticationScheme, headers::Header};
 /// let authz = WwwAuthenticate::new(scheme, realm.into());
 ///
 /// let mut res = Response::new(200);
-/// authz.apply_header(&mut res);
+/// res.insert_header(&authz, &authz);
 ///
 /// let authz = WwwAuthenticate::from_headers(res)?.unwrap();
 ///

--- a/src/auth/www_authenticate.rs
+++ b/src/auth/www_authenticate.rs
@@ -19,7 +19,7 @@ use crate::{auth::AuthenticationScheme, headers::Header};
 /// ```
 /// # fn main() -> http_types::Result<()> {
 /// #
-/// use http_types::Response;
+/// use http_types::{headers::Header, Response};
 /// use http_types::auth::{AuthenticationScheme, WwwAuthenticate};
 ///
 /// let scheme = AuthenticationScheme::Basic;

--- a/src/auth/www_authenticate.rs
+++ b/src/auth/www_authenticate.rs
@@ -19,7 +19,7 @@ use crate::{auth::AuthenticationScheme, headers::Header};
 /// ```
 /// # fn main() -> http_types::Result<()> {
 /// #
-/// use http_types::{headers::Header, Response};
+/// use http_types::Response;
 /// use http_types::auth::{AuthenticationScheme, WwwAuthenticate};
 ///
 /// let scheme = AuthenticationScheme::Basic;

--- a/src/cache/age.rs
+++ b/src/cache/age.rs
@@ -16,7 +16,7 @@ use std::time::Duration;
 /// ```
 /// # fn main() -> http_types::Result<()> {
 /// #
-/// use http_types::Response;
+/// use http_types::{headers::Header, Response};
 /// use http_types::cache::Age;
 ///
 /// let age = Age::from_secs(12);

--- a/src/cache/age.rs
+++ b/src/cache/age.rs
@@ -16,7 +16,7 @@ use std::time::Duration;
 /// ```
 /// # fn main() -> http_types::Result<()> {
 /// #
-/// use http_types::{headers::Header, Response};
+/// use http_types::Response;
 /// use http_types::cache::Age;
 ///
 /// let age = Age::from_secs(12);

--- a/src/cache/age.rs
+++ b/src/cache/age.rs
@@ -22,7 +22,7 @@ use std::time::Duration;
 /// let age = Age::from_secs(12);
 ///
 /// let mut res = Response::new(200);
-/// age.apply_header(&mut res);
+/// res.insert_header(&age, &age);
 ///
 /// let age = Age::from_headers(res)?.unwrap();
 /// assert_eq!(age, Age::from_secs(12));
@@ -66,14 +66,6 @@ impl Age {
         let dur = Duration::from_secs_f64(num as f64);
 
         Ok(Some(Self { dur }))
-    }
-}
-
-impl ToHeaderValues for Age {
-    type Iter = option::IntoIter<HeaderValue>;
-    fn to_header_values(&self) -> crate::Result<Self::Iter> {
-        // A HeaderValue will always convert into itself.
-        Ok(self.header_value().to_header_values().unwrap())
     }
 }
 

--- a/src/cache/age.rs
+++ b/src/cache/age.rs
@@ -1,8 +1,8 @@
-use crate::headers::{Header, HeaderName, HeaderValue, Headers, ToHeaderValues, AGE};
+use crate::headers::{Header, HeaderName, HeaderValue, Headers, AGE};
 use crate::Status;
 
 use std::fmt::Debug;
-use std::option;
+
 use std::time::Duration;
 
 /// HTTP `Age` header

--- a/src/cache/cache_control/cache_control.rs
+++ b/src/cache/cache_control/cache_control.rs
@@ -15,7 +15,7 @@ use std::slice;
 /// ```
 /// # fn main() -> http_types::Result<()> {
 /// #
-/// use http_types::Response;
+/// use http_types::{headers::Header, Response};
 /// use http_types::cache::{CacheControl, CacheDirective};
 /// let mut entries = CacheControl::new();
 /// entries.push(CacheDirective::Immutable);

--- a/src/cache/cache_control/cache_control.rs
+++ b/src/cache/cache_control/cache_control.rs
@@ -22,7 +22,7 @@ use std::slice;
 /// entries.push(CacheDirective::NoStore);
 ///
 /// let mut res = Response::new(200);
-/// entries.apply_header(&mut res);
+/// res.insert_header(&entries, &entries);
 ///
 /// let entries = CacheControl::from_headers(res)?.unwrap();
 /// let mut entries = entries.iter();
@@ -186,14 +186,6 @@ impl<'a> Iterator for IterMut<'a> {
     #[inline]
     fn size_hint(&self) -> (usize, Option<usize>) {
         self.inner.size_hint()
-    }
-}
-
-impl ToHeaderValues for CacheControl {
-    type Iter = option::IntoIter<HeaderValue>;
-    fn to_header_values(&self) -> crate::Result<Self::Iter> {
-        // A HeaderValue will always convert into itself.
-        Ok(self.header_value().to_header_values().unwrap())
     }
 }
 

--- a/src/cache/cache_control/cache_control.rs
+++ b/src/cache/cache_control/cache_control.rs
@@ -1,5 +1,7 @@
-use crate::cache::CacheDirective;
+use headers::Header;
+
 use crate::headers::{HeaderName, HeaderValue, Headers, ToHeaderValues, CACHE_CONTROL};
+use crate::{cache::CacheDirective, headers};
 
 use std::fmt::{self, Debug, Write};
 use std::iter::Iterator;
@@ -20,7 +22,7 @@ use std::slice;
 /// entries.push(CacheDirective::NoStore);
 ///
 /// let mut res = Response::new(200);
-/// entries.apply(&mut res);
+/// entries.apply_header(&mut res);
 ///
 /// let entries = CacheControl::from_headers(res)?.unwrap();
 /// let mut entries = entries.iter();
@@ -59,31 +61,6 @@ impl CacheControl {
 
         Ok(Some(Self { entries }))
     }
-
-    /// Sets the `Server-Timing` header.
-    pub fn apply(&self, mut headers: impl AsMut<Headers>) {
-        headers.as_mut().insert(CACHE_CONTROL, self.value());
-    }
-
-    /// Get the `HeaderName`.
-    pub fn name(&self) -> HeaderName {
-        CACHE_CONTROL
-    }
-
-    /// Get the `HeaderValue`.
-    pub fn value(&self) -> HeaderValue {
-        let mut output = String::new();
-        for (n, directive) in self.entries.iter().enumerate() {
-            let directive: HeaderValue = directive.clone().into();
-            match n {
-                0 => write!(output, "{}", directive).unwrap(),
-                _ => write!(output, ", {}", directive).unwrap(),
-            };
-        }
-
-        // SAFETY: the internal string is validated to be ASCII.
-        unsafe { HeaderValue::from_bytes_unchecked(output.into()) }
-    }
     /// Push a directive into the list of entries.
     pub fn push(&mut self, directive: CacheDirective) {
         self.entries.push(directive);
@@ -104,12 +81,22 @@ impl CacheControl {
     }
 }
 
-impl crate::headers::Header for CacheControl {
+impl Header for CacheControl {
     fn header_name(&self) -> HeaderName {
         CACHE_CONTROL
     }
     fn header_value(&self) -> HeaderValue {
-        self.value()
+        let mut output = String::new();
+        for (n, directive) in self.entries.iter().enumerate() {
+            let directive: HeaderValue = directive.clone().into();
+            match n {
+                0 => write!(output, "{}", directive).unwrap(),
+                _ => write!(output, ", {}", directive).unwrap(),
+            };
+        }
+
+        // SAFETY: the internal string is validated to be ASCII.
+        unsafe { HeaderValue::from_bytes_unchecked(output.into()) }
     }
 }
 
@@ -206,7 +193,7 @@ impl ToHeaderValues for CacheControl {
     type Iter = option::IntoIter<HeaderValue>;
     fn to_header_values(&self) -> crate::Result<Self::Iter> {
         // A HeaderValue will always convert into itself.
-        Ok(self.value().to_header_values().unwrap())
+        Ok(self.header_value().to_header_values().unwrap())
     }
 }
 

--- a/src/cache/cache_control/cache_control.rs
+++ b/src/cache/cache_control/cache_control.rs
@@ -15,7 +15,7 @@ use std::slice;
 /// ```
 /// # fn main() -> http_types::Result<()> {
 /// #
-/// use http_types::{headers::Header, Response};
+/// use http_types::Response;
 /// use http_types::cache::{CacheControl, CacheDirective};
 /// let mut entries = CacheControl::new();
 /// entries.push(CacheDirective::Immutable);

--- a/src/cache/cache_control/cache_control.rs
+++ b/src/cache/cache_control/cache_control.rs
@@ -1,11 +1,11 @@
 use headers::Header;
 
-use crate::headers::{HeaderName, HeaderValue, Headers, ToHeaderValues, CACHE_CONTROL};
+use crate::headers::{HeaderName, HeaderValue, Headers, CACHE_CONTROL};
 use crate::{cache::CacheDirective, headers};
 
 use std::fmt::{self, Debug, Write};
 use std::iter::Iterator;
-use std::option;
+
 use std::slice;
 
 /// A Cache-Control header.

--- a/src/cache/cache_control/mod.rs
+++ b/src/cache/cache_control/mod.rs
@@ -16,7 +16,7 @@ pub use cache_directive::CacheDirective;
 #[cfg(test)]
 mod test {
     use super::*;
-    use crate::headers::{Headers, CACHE_CONTROL};
+    use crate::headers::{Header, Headers, CACHE_CONTROL};
 
     #[test]
     fn smoke() -> crate::Result<()> {
@@ -25,7 +25,7 @@ mod test {
         entries.push(CacheDirective::NoStore);
 
         let mut headers = Headers::new();
-        entries.apply(&mut headers);
+        entries.apply_header(&mut headers);
 
         let entries = CacheControl::from_headers(headers)?.unwrap();
         let mut entries = entries.iter();

--- a/src/cache/clear_site_data/mod.rs
+++ b/src/cache/clear_site_data/mod.rs
@@ -28,7 +28,7 @@ use headers::Header;
 /// ```
 /// # fn main() -> http_types::Result<()> {
 /// #
-/// use http_types::{headers::Header, Response};
+/// use http_types::Response;
 /// use http_types::cache::{ClearSiteData, ClearDirective};
 ///
 /// let mut entries = ClearSiteData::new();

--- a/src/cache/clear_site_data/mod.rs
+++ b/src/cache/clear_site_data/mod.rs
@@ -36,7 +36,7 @@ use headers::Header;
 /// entries.push(ClearDirective::Cookies);
 ///
 /// let mut res = Response::new(200);
-/// entries.apply_header(&mut res);
+/// res.insert_header(&entries, &entries);
 ///
 /// let entries = ClearSiteData::from_headers(res)?.unwrap();
 /// let mut entries = entries.iter();
@@ -198,14 +198,6 @@ impl<'a> Iterator for IterMut<'a> {
     #[inline]
     fn size_hint(&self) -> (usize, Option<usize>) {
         self.inner.size_hint()
-    }
-}
-
-impl ToHeaderValues for ClearSiteData {
-    type Iter = option::IntoIter<HeaderValue>;
-    fn to_header_values(&self) -> crate::Result<Self::Iter> {
-        // A HeaderValue will always convert into itself.
-        Ok(self.header_value().to_header_values().unwrap())
     }
 }
 

--- a/src/cache/clear_site_data/mod.rs
+++ b/src/cache/clear_site_data/mod.rs
@@ -1,11 +1,11 @@
 //! Clear browsing data (cookies, storage, cache) associated with the
 //! requesting website
 
-use crate::headers::{self, HeaderName, HeaderValue, Headers, ToHeaderValues, CLEAR_SITE_DATA};
+use crate::headers::{self, HeaderName, HeaderValue, Headers, CLEAR_SITE_DATA};
 
 use std::fmt::{self, Debug, Write};
 use std::iter::Iterator;
-use std::option;
+
 use std::slice;
 use std::str::FromStr;
 

--- a/src/cache/clear_site_data/mod.rs
+++ b/src/cache/clear_site_data/mod.rs
@@ -28,7 +28,7 @@ use headers::Header;
 /// ```
 /// # fn main() -> http_types::Result<()> {
 /// #
-/// use http_types::Response;
+/// use http_types::{headers::Header, Response};
 /// use http_types::cache::{ClearSiteData, ClearDirective};
 ///
 /// let mut entries = ClearSiteData::new();

--- a/src/cache/expires.rs
+++ b/src/cache/expires.rs
@@ -1,8 +1,7 @@
-use crate::headers::{Header, HeaderName, HeaderValue, Headers, ToHeaderValues, EXPIRES};
+use crate::headers::{Header, HeaderName, HeaderValue, Headers, EXPIRES};
 use crate::utils::{fmt_http_date, parse_http_date};
 
 use std::fmt::Debug;
-use std::option;
 use std::time::{Duration, SystemTime};
 
 /// HTTP `Expires` header
@@ -24,7 +23,7 @@ use std::time::{Duration, SystemTime};
 /// let expires = Expires::new_at(time);
 ///
 /// let mut res = Response::new(200);
-/// expires.apply_header(&mut res);
+/// res.insert_header(&expires, &expires);
 ///
 /// let expires = Expires::from_headers(res)?.unwrap();
 ///
@@ -81,14 +80,6 @@ impl Header for Expires {
 
         // SAFETY: the internal string is validated to be ASCII.
         unsafe { HeaderValue::from_bytes_unchecked(output.into()) }
-    }
-}
-
-impl ToHeaderValues for Expires {
-    type Iter = option::IntoIter<HeaderValue>;
-    fn to_header_values(&self) -> crate::Result<Self::Iter> {
-        // A HeaderValue will always convert into itself.
-        Ok(self.header_value().to_header_values().unwrap())
     }
 }
 

--- a/src/cache/expires.rs
+++ b/src/cache/expires.rs
@@ -16,7 +16,7 @@ use std::time::{Duration, SystemTime};
 /// ```
 /// # fn main() -> http_types::Result<()> {
 /// #
-/// use http_types::Response;
+/// use http_types::{headers::Header, Response};
 /// use http_types::cache::Expires;
 /// use std::time::{SystemTime, Duration};
 ///

--- a/src/cache/expires.rs
+++ b/src/cache/expires.rs
@@ -15,7 +15,7 @@ use std::time::{Duration, SystemTime};
 /// ```
 /// # fn main() -> http_types::Result<()> {
 /// #
-/// use http_types::{headers::Header, Response};
+/// use http_types::Response;
 /// use http_types::cache::Expires;
 /// use std::time::{SystemTime, Duration};
 ///

--- a/src/conditional/etag.rs
+++ b/src/conditional/etag.rs
@@ -3,7 +3,6 @@ use crate::{Error, StatusCode};
 
 use std::fmt::{self, Debug, Display};
 
-
 /// HTTP Entity Tags.
 ///
 /// ETags provide an ID for a particular resource, enabling clients and servers

--- a/src/conditional/etag.rs
+++ b/src/conditional/etag.rs
@@ -18,7 +18,7 @@ use std::option;
 /// ```
 /// # fn main() -> http_types::Result<()> {
 /// #
-/// use http_types::Response;
+/// use http_types::{headers::Header, Response};
 /// use http_types::conditional::ETag;
 ///
 /// let etag = ETag::new("0xcafebeef".to_string());

--- a/src/conditional/etag.rs
+++ b/src/conditional/etag.rs
@@ -1,8 +1,8 @@
-use crate::headers::{Header, HeaderName, HeaderValue, Headers, ToHeaderValues, ETAG};
+use crate::headers::{Header, HeaderName, HeaderValue, Headers, ETAG};
 use crate::{Error, StatusCode};
 
 use std::fmt::{self, Debug, Display};
-use std::option;
+
 
 /// HTTP Entity Tags.
 ///

--- a/src/conditional/etag.rs
+++ b/src/conditional/etag.rs
@@ -18,7 +18,7 @@ use std::option;
 /// ```
 /// # fn main() -> http_types::Result<()> {
 /// #
-/// use http_types::{headers::Header, Response};
+/// use http_types::Response;
 /// use http_types::conditional::ETag;
 ///
 /// let etag = ETag::new("0xcafebeef".to_string());

--- a/src/conditional/etag.rs
+++ b/src/conditional/etag.rs
@@ -24,7 +24,7 @@ use std::option;
 /// let etag = ETag::new("0xcafebeef".to_string());
 ///
 /// let mut res = Response::new(200);
-/// etag.apply_header(&mut res);
+/// res.insert_header(&etag, &etag);
 ///
 /// let etag = ETag::from_headers(res)?.unwrap();
 /// assert_eq!(etag, ETag::Strong(String::from("0xcafebeef")));
@@ -130,14 +130,6 @@ impl Display for ETag {
             Self::Strong(s) => write!(f, r#""{}""#, s),
             Self::Weak(s) => write!(f, r#"W/"{}""#, s),
         }
-    }
-}
-
-impl ToHeaderValues for ETag {
-    type Iter = option::IntoIter<HeaderValue>;
-    fn to_header_values(&self) -> crate::Result<Self::Iter> {
-        // A HeaderValue will always convert into itself.
-        Ok(self.header_value().to_header_values().unwrap())
     }
 }
 

--- a/src/conditional/if_match.rs
+++ b/src/conditional/if_match.rs
@@ -19,7 +19,7 @@ use std::slice;
 /// ```
 /// # fn main() -> http_types::Result<()> {
 /// #
-/// use http_types::Response;
+/// use http_types::{headers::Header, Response};
 /// use http_types::conditional::{IfMatch, ETag};
 ///
 /// let mut entries = IfMatch::new();

--- a/src/conditional/if_match.rs
+++ b/src/conditional/if_match.rs
@@ -1,11 +1,11 @@
 //! Apply the HTTP method if the ETag matches.
 
-use crate::headers::{HeaderName, HeaderValue, Headers, ToHeaderValues, IF_MATCH};
+use crate::headers::{HeaderName, HeaderValue, Headers, IF_MATCH};
 use crate::{conditional::ETag, headers::Header};
 
 use std::fmt::{self, Debug, Write};
 use std::iter::Iterator;
-use std::option;
+
 use std::slice;
 
 /// Apply the HTTP method if the ETag matches.

--- a/src/conditional/if_match.rs
+++ b/src/conditional/if_match.rs
@@ -27,7 +27,7 @@ use std::slice;
 /// entries.push(ETag::new("0xbeefcafe".to_string()));
 ///
 /// let mut res = Response::new(200);
-/// entries.apply_header(&mut res);
+/// res.insert_header(&entries, &entries);
 ///
 /// let entries = IfMatch::from_headers(res)?.unwrap();
 /// let mut entries = entries.iter();
@@ -214,14 +214,6 @@ impl<'a> Iterator for IterMut<'a> {
     #[inline]
     fn size_hint(&self) -> (usize, Option<usize>) {
         self.inner.size_hint()
-    }
-}
-
-impl ToHeaderValues for IfMatch {
-    type Iter = option::IntoIter<HeaderValue>;
-    fn to_header_values(&self) -> crate::Result<Self::Iter> {
-        // A HeaderValue will always convert into itself.
-        Ok(self.header_value().to_header_values().unwrap())
     }
 }
 

--- a/src/conditional/if_match.rs
+++ b/src/conditional/if_match.rs
@@ -19,7 +19,7 @@ use std::slice;
 /// ```
 /// # fn main() -> http_types::Result<()> {
 /// #
-/// use http_types::{headers::Header, Response};
+/// use http_types::Response;
 /// use http_types::conditional::{IfMatch, ETag};
 ///
 /// let mut entries = IfMatch::new();

--- a/src/conditional/if_match.rs
+++ b/src/conditional/if_match.rs
@@ -1,7 +1,7 @@
 //! Apply the HTTP method if the ETag matches.
 
-use crate::conditional::ETag;
 use crate::headers::{HeaderName, HeaderValue, Headers, ToHeaderValues, IF_MATCH};
+use crate::{conditional::ETag, headers::Header};
 
 use std::fmt::{self, Debug, Write};
 use std::iter::Iterator;
@@ -27,7 +27,7 @@ use std::slice;
 /// entries.push(ETag::new("0xbeefcafe".to_string()));
 ///
 /// let mut res = Response::new(200);
-/// entries.apply(&mut res);
+/// entries.apply_header(&mut res);
 ///
 /// let entries = IfMatch::from_headers(res)?.unwrap();
 /// let mut entries = entries.iter();
@@ -73,37 +73,6 @@ impl IfMatch {
         Ok(Some(Self { entries, wildcard }))
     }
 
-    /// Sets the `If-Match` header.
-    pub fn apply(&self, mut headers: impl AsMut<Headers>) {
-        headers.as_mut().insert(IF_MATCH, self.value());
-    }
-
-    /// Get the `HeaderName`.
-    pub fn name(&self) -> HeaderName {
-        IF_MATCH
-    }
-
-    /// Get the `HeaderValue`.
-    pub fn value(&self) -> HeaderValue {
-        let mut output = String::new();
-        for (n, etag) in self.entries.iter().enumerate() {
-            match n {
-                0 => write!(output, "{}", etag.to_string()).unwrap(),
-                _ => write!(output, ", {}", etag.to_string()).unwrap(),
-            };
-        }
-
-        if self.wildcard {
-            match output.len() {
-                0 => write!(output, "*").unwrap(),
-                _ => write!(output, ", *").unwrap(),
-            };
-        }
-
-        // SAFETY: the internal string is validated to be ASCII.
-        unsafe { HeaderValue::from_bytes_unchecked(output.into()) }
-    }
-
     /// Push a directive into the list of entries.
     pub fn push(&mut self, directive: impl Into<ETag>) {
         self.entries.push(directive.into());
@@ -134,12 +103,28 @@ impl IfMatch {
     }
 }
 
-impl crate::headers::Header for IfMatch {
+impl Header for IfMatch {
     fn header_name(&self) -> HeaderName {
         IF_MATCH
     }
     fn header_value(&self) -> HeaderValue {
-        self.value()
+        let mut output = String::new();
+        for (n, etag) in self.entries.iter().enumerate() {
+            match n {
+                0 => write!(output, "{}", etag.to_string()).unwrap(),
+                _ => write!(output, ", {}", etag.to_string()).unwrap(),
+            };
+        }
+
+        if self.wildcard {
+            match output.len() {
+                0 => write!(output, "*").unwrap(),
+                _ => write!(output, ", *").unwrap(),
+            };
+        }
+
+        // SAFETY: the internal string is validated to be ASCII.
+        unsafe { HeaderValue::from_bytes_unchecked(output.into()) }
     }
 }
 
@@ -236,7 +221,7 @@ impl ToHeaderValues for IfMatch {
     type Iter = option::IntoIter<HeaderValue>;
     fn to_header_values(&self) -> crate::Result<Self::Iter> {
         // A HeaderValue will always convert into itself.
-        Ok(self.value().to_header_values().unwrap())
+        Ok(self.header_value().to_header_values().unwrap())
     }
 }
 
@@ -252,6 +237,7 @@ impl Debug for IfMatch {
 
 #[cfg(test)]
 mod test {
+    use super::*;
     use crate::conditional::{ETag, IfMatch};
     use crate::Response;
 
@@ -262,7 +248,7 @@ mod test {
         entries.push(ETag::new("0xbeefcafe".to_string()));
 
         let mut res = Response::new(200);
-        entries.apply(&mut res);
+        entries.apply_header(&mut res);
 
         let entries = IfMatch::from_headers(res)?.unwrap();
         let mut entries = entries.iter();
@@ -284,7 +270,7 @@ mod test {
         entries.set_wildcard(true);
 
         let mut res = Response::new(200);
-        entries.apply(&mut res);
+        entries.apply_header(&mut res);
 
         let entries = IfMatch::from_headers(res)?.unwrap();
         assert_eq!(entries.wildcard(), true);

--- a/src/conditional/if_modified_since.rs
+++ b/src/conditional/if_modified_since.rs
@@ -25,7 +25,7 @@ use std::time::SystemTime;
 /// let expires = IfModifiedSince::new(time);
 ///
 /// let mut res = Response::new(200);
-/// expires.apply_header(&mut res);
+/// res.insert_header(&expires, &expires);
 ///
 /// let expires = IfModifiedSince::from_headers(res)?.unwrap();
 ///
@@ -64,14 +64,6 @@ impl IfModifiedSince {
 
         let instant = parse_http_date(header.as_str())?;
         Ok(Some(Self { instant }))
-    }
-}
-
-impl ToHeaderValues for IfModifiedSince {
-    type Iter = option::IntoIter<HeaderValue>;
-    fn to_header_values(&self) -> crate::Result<Self::Iter> {
-        // A HeaderValue will always convert into itself.
-        Ok(self.header_value().to_header_values().unwrap())
     }
 }
 

--- a/src/conditional/if_modified_since.rs
+++ b/src/conditional/if_modified_since.rs
@@ -1,8 +1,8 @@
-use crate::headers::{Header, HeaderName, HeaderValue, Headers, ToHeaderValues, IF_MODIFIED_SINCE};
+use crate::headers::{Header, HeaderName, HeaderValue, Headers, IF_MODIFIED_SINCE};
 use crate::utils::{fmt_http_date, parse_http_date};
 
 use std::fmt::Debug;
-use std::option;
+
 use std::time::SystemTime;
 
 /// Apply the HTTP method if the entity has been modified after the given

--- a/src/conditional/if_modified_since.rs
+++ b/src/conditional/if_modified_since.rs
@@ -17,7 +17,7 @@ use std::time::SystemTime;
 /// ```
 /// # fn main() -> http_types::Result<()> {
 /// #
-/// use http_types::Response;
+/// use http_types::{headers::Header, Response};
 /// use http_types::conditional::IfModifiedSince;
 /// use std::time::{SystemTime, Duration};
 ///

--- a/src/conditional/if_modified_since.rs
+++ b/src/conditional/if_modified_since.rs
@@ -17,7 +17,7 @@ use std::time::SystemTime;
 /// ```
 /// # fn main() -> http_types::Result<()> {
 /// #
-/// use http_types::{headers::Header, Response};
+/// use http_types::Response;
 /// use http_types::conditional::IfModifiedSince;
 /// use std::time::{SystemTime, Duration};
 ///

--- a/src/conditional/if_modified_since.rs
+++ b/src/conditional/if_modified_since.rs
@@ -1,4 +1,4 @@
-use crate::headers::{HeaderName, HeaderValue, Headers, ToHeaderValues, IF_MODIFIED_SINCE};
+use crate::headers::{Header, HeaderName, HeaderValue, Headers, ToHeaderValues, IF_MODIFIED_SINCE};
 use crate::utils::{fmt_http_date, parse_http_date};
 
 use std::fmt::Debug;
@@ -25,7 +25,7 @@ use std::time::SystemTime;
 /// let expires = IfModifiedSince::new(time);
 ///
 /// let mut res = Response::new(200);
-/// expires.apply(&mut res);
+/// expires.apply_header(&mut res);
 ///
 /// let expires = IfModifiedSince::from_headers(res)?.unwrap();
 ///
@@ -65,40 +65,25 @@ impl IfModifiedSince {
         let instant = parse_http_date(header.as_str())?;
         Ok(Some(Self { instant }))
     }
-
-    /// Insert a `HeaderName` + `HeaderValue` pair into a `Headers` instance.
-    pub fn apply(&self, mut headers: impl AsMut<Headers>) {
-        headers.as_mut().insert(IF_MODIFIED_SINCE, self.value());
-    }
-
-    /// Get the `HeaderName`.
-    pub fn name(&self) -> HeaderName {
-        IF_MODIFIED_SINCE
-    }
-
-    /// Get the `HeaderValue`.
-    pub fn value(&self) -> HeaderValue {
-        let output = fmt_http_date(self.instant);
-
-        // SAFETY: the internal string is validated to be ASCII.
-        unsafe { HeaderValue::from_bytes_unchecked(output.into()) }
-    }
 }
 
 impl ToHeaderValues for IfModifiedSince {
     type Iter = option::IntoIter<HeaderValue>;
     fn to_header_values(&self) -> crate::Result<Self::Iter> {
         // A HeaderValue will always convert into itself.
-        Ok(self.value().to_header_values().unwrap())
+        Ok(self.header_value().to_header_values().unwrap())
     }
 }
 
-impl crate::headers::Header for IfModifiedSince {
+impl Header for IfModifiedSince {
     fn header_name(&self) -> HeaderName {
         IF_MODIFIED_SINCE
     }
     fn header_value(&self) -> HeaderValue {
-        self.value()
+        let output = fmt_http_date(self.instant);
+
+        // SAFETY: the internal string is validated to be ASCII.
+        unsafe { HeaderValue::from_bytes_unchecked(output.into()) }
     }
 }
 
@@ -114,7 +99,7 @@ mod test {
         let expires = IfModifiedSince::new(time);
 
         let mut headers = Headers::new();
-        expires.apply(&mut headers);
+        expires.apply_header(&mut headers);
 
         let expires = IfModifiedSince::from_headers(headers)?.unwrap();
 

--- a/src/conditional/if_none_match.rs
+++ b/src/conditional/if_none_match.rs
@@ -25,7 +25,7 @@ use std::slice;
 /// ```
 /// # fn main() -> http_types::Result<()> {
 /// #
-/// use http_types::{headers::Header, Response};
+/// use http_types::Response;
 /// use http_types::conditional::{IfNoneMatch, ETag};
 ///
 /// let mut entries = IfNoneMatch::new();

--- a/src/conditional/if_none_match.rs
+++ b/src/conditional/if_none_match.rs
@@ -25,7 +25,7 @@ use std::slice;
 /// ```
 /// # fn main() -> http_types::Result<()> {
 /// #
-/// use http_types::Response;
+/// use http_types::{headers::Header, Response};
 /// use http_types::conditional::{IfNoneMatch, ETag};
 ///
 /// let mut entries = IfNoneMatch::new();

--- a/src/conditional/if_none_match.rs
+++ b/src/conditional/if_none_match.rs
@@ -33,7 +33,7 @@ use std::slice;
 /// entries.push(ETag::new("0xbeefcafe".to_string()));
 ///
 /// let mut res = Response::new(200);
-/// entries.apply_header(&mut res);
+/// res.insert_header(&entries, &entries);
 ///
 /// let entries = IfNoneMatch::from_headers(res)?.unwrap();
 /// let mut entries = entries.iter();
@@ -220,14 +220,6 @@ impl<'a> Iterator for IterMut<'a> {
     #[inline]
     fn size_hint(&self) -> (usize, Option<usize>) {
         self.inner.size_hint()
-    }
-}
-
-impl ToHeaderValues for IfNoneMatch {
-    type Iter = option::IntoIter<HeaderValue>;
-    fn to_header_values(&self) -> crate::Result<Self::Iter> {
-        // A HeaderValue will always convert into itself.
-        Ok(self.header_value().to_header_values().unwrap())
     }
 }
 

--- a/src/conditional/if_none_match.rs
+++ b/src/conditional/if_none_match.rs
@@ -3,12 +3,12 @@
 //! This is used to update caches or to prevent uploading a new resource when
 //! one already exists.
 
-use crate::headers::{HeaderName, HeaderValue, Headers, ToHeaderValues, IF_NONE_MATCH};
+use crate::headers::{HeaderName, HeaderValue, Headers, IF_NONE_MATCH};
 use crate::{conditional::ETag, headers::Header};
 
 use std::fmt::{self, Debug, Write};
 use std::iter::Iterator;
-use std::option;
+
 use std::slice;
 
 /// Apply the HTTP method if the ETags do not match.

--- a/src/conditional/if_none_match.rs
+++ b/src/conditional/if_none_match.rs
@@ -3,8 +3,8 @@
 //! This is used to update caches or to prevent uploading a new resource when
 //! one already exists.
 
-use crate::conditional::ETag;
 use crate::headers::{HeaderName, HeaderValue, Headers, ToHeaderValues, IF_NONE_MATCH};
+use crate::{conditional::ETag, headers::Header};
 
 use std::fmt::{self, Debug, Write};
 use std::iter::Iterator;
@@ -33,7 +33,7 @@ use std::slice;
 /// entries.push(ETag::new("0xbeefcafe".to_string()));
 ///
 /// let mut res = Response::new(200);
-/// entries.apply(&mut res);
+/// entries.apply_header(&mut res);
 ///
 /// let entries = IfNoneMatch::from_headers(res)?.unwrap();
 /// let mut entries = entries.iter();
@@ -79,37 +79,6 @@ impl IfNoneMatch {
         Ok(Some(Self { entries, wildcard }))
     }
 
-    /// Sets the `If-None-Match` header.
-    pub fn apply(&self, mut headers: impl AsMut<Headers>) {
-        headers.as_mut().insert(IF_NONE_MATCH, self.value());
-    }
-
-    /// Get the `HeaderName`.
-    pub fn name(&self) -> HeaderName {
-        IF_NONE_MATCH
-    }
-
-    /// Get the `HeaderValue`.
-    pub fn value(&self) -> HeaderValue {
-        let mut output = String::new();
-        for (n, etag) in self.entries.iter().enumerate() {
-            match n {
-                0 => write!(output, "{}", etag.to_string()).unwrap(),
-                _ => write!(output, ", {}", etag.to_string()).unwrap(),
-            };
-        }
-
-        if self.wildcard {
-            match output.len() {
-                0 => write!(output, "*").unwrap(),
-                _ => write!(output, ", *").unwrap(),
-            };
-        }
-
-        // SAFETY: the internal string is validated to be ASCII.
-        unsafe { HeaderValue::from_bytes_unchecked(output.into()) }
-    }
-
     /// Push a directive into the list of entries.
     pub fn push(&mut self, directive: impl Into<ETag>) {
         self.entries.push(directive.into());
@@ -140,12 +109,28 @@ impl IfNoneMatch {
     }
 }
 
-impl crate::headers::Header for IfNoneMatch {
+impl Header for IfNoneMatch {
     fn header_name(&self) -> HeaderName {
         IF_NONE_MATCH
     }
     fn header_value(&self) -> HeaderValue {
-        self.value()
+        let mut output = String::new();
+        for (n, etag) in self.entries.iter().enumerate() {
+            match n {
+                0 => write!(output, "{}", etag.to_string()).unwrap(),
+                _ => write!(output, ", {}", etag.to_string()).unwrap(),
+            };
+        }
+
+        if self.wildcard {
+            match output.len() {
+                0 => write!(output, "*").unwrap(),
+                _ => write!(output, ", *").unwrap(),
+            };
+        }
+
+        // SAFETY: the internal string is validated to be ASCII.
+        unsafe { HeaderValue::from_bytes_unchecked(output.into()) }
     }
 }
 
@@ -242,7 +227,7 @@ impl ToHeaderValues for IfNoneMatch {
     type Iter = option::IntoIter<HeaderValue>;
     fn to_header_values(&self) -> crate::Result<Self::Iter> {
         // A HeaderValue will always convert into itself.
-        Ok(self.value().to_header_values().unwrap())
+        Ok(self.header_value().to_header_values().unwrap())
     }
 }
 
@@ -258,6 +243,7 @@ impl Debug for IfNoneMatch {
 
 #[cfg(test)]
 mod test {
+    use super::*;
     use crate::conditional::{ETag, IfNoneMatch};
     use crate::Response;
 
@@ -268,7 +254,7 @@ mod test {
         entries.push(ETag::new("0xbeefcafe".to_string()));
 
         let mut res = Response::new(200);
-        entries.apply(&mut res);
+        entries.apply_header(&mut res);
 
         let entries = IfNoneMatch::from_headers(res)?.unwrap();
         let mut entries = entries.iter();
@@ -290,7 +276,7 @@ mod test {
         entries.set_wildcard(true);
 
         let mut res = Response::new(200);
-        entries.apply(&mut res);
+        entries.apply_header(&mut res);
 
         let entries = IfNoneMatch::from_headers(res)?.unwrap();
         assert_eq!(entries.wildcard(), true);

--- a/src/conditional/if_unmodified_since.rs
+++ b/src/conditional/if_unmodified_since.rs
@@ -1,6 +1,4 @@
-use crate::headers::{
-    Header, HeaderName, HeaderValue, Headers, IF_UNMODIFIED_SINCE,
-};
+use crate::headers::{Header, HeaderName, HeaderValue, Headers, IF_UNMODIFIED_SINCE};
 use crate::utils::{fmt_http_date, parse_http_date};
 
 use std::fmt::Debug;

--- a/src/conditional/if_unmodified_since.rs
+++ b/src/conditional/if_unmodified_since.rs
@@ -27,7 +27,7 @@ use std::time::SystemTime;
 /// let expires = IfUnmodifiedSince::new(time);
 ///
 /// let mut res = Response::new(200);
-/// expires.apply_header(&mut res);
+/// res.insert_header(&expires, &expires);
 ///
 /// let expires = IfUnmodifiedSince::from_headers(res)?.unwrap();
 ///
@@ -78,14 +78,6 @@ impl Header for IfUnmodifiedSince {
 
         // SAFETY: the internal string is validated to be ASCII.
         unsafe { HeaderValue::from_bytes_unchecked(output.into()) }
-    }
-}
-
-impl ToHeaderValues for IfUnmodifiedSince {
-    type Iter = option::IntoIter<HeaderValue>;
-    fn to_header_values(&self) -> crate::Result<Self::Iter> {
-        // A HeaderValue will always convert into itself.
-        Ok(self.header_value().to_header_values().unwrap())
     }
 }
 

--- a/src/conditional/if_unmodified_since.rs
+++ b/src/conditional/if_unmodified_since.rs
@@ -19,7 +19,7 @@ use std::time::SystemTime;
 /// ```
 /// # fn main() -> http_types::Result<()> {
 /// #
-/// use http_types::Response;
+/// use http_types::{headers::Header, Response};
 /// use http_types::conditional::IfUnmodifiedSince;
 /// use std::time::{SystemTime, Duration};
 ///

--- a/src/conditional/if_unmodified_since.rs
+++ b/src/conditional/if_unmodified_since.rs
@@ -19,7 +19,7 @@ use std::time::SystemTime;
 /// ```
 /// # fn main() -> http_types::Result<()> {
 /// #
-/// use http_types::{headers::Header, Response};
+/// use http_types::Response;
 /// use http_types::conditional::IfUnmodifiedSince;
 /// use std::time::{SystemTime, Duration};
 ///

--- a/src/conditional/if_unmodified_since.rs
+++ b/src/conditional/if_unmodified_since.rs
@@ -1,10 +1,10 @@
 use crate::headers::{
-    Header, HeaderName, HeaderValue, Headers, ToHeaderValues, IF_UNMODIFIED_SINCE,
+    Header, HeaderName, HeaderValue, Headers, IF_UNMODIFIED_SINCE,
 };
 use crate::utils::{fmt_http_date, parse_http_date};
 
 use std::fmt::Debug;
-use std::option;
+
 use std::time::SystemTime;
 
 /// Apply the HTTP method if the entity has not been modified after the

--- a/src/conditional/last_modified.rs
+++ b/src/conditional/last_modified.rs
@@ -16,7 +16,7 @@ use std::time::SystemTime;
 /// ```
 /// # fn main() -> http_types::Result<()> {
 /// #
-/// use http_types::{headers::Header, Response};
+/// use http_types::Response;
 /// use http_types::conditional::LastModified;
 /// use std::time::{SystemTime, Duration};
 ///
@@ -24,7 +24,7 @@ use std::time::SystemTime;
 /// let last_modified = LastModified::new(time);
 ///
 /// let mut res = Response::new(200);
-/// last_modified.apply_header(&mut res);
+/// res.insert_header(&last_modified, &last_modified);
 ///
 /// let last_modified = LastModified::from_headers(res)?.unwrap();
 ///

--- a/src/conditional/last_modified.rs
+++ b/src/conditional/last_modified.rs
@@ -16,7 +16,7 @@ use std::time::SystemTime;
 /// ```
 /// # fn main() -> http_types::Result<()> {
 /// #
-/// use http_types::Response;
+/// use http_types::{headers::Header, Response};
 /// use http_types::conditional::LastModified;
 /// use std::time::{SystemTime, Duration};
 ///

--- a/src/conditional/last_modified.rs
+++ b/src/conditional/last_modified.rs
@@ -1,8 +1,8 @@
-use crate::headers::{Header, HeaderName, HeaderValue, Headers, ToHeaderValues, LAST_MODIFIED};
+use crate::headers::{Header, HeaderName, HeaderValue, Headers, LAST_MODIFIED};
 use crate::utils::{fmt_http_date, parse_http_date};
 
 use std::fmt::Debug;
-use std::option;
+
 use std::time::SystemTime;
 
 /// The last modification date of a resource.

--- a/src/conditional/last_modified.rs
+++ b/src/conditional/last_modified.rs
@@ -78,14 +78,6 @@ impl Header for LastModified {
     }
 }
 
-impl ToHeaderValues for LastModified {
-    type Iter = option::IntoIter<HeaderValue>;
-    fn to_header_values(&self) -> crate::Result<Self::Iter> {
-        // A HeaderValue will always convert into itself.
-        Ok(self.header_value().to_header_values().unwrap())
-    }
-}
-
 #[cfg(test)]
 mod test {
     use super::*;

--- a/src/conditional/vary.rs
+++ b/src/conditional/vary.rs
@@ -1,10 +1,10 @@
 //! Apply the HTTP method if the ETag matches.
 
-use crate::headers::{Header, HeaderName, HeaderValue, Headers, ToHeaderValues, VARY};
+use crate::headers::{Header, HeaderName, HeaderValue, Headers, VARY};
 
 use std::fmt::{self, Debug, Write};
 use std::iter::Iterator;
-use std::option;
+
 use std::slice;
 use std::str::FromStr;
 

--- a/src/conditional/vary.rs
+++ b/src/conditional/vary.rs
@@ -27,7 +27,7 @@ use std::str::FromStr;
 /// entries.push("Accept-Encoding")?;
 ///
 /// let mut res = Response::new(200);
-/// entries.apply_header(&mut res);
+/// res.insert_header(&entries, &entries);
 ///
 /// let entries = Vary::from_headers(res)?.unwrap();
 /// let mut entries = entries.iter();
@@ -221,14 +221,6 @@ impl<'a> Iterator for IterMut<'a> {
     #[inline]
     fn size_hint(&self) -> (usize, Option<usize>) {
         self.inner.size_hint()
-    }
-}
-
-impl ToHeaderValues for Vary {
-    type Iter = option::IntoIter<HeaderValue>;
-    fn to_header_values(&self) -> crate::Result<Self::Iter> {
-        // A HeaderValue will always convert into itself.
-        Ok(self.header_value().to_header_values().unwrap())
     }
 }
 

--- a/src/conditional/vary.rs
+++ b/src/conditional/vary.rs
@@ -19,7 +19,7 @@ use std::str::FromStr;
 /// ```
 /// # fn main() -> http_types::Result<()> {
 /// #
-/// use http_types::Response;
+/// use http_types::{headers::Header, Response};
 /// use http_types::conditional::Vary;
 ///
 /// let mut entries = Vary::new();

--- a/src/conditional/vary.rs
+++ b/src/conditional/vary.rs
@@ -19,7 +19,7 @@ use std::str::FromStr;
 /// ```
 /// # fn main() -> http_types::Result<()> {
 /// #
-/// use http_types::{headers::Header, Response};
+/// use http_types::Response;
 /// use http_types::conditional::Vary;
 ///
 /// let mut entries = Vary::new();

--- a/src/content/accept.rs
+++ b/src/content/accept.rs
@@ -146,38 +146,6 @@ impl Accept {
         Err(err)
     }
 
-    /// Sets the `Accept-Encoding` header.
-    pub fn apply(&self, mut headers: impl AsMut<Headers>) {
-        headers.as_mut().insert(ACCEPT, self.header_value());
-    }
-
-    /// Get the `HeaderName`.
-    pub fn name(&self) -> HeaderName {
-        ACCEPT
-    }
-
-    /// Get the `HeaderValue`.
-    pub fn value(&self) -> HeaderValue {
-        let mut output = String::new();
-        for (n, directive) in self.entries.iter().enumerate() {
-            let directive: HeaderValue = directive.clone().into();
-            match n {
-                0 => write!(output, "{}", directive).unwrap(),
-                _ => write!(output, ", {}", directive).unwrap(),
-            };
-        }
-
-        if self.wildcard {
-            match output.len() {
-                0 => write!(output, "*").unwrap(),
-                _ => write!(output, ", *").unwrap(),
-            }
-        }
-
-        // SAFETY: the internal string is validated to be ASCII.
-        unsafe { HeaderValue::from_bytes_unchecked(output.into()) }
-    }
-
     /// An iterator visiting all entries.
     pub fn iter(&self) -> Iter<'_> {
         Iter {
@@ -198,7 +166,24 @@ impl Header for Accept {
         ACCEPT
     }
     fn header_value(&self) -> HeaderValue {
-        self.header_value()
+        let mut output = String::new();
+        for (n, directive) in self.entries.iter().enumerate() {
+            let directive: HeaderValue = directive.clone().into();
+            match n {
+                0 => write!(output, "{}", directive).unwrap(),
+                _ => write!(output, ", {}", directive).unwrap(),
+            };
+        }
+
+        if self.wildcard {
+            match output.len() {
+                0 => write!(output, "*").unwrap(),
+                _ => write!(output, ", *").unwrap(),
+            }
+        }
+
+        // SAFETY: the internal string is validated to be ASCII.
+        unsafe { HeaderValue::from_bytes_unchecked(output.into()) }
     }
 }
 

--- a/src/content/accept.rs
+++ b/src/content/accept.rs
@@ -33,7 +33,7 @@ use std::slice;
 /// # fn main() -> http_types::Result<()> {
 /// #
 /// use http_types::content::{Accept, MediaTypeProposal};
-/// use http_types::{mime, Response};
+/// use http_types::{headers::Header, mime, Response};
 ///
 /// let mut accept = Accept::new();
 /// accept.push(MediaTypeProposal::new(mime::HTML, Some(0.8))?);

--- a/src/content/accept.rs
+++ b/src/content/accept.rs
@@ -276,14 +276,6 @@ impl<'a> Iterator for IterMut<'a> {
     }
 }
 
-impl ToHeaderValues for Accept {
-    type Iter = option::IntoIter<HeaderValue>;
-    fn to_header_values(&self) -> crate::Result<Self::Iter> {
-        // A HeaderValue will always convert into itself.
-        Ok(self.header_value().to_header_values().unwrap())
-    }
-}
-
 impl Debug for Accept {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let mut list = f.debug_list();

--- a/src/content/accept.rs
+++ b/src/content/accept.rs
@@ -1,6 +1,6 @@
 //! Client header advertising which media types the client is able to understand.
 
-use crate::headers::{HeaderName, HeaderValue, Headers, ToHeaderValues, ACCEPT};
+use crate::headers::{HeaderName, HeaderValue, Headers, ACCEPT};
 use crate::mime::Mime;
 use crate::utils::sort_by_weight;
 use crate::{
@@ -10,7 +10,7 @@ use crate::{
 use crate::{Error, StatusCode};
 
 use std::fmt::{self, Debug, Write};
-use std::option;
+
 use std::slice;
 
 /// Client header advertising which media types the client is able to understand.

--- a/src/content/accept.rs
+++ b/src/content/accept.rs
@@ -33,7 +33,7 @@ use std::slice;
 /// # fn main() -> http_types::Result<()> {
 /// #
 /// use http_types::content::{Accept, MediaTypeProposal};
-/// use http_types::{headers::Header, mime, Response};
+/// use http_types::{mime, Response};
 ///
 /// let mut accept = Accept::new();
 /// accept.push(MediaTypeProposal::new(mime::HTML, Some(0.8))?);
@@ -42,7 +42,7 @@ use std::slice;
 ///
 /// let mut res = Response::new(200);
 /// let content_type = accept.negotiate(&[mime::XML])?;
-/// content_type.apply_header(&mut res);
+/// res.insert_header(&content_type, &content_type);
 ///
 /// assert_eq!(res["Content-Type"], "application/xml;charset=utf-8");
 /// #

--- a/src/content/accept_encoding.rs
+++ b/src/content/accept_encoding.rs
@@ -33,7 +33,7 @@ use std::slice;
 ///
 /// let mut res = Response::new(200);
 /// let encoding = accept.negotiate(&[Encoding::Brotli, Encoding::Gzip])?;
-/// encoding.apply_header(&mut res);
+/// res.insert_header(&encoding, &encoding);
 ///
 /// assert_eq!(res["Content-Encoding"], "br");
 /// #
@@ -266,14 +266,6 @@ impl<'a> Iterator for IterMut<'a> {
     #[inline]
     fn size_hint(&self) -> (usize, Option<usize>) {
         self.inner.size_hint()
-    }
-}
-
-impl ToHeaderValues for AcceptEncoding {
-    type Iter = option::IntoIter<HeaderValue>;
-    fn to_header_values(&self) -> crate::Result<Self::Iter> {
-        // A HeaderValue will always convert into itself.
-        Ok(self.header_value().to_header_values().unwrap())
     }
 }
 

--- a/src/content/accept_encoding.rs
+++ b/src/content/accept_encoding.rs
@@ -1,6 +1,6 @@
 //! Client header advertising available compression algorithms.
 
-use crate::headers::{HeaderName, HeaderValue, Headers, ToHeaderValues, ACCEPT_ENCODING};
+use crate::headers::{HeaderName, HeaderValue, Headers, ACCEPT_ENCODING};
 use crate::utils::sort_by_weight;
 use crate::{
     content::{ContentEncoding, Encoding, EncodingProposal},
@@ -9,7 +9,7 @@ use crate::{
 use crate::{Error, StatusCode};
 
 use std::fmt::{self, Debug, Write};
-use std::option;
+
 use std::slice;
 
 /// Client header advertising available compression algorithms.

--- a/src/content/accept_encoding.rs
+++ b/src/content/accept_encoding.rs
@@ -24,7 +24,7 @@ use std::slice;
 /// # fn main() -> http_types::Result<()> {
 /// #
 /// use http_types::content::{AcceptEncoding, ContentEncoding, Encoding, EncodingProposal};
-/// use http_types::{headers::Header, Response};
+/// use http_types::Response;
 ///
 /// let mut accept = AcceptEncoding::new();
 /// accept.push(EncodingProposal::new(Encoding::Brotli, Some(0.8))?);

--- a/src/content/accept_encoding.rs
+++ b/src/content/accept_encoding.rs
@@ -24,7 +24,7 @@ use std::slice;
 /// # fn main() -> http_types::Result<()> {
 /// #
 /// use http_types::content::{AcceptEncoding, ContentEncoding, Encoding, EncodingProposal};
-/// use http_types::Response;
+/// use http_types::{headers::Header, Response};
 ///
 /// let mut accept = AcceptEncoding::new();
 /// accept.push(EncodingProposal::new(Encoding::Brotli, Some(0.8))?);

--- a/src/content/accept_encoding.rs
+++ b/src/content/accept_encoding.rs
@@ -138,40 +138,6 @@ impl AcceptEncoding {
         Err(err)
     }
 
-    /// Sets the `Accept-Encoding` header.
-    pub fn apply(&self, mut headers: impl AsMut<Headers>) {
-        headers
-            .as_mut()
-            .insert(ACCEPT_ENCODING, self.header_value());
-    }
-
-    /// Get the `HeaderName`.
-    pub fn name(&self) -> HeaderName {
-        ACCEPT_ENCODING
-    }
-
-    /// Get the `HeaderValue`.
-    pub fn value(&self) -> HeaderValue {
-        let mut output = String::new();
-        for (n, directive) in self.entries.iter().enumerate() {
-            let directive: HeaderValue = directive.clone().into();
-            match n {
-                0 => write!(output, "{}", directive).unwrap(),
-                _ => write!(output, ", {}", directive).unwrap(),
-            };
-        }
-
-        if self.wildcard {
-            match output.len() {
-                0 => write!(output, "*").unwrap(),
-                _ => write!(output, ", *").unwrap(),
-            }
-        }
-
-        // SAFETY: the internal string is validated to be ASCII.
-        unsafe { HeaderValue::from_bytes_unchecked(output.into()) }
-    }
-
     /// An iterator visiting all entries.
     pub fn iter(&self) -> Iter<'_> {
         Iter {
@@ -191,8 +157,26 @@ impl Header for AcceptEncoding {
     fn header_name(&self) -> HeaderName {
         ACCEPT_ENCODING
     }
+
     fn header_value(&self) -> HeaderValue {
-        self.header_value()
+        let mut output = String::new();
+        for (n, directive) in self.entries.iter().enumerate() {
+            let directive: HeaderValue = directive.clone().into();
+            match n {
+                0 => write!(output, "{}", directive).unwrap(),
+                _ => write!(output, ", {}", directive).unwrap(),
+            };
+        }
+
+        if self.wildcard {
+            match output.len() {
+                0 => write!(output, "*").unwrap(),
+                _ => write!(output, ", *").unwrap(),
+            }
+        }
+
+        // SAFETY: the internal string is validated to be ASCII.
+        unsafe { HeaderValue::from_bytes_unchecked(output.into()) }
     }
 }
 

--- a/src/content/content_encoding.rs
+++ b/src/content/content_encoding.rs
@@ -1,6 +1,6 @@
 //! Specify the compression algorithm.
 
-use crate::headers::{HeaderName, HeaderValue, Headers, ToHeaderValues, CONTENT_ENCODING};
+use crate::headers::{HeaderName, HeaderValue, Headers, CONTENT_ENCODING};
 use crate::{
     content::{Encoding, EncodingProposal},
     headers::Header,
@@ -8,7 +8,7 @@ use crate::{
 
 use std::fmt::{self, Debug};
 use std::ops::{Deref, DerefMut};
-use std::option;
+
 
 /// Specify the compression algorithm.
 ///

--- a/src/content/content_encoding.rs
+++ b/src/content/content_encoding.rs
@@ -21,7 +21,7 @@ use std::option;
 /// ```
 /// # fn main() -> http_types::Result<()> {
 /// #
-/// use http_types::{headers::Header, Response};
+/// use http_types::Response;
 /// use http_types::content::{ContentEncoding, Encoding};
 /// let mut encoding = ContentEncoding::new(Encoding::Gzip);
 ///

--- a/src/content/content_encoding.rs
+++ b/src/content/content_encoding.rs
@@ -1,7 +1,10 @@
 //! Specify the compression algorithm.
 
-use crate::content::{Encoding, EncodingProposal};
 use crate::headers::{HeaderName, HeaderValue, Headers, ToHeaderValues, CONTENT_ENCODING};
+use crate::{
+    content::{Encoding, EncodingProposal},
+    headers::Header,
+};
 
 use std::fmt::{self, Debug};
 use std::ops::{Deref, DerefMut};
@@ -23,7 +26,7 @@ use std::option;
 /// let mut encoding = ContentEncoding::new(Encoding::Gzip);
 ///
 /// let mut res = Response::new(200);
-/// encoding.apply(&mut res);
+/// encoding.apply_header(&mut res);
 ///
 /// let encoding = ContentEncoding::from_headers(res)?.unwrap();
 /// assert_eq!(encoding, &Encoding::Gzip);
@@ -61,7 +64,9 @@ impl ContentEncoding {
 
     /// Sets the `Content-Encoding` header.
     pub fn apply(&self, mut headers: impl AsMut<Headers>) {
-        headers.as_mut().insert(CONTENT_ENCODING, self.value());
+        headers
+            .as_mut()
+            .insert(CONTENT_ENCODING, self.header_value());
     }
 
     /// Get the `HeaderName`.
@@ -80,12 +85,12 @@ impl ContentEncoding {
     }
 }
 
-impl crate::headers::Header for ContentEncoding {
+impl Header for ContentEncoding {
     fn header_name(&self) -> HeaderName {
         CONTENT_ENCODING
     }
     fn header_value(&self) -> HeaderValue {
-        self.value()
+        self.header_value()
     }
 }
 
@@ -93,7 +98,7 @@ impl ToHeaderValues for ContentEncoding {
     type Iter = option::IntoIter<HeaderValue>;
     fn to_header_values(&self) -> crate::Result<Self::Iter> {
         // A HeaderValue will always convert into itself.
-        Ok(self.value().to_header_values().unwrap())
+        Ok(self.header_value().to_header_values().unwrap())
     }
 }
 

--- a/src/content/content_encoding.rs
+++ b/src/content/content_encoding.rs
@@ -9,7 +9,6 @@ use crate::{
 use std::fmt::{self, Debug};
 use std::ops::{Deref, DerefMut};
 
-
 /// Specify the compression algorithm.
 ///
 /// # Specifications

--- a/src/content/content_encoding.rs
+++ b/src/content/content_encoding.rs
@@ -26,7 +26,7 @@ use std::option;
 /// let mut encoding = ContentEncoding::new(Encoding::Gzip);
 ///
 /// let mut res = Response::new(200);
-/// encoding.apply_header(&mut res);
+/// res.insert_header(&encoding, &encoding);
 ///
 /// let encoding = ContentEncoding::from_headers(res)?.unwrap();
 /// assert_eq!(encoding, &Encoding::Gzip);
@@ -74,14 +74,6 @@ impl Header for ContentEncoding {
     }
     fn header_value(&self) -> HeaderValue {
         self.inner.into()
-    }
-}
-
-impl ToHeaderValues for ContentEncoding {
-    type Iter = option::IntoIter<HeaderValue>;
-    fn to_header_values(&self) -> crate::Result<Self::Iter> {
-        // A HeaderValue will always convert into itself.
-        Ok(self.header_value().to_header_values().unwrap())
     }
 }
 

--- a/src/content/content_encoding.rs
+++ b/src/content/content_encoding.rs
@@ -21,7 +21,7 @@ use std::option;
 /// ```
 /// # fn main() -> http_types::Result<()> {
 /// #
-/// use http_types::Response;
+/// use http_types::{headers::Header, Response};
 /// use http_types::content::{ContentEncoding, Encoding};
 /// let mut encoding = ContentEncoding::new(Encoding::Gzip);
 ///

--- a/src/content/content_encoding.rs
+++ b/src/content/content_encoding.rs
@@ -62,23 +62,6 @@ impl ContentEncoding {
         Ok(Some(Self { inner }))
     }
 
-    /// Sets the `Content-Encoding` header.
-    pub fn apply(&self, mut headers: impl AsMut<Headers>) {
-        headers
-            .as_mut()
-            .insert(CONTENT_ENCODING, self.header_value());
-    }
-
-    /// Get the `HeaderName`.
-    pub fn name(&self) -> HeaderName {
-        CONTENT_ENCODING
-    }
-
-    /// Get the `HeaderValue`.
-    pub fn value(&self) -> HeaderValue {
-        self.inner.into()
-    }
-
     /// Access the encoding kind.
     pub fn encoding(&self) -> Encoding {
         self.inner
@@ -90,7 +73,7 @@ impl Header for ContentEncoding {
         CONTENT_ENCODING
     }
     fn header_value(&self) -> HeaderValue {
-        self.header_value()
+        self.inner.into()
     }
 }
 

--- a/src/content/content_length.rs
+++ b/src/content/content_length.rs
@@ -12,13 +12,13 @@ use crate::Status;
 /// ```
 /// # fn main() -> http_types::Result<()> {
 /// #
-/// use http_types::{headers::Header, Response};
+/// use http_types::Response;
 /// use http_types::content::{ContentLength};
 ///
 /// let content_len = ContentLength::new(12);
 ///
 /// let mut res = Response::new(200);
-/// content_len.apply_header(&mut res);
+/// res.insert_header(&content_len, &content_len);
 ///
 /// let content_len = ContentLength::from_headers(res)?.unwrap();
 /// assert_eq!(content_len.len(), 12);

--- a/src/content/content_length.rs
+++ b/src/content/content_length.rs
@@ -1,4 +1,4 @@
-use crate::headers::{HeaderName, HeaderValue, Headers, CONTENT_LENGTH};
+use crate::headers::{Header, HeaderName, HeaderValue, Headers, CONTENT_LENGTH};
 use crate::Status;
 
 /// The size of the entity-body, in bytes, sent to the recipient.
@@ -18,7 +18,7 @@ use crate::Status;
 /// let content_len = ContentLength::new(12);
 ///
 /// let mut res = Response::new(200);
-/// content_len.apply(&mut res);
+/// content_len.apply_header(&mut res);
 ///
 /// let content_len = ContentLength::from_headers(res)?.unwrap();
 /// assert_eq!(content_len.len(), 12);
@@ -53,7 +53,7 @@ impl ContentLength {
 
     /// Sets the header.
     pub fn apply(&self, mut headers: impl AsMut<Headers>) {
-        headers.as_mut().insert(self.name(), self.value());
+        headers.as_mut().insert(self.name(), self.header_value());
     }
 
     /// Get the `HeaderName`.
@@ -80,12 +80,12 @@ impl ContentLength {
     }
 }
 
-impl crate::headers::Header for ContentLength {
+impl Header for ContentLength {
     fn header_name(&self) -> HeaderName {
         CONTENT_LENGTH
     }
     fn header_value(&self) -> HeaderValue {
-        self.value()
+        self.header_value()
     }
 }
 
@@ -99,7 +99,7 @@ mod test {
         let content_len = ContentLength::new(12);
 
         let mut headers = Headers::new();
-        content_len.apply(&mut headers);
+        content_len.apply_header(&mut headers);
 
         let content_len = ContentLength::from_headers(headers)?.unwrap();
         assert_eq!(content_len.len(), 12);

--- a/src/content/content_length.rs
+++ b/src/content/content_length.rs
@@ -51,24 +51,6 @@ impl ContentLength {
         Ok(Some(Self { length }))
     }
 
-    /// Sets the header.
-    pub fn apply(&self, mut headers: impl AsMut<Headers>) {
-        headers.as_mut().insert(self.name(), self.header_value());
-    }
-
-    /// Get the `HeaderName`.
-    pub fn name(&self) -> HeaderName {
-        CONTENT_LENGTH
-    }
-
-    /// Get the `HeaderValue`.
-    pub fn value(&self) -> HeaderValue {
-        let output = format!("{}", self.length);
-
-        // SAFETY: the internal string is validated to be ASCII.
-        unsafe { HeaderValue::from_bytes_unchecked(output.into()) }
-    }
-
     /// Get the content length.
     pub fn len(&self) -> u64 {
         self.length
@@ -85,7 +67,10 @@ impl Header for ContentLength {
         CONTENT_LENGTH
     }
     fn header_value(&self) -> HeaderValue {
-        self.header_value()
+        let output = format!("{}", self.length);
+
+        // SAFETY: the internal string is validated to be ASCII.
+        unsafe { HeaderValue::from_bytes_unchecked(output.into()) }
     }
 }
 

--- a/src/content/content_length.rs
+++ b/src/content/content_length.rs
@@ -12,7 +12,7 @@ use crate::Status;
 /// ```
 /// # fn main() -> http_types::Result<()> {
 /// #
-/// use http_types::Response;
+/// use http_types::{headers::Header, Response};
 /// use http_types::content::{ContentLength};
 ///
 /// let content_len = ContentLength::new(12);

--- a/src/content/content_location.rs
+++ b/src/content/content_location.rs
@@ -16,13 +16,13 @@ use std::convert::TryInto;
 /// ```
 /// # fn main() -> http_types::Result<()> {
 /// #
-/// use http_types::{headers::Header, Response, Url};
+/// use http_types::{Response, Url};
 /// use http_types::content::ContentLocation;
 ///
 /// let content_location = ContentLocation::new(Url::parse("https://example.net/")?);
 ///
 /// let mut res = Response::new(200);
-/// content_location.apply_header(&mut res);
+/// res.insert_header(&content_location, &content_location);
 ///
 /// let url = Url::parse("https://example.net/")?;
 /// let content_location = ContentLocation::from_headers(url, res)?.unwrap();

--- a/src/content/content_location.rs
+++ b/src/content/content_location.rs
@@ -16,7 +16,7 @@ use std::convert::TryInto;
 /// ```
 /// # fn main() -> http_types::Result<()> {
 /// #
-/// use http_types::{Response, Url};
+/// use http_types::{headers::Header, Response, Url};
 /// use http_types::content::ContentLocation;
 ///
 /// let content_location = ContentLocation::new(Url::parse("https://example.net/")?);

--- a/src/content/content_location.rs
+++ b/src/content/content_location.rs
@@ -1,4 +1,4 @@
-use crate::headers::{HeaderName, HeaderValue, Headers, CONTENT_LOCATION};
+use crate::headers::{Header, HeaderName, HeaderValue, Headers, CONTENT_LOCATION};
 use crate::{bail_status as bail, Status, Url};
 
 use std::convert::TryInto;
@@ -22,7 +22,7 @@ use std::convert::TryInto;
 /// let content_location = ContentLocation::new(Url::parse("https://example.net/")?);
 ///
 /// let mut res = Response::new(200);
-/// content_location.apply(&mut res);
+/// content_location.apply_header(&mut res);
 ///
 /// let url = Url::parse("https://example.net/")?;
 /// let content_location = ContentLocation::from_headers(url, res)?.unwrap();
@@ -66,7 +66,7 @@ impl ContentLocation {
 
     /// Sets the header.
     pub fn apply(&self, mut headers: impl AsMut<Headers>) {
-        headers.as_mut().insert(self.name(), self.value());
+        headers.as_mut().insert(self.name(), self.header_value());
     }
 
     /// Get the `HeaderName`.
@@ -99,12 +99,12 @@ impl ContentLocation {
     }
 }
 
-impl crate::headers::Header for ContentLocation {
+impl Header for ContentLocation {
     fn header_name(&self) -> HeaderName {
         CONTENT_LOCATION
     }
     fn header_value(&self) -> HeaderValue {
-        self.value()
+        self.header_value()
     }
 }
 
@@ -118,7 +118,7 @@ mod test {
         let content_location = ContentLocation::new(Url::parse("https://example.net/test.json")?);
 
         let mut headers = Headers::new();
-        content_location.apply(&mut headers);
+        content_location.apply_header(&mut headers);
 
         let content_location =
             ContentLocation::from_headers(Url::parse("https://example.net/").unwrap(), headers)?

--- a/src/content/content_location.rs
+++ b/src/content/content_location.rs
@@ -64,24 +64,6 @@ impl ContentLocation {
         Ok(Some(Self { url }))
     }
 
-    /// Sets the header.
-    pub fn apply(&self, mut headers: impl AsMut<Headers>) {
-        headers.as_mut().insert(self.name(), self.header_value());
-    }
-
-    /// Get the `HeaderName`.
-    pub fn name(&self) -> HeaderName {
-        CONTENT_LOCATION
-    }
-
-    /// Get the `HeaderValue`.
-    pub fn value(&self) -> HeaderValue {
-        let output = self.url.to_string();
-
-        // SAFETY: the internal string is validated to be ASCII.
-        unsafe { HeaderValue::from_bytes_unchecked(output.into()) }
-    }
-
     /// Get the url.
     pub fn location(&self) -> &Url {
         &self.url
@@ -104,7 +86,10 @@ impl Header for ContentLocation {
         CONTENT_LOCATION
     }
     fn header_value(&self) -> HeaderValue {
-        self.header_value()
+        let output = self.url.to_string();
+
+        // SAFETY: the internal string is validated to be ASCII.
+        unsafe { HeaderValue::from_bytes_unchecked(output.into()) }
     }
 }
 

--- a/src/content/content_type.rs
+++ b/src/content/content_type.rs
@@ -25,7 +25,7 @@ use crate::mime::Mime;
 /// let content_type = ContentType::new("text/*");
 ///
 /// let mut res = Response::new(200);
-/// content_type.apply_header(&mut res);
+/// res.insert_header(&content_type, &content_type);
 ///
 /// let content_type = ContentType::from_headers(res)?.unwrap();
 /// assert_eq!(content_type.header_value(), format!("{}", Mime::from_str("text/*")?).as_str());

--- a/src/content/content_type.rs
+++ b/src/content/content_type.rs
@@ -18,7 +18,7 @@ use crate::mime::Mime;
 /// # fn main() -> http_types::Result<()> {
 /// #
 /// use http_types::content::ContentType;
-/// use http_types::Response;
+/// use http_types::{headers::Header, Response};
 /// use http_types::mime::Mime;
 /// use std::str::FromStr;
 ///

--- a/src/content/content_type.rs
+++ b/src/content/content_type.rs
@@ -1,6 +1,6 @@
 use std::{convert::TryInto, str::FromStr};
 
-use crate::headers::{HeaderName, HeaderValue, Headers, CONTENT_TYPE};
+use crate::headers::{Header, HeaderName, HeaderValue, Headers, CONTENT_TYPE};
 use crate::mime::Mime;
 
 /// Indicate the media type of a resource's content.
@@ -25,10 +25,10 @@ use crate::mime::Mime;
 /// let content_type = ContentType::new("text/*");
 ///
 /// let mut res = Response::new(200);
-/// content_type.apply(&mut res);
+/// content_type.apply_header(&mut res);
 ///
 /// let content_type = ContentType::from_headers(res)?.unwrap();
-/// assert_eq!(content_type.value(), format!("{}", Mime::from_str("text/*")?).as_str());
+/// assert_eq!(content_type.header_value(), format!("{}", Mime::from_str("text/*")?).as_str());
 /// #
 /// # Ok(()) }
 /// ```
@@ -76,7 +76,7 @@ impl ContentType {
 
     /// Sets the header.
     pub fn apply(&self, mut headers: impl AsMut<Headers>) {
-        headers.as_mut().insert(self.name(), self.value());
+        headers.as_mut().insert(self.name(), self.header_value());
     }
 
     /// Get the `HeaderName`.
@@ -92,12 +92,12 @@ impl ContentType {
     }
 }
 
-impl crate::headers::Header for ContentType {
+impl Header for ContentType {
     fn header_name(&self) -> HeaderName {
         CONTENT_TYPE
     }
     fn header_value(&self) -> HeaderValue {
-        self.value()
+        self.header_value()
     }
 }
 
@@ -129,11 +129,11 @@ mod test {
         let ct = ContentType::new(Mime::from_str("text/*")?);
 
         let mut headers = Headers::new();
-        ct.apply(&mut headers);
+        ct.apply_header(&mut headers);
 
         let ct = ContentType::from_headers(headers)?.unwrap();
         assert_eq!(
-            ct.value(),
+            ct.header_value(),
             format!("{}", Mime::from_str("text/*")?).as_str()
         );
         Ok(())

--- a/src/content/content_type.rs
+++ b/src/content/content_type.rs
@@ -73,23 +73,6 @@ impl ContentType {
         })?;
         Ok(Some(Self { media_type }))
     }
-
-    /// Sets the header.
-    pub fn apply(&self, mut headers: impl AsMut<Headers>) {
-        headers.as_mut().insert(self.name(), self.header_value());
-    }
-
-    /// Get the `HeaderName`.
-    pub fn name(&self) -> HeaderName {
-        CONTENT_TYPE
-    }
-
-    /// Get the `HeaderValue`.
-    pub fn value(&self) -> HeaderValue {
-        let output = format!("{}", self.media_type);
-        // SAFETY: the internal string is validated to be ASCII.
-        unsafe { HeaderValue::from_bytes_unchecked(output.into()) }
-    }
 }
 
 impl Header for ContentType {
@@ -97,7 +80,9 @@ impl Header for ContentType {
         CONTENT_TYPE
     }
     fn header_value(&self) -> HeaderValue {
-        self.header_value()
+        let output = format!("{}", self.media_type);
+        // SAFETY: the internal string is validated to be ASCII.
+        unsafe { HeaderValue::from_bytes_unchecked(output.into()) }
     }
 }
 

--- a/src/content/mod.rs
+++ b/src/content/mod.rs
@@ -15,7 +15,7 @@
 //! # fn main() -> http_types::Result<()> {
 //! #
 //! use http_types::content::{Accept, MediaTypeProposal};
-//! use http_types::{headers::Header, mime, Response};
+//! use http_types::{mime, Response};
 //!
 //! let mut accept = Accept::new();
 //! accept.push(MediaTypeProposal::new(mime::HTML, Some(0.8))?);
@@ -24,7 +24,7 @@
 //!
 //! let mut res = Response::new(200);
 //! let content_type = accept.negotiate(&[mime::XML])?;
-//! content_type.apply_header(&mut res);
+//! res.insert_header(&content_type, &content_type);
 //!
 //! assert_eq!(res["Content-Type"], "application/xml;charset=utf-8");
 //! #

--- a/src/content/mod.rs
+++ b/src/content/mod.rs
@@ -24,7 +24,7 @@
 //!
 //! let mut res = Response::new(200);
 //! let content_type = accept.negotiate(&[mime::XML])?;
-//! content_type.apply(&mut res);
+//! content_type.apply_header(&mut res);
 //!
 //! assert_eq!(res["Content-Type"], "application/xml;charset=utf-8");
 //! #

--- a/src/content/mod.rs
+++ b/src/content/mod.rs
@@ -15,7 +15,7 @@
 //! # fn main() -> http_types::Result<()> {
 //! #
 //! use http_types::content::{Accept, MediaTypeProposal};
-//! use http_types::{mime, Response};
+//! use http_types::{headers::Header, mime, Response};
 //!
 //! let mut accept = Accept::new();
 //! accept.push(MediaTypeProposal::new(mime::HTML, Some(0.8))?);

--- a/src/headers/header.rs
+++ b/src/headers/header.rs
@@ -1,3 +1,5 @@
+use std::ops::Deref;
+
 use crate::headers::{HeaderName, HeaderValue, Headers};
 
 /// A trait representing a [`HeaderName`] and [`HeaderValue`] pair.
@@ -25,6 +27,16 @@ impl<'a, 'b> Header for (&'a str, &'b str) {
     fn header_value(&self) -> HeaderValue {
         HeaderValue::from_bytes(self.1.to_owned().into_bytes())
             .expect("String slice should be valid ASCII")
+    }
+}
+
+impl<'a, T: Header> Header for &'a T {
+    fn header_name(&self) -> HeaderName {
+        self.deref().header_name()
+    }
+
+    fn header_value(&self) -> HeaderValue {
+        self.deref().header_value()
     }
 }
 

--- a/src/headers/header_name.rs
+++ b/src/headers/header_name.rs
@@ -4,6 +4,8 @@ use std::str::FromStr;
 
 use crate::Error;
 
+use super::Header;
+
 /// A header name.
 #[derive(Clone, PartialEq, Eq, Hash)]
 pub struct HeaderName(Cow<'static, str>);
@@ -85,6 +87,12 @@ impl FromStr for HeaderName {
 impl From<&HeaderName> for HeaderName {
     fn from(value: &HeaderName) -> HeaderName {
         value.clone()
+    }
+}
+
+impl<T: Header> From<T> for HeaderName {
+    fn from(header: T) -> HeaderName {
+        header.header_name()
     }
 }
 

--- a/src/headers/to_header_values.rs
+++ b/src/headers/to_header_values.rs
@@ -4,7 +4,7 @@ use std::iter;
 use std::option;
 use std::slice;
 
-use crate::headers::{HeaderValue, HeaderValues, Values};
+use crate::headers::{Header, HeaderValue, HeaderValues, Values};
 
 /// A trait for objects which can be converted or resolved to one or more `HeaderValue`s.
 pub trait ToHeaderValues {
@@ -13,6 +13,14 @@ pub trait ToHeaderValues {
 
     /// Converts this object to an iterator of resolved `HeaderValues`.
     fn to_header_values(&self) -> crate::Result<Self::Iter>;
+}
+
+impl<T: Header> ToHeaderValues for T {
+    type Iter = option::IntoIter<HeaderValue>;
+
+    fn to_header_values(&self) -> crate::Result<Self::Iter> {
+        Ok(Some(self.header_value()).into_iter())
+    }
 }
 
 impl ToHeaderValues for HeaderValue {

--- a/src/other/date.rs
+++ b/src/other/date.rs
@@ -14,7 +14,7 @@ use std::time::SystemTime;
 /// ```
 /// # fn main() -> http_types::Result<()> {
 /// #
-/// use http_types::Response;
+/// use http_types::{headers::Header, Response};
 /// use http_types::other::Date;
 ///
 /// use std::time::{Duration, SystemTime};

--- a/src/other/date.rs
+++ b/src/other/date.rs
@@ -23,7 +23,7 @@ use std::time::SystemTime;
 /// let date = Date::new(now);
 ///
 /// let mut res = Response::new(200);
-/// date.apply_header(&mut res);
+/// res.insert_header(&date, &date);
 ///
 /// let date = Date::from_headers(res)?.unwrap();
 ///

--- a/src/other/date.rs
+++ b/src/other/date.rs
@@ -71,33 +71,19 @@ impl Date {
         let at = date.into();
         Ok(Some(Self { at }))
     }
-
-    /// Sets the header.
-    pub fn apply(&self, mut headers: impl AsMut<Headers>) {
-        headers.as_mut().insert(self.name(), self.header_value());
-    }
-
-    /// Get the `HeaderName`.
-    pub fn name(&self) -> HeaderName {
-        DATE
-    }
-
-    /// Get the `HeaderValue`.
-    pub fn value(&self) -> HeaderValue {
-        let date: HttpDate = self.at.into();
-        let output = format!("{}", date);
-
-        // SAFETY: the internal string is validated to be ASCII.
-        unsafe { HeaderValue::from_bytes_unchecked(output.into()) }
-    }
 }
 
 impl Header for Date {
     fn header_name(&self) -> HeaderName {
         DATE
     }
+
     fn header_value(&self) -> HeaderValue {
-        self.header_value()
+        let date: HttpDate = self.at.into();
+        let output = format!("{}", date);
+
+        // SAFETY: the internal string is validated to be ASCII.
+        unsafe { HeaderValue::from_bytes_unchecked(output.into()) }
     }
 }
 

--- a/src/other/date.rs
+++ b/src/other/date.rs
@@ -1,4 +1,4 @@
-use crate::headers::{HeaderName, HeaderValue, Headers, DATE};
+use crate::headers::{Header, HeaderName, HeaderValue, Headers, DATE};
 use crate::utils::HttpDate;
 
 use std::time::SystemTime;
@@ -23,7 +23,7 @@ use std::time::SystemTime;
 /// let date = Date::new(now);
 ///
 /// let mut res = Response::new(200);
-/// date.apply(&mut res);
+/// date.apply_header(&mut res);
 ///
 /// let date = Date::from_headers(res)?.unwrap();
 ///
@@ -74,7 +74,7 @@ impl Date {
 
     /// Sets the header.
     pub fn apply(&self, mut headers: impl AsMut<Headers>) {
-        headers.as_mut().insert(self.name(), self.value());
+        headers.as_mut().insert(self.name(), self.header_value());
     }
 
     /// Get the `HeaderName`.
@@ -92,12 +92,12 @@ impl Date {
     }
 }
 
-impl crate::headers::Header for Date {
+impl Header for Date {
     fn header_name(&self) -> HeaderName {
         DATE
     }
     fn header_value(&self) -> HeaderValue {
-        self.value()
+        self.header_value()
     }
 }
 
@@ -131,7 +131,7 @@ mod test {
         let date = Date::new(now);
 
         let mut headers = Headers::new();
-        date.apply(&mut headers);
+        date.apply_header(&mut headers);
 
         let date = Date::from_headers(headers)?.unwrap();
 

--- a/src/other/date.rs
+++ b/src/other/date.rs
@@ -14,7 +14,7 @@ use std::time::SystemTime;
 /// ```
 /// # fn main() -> http_types::Result<()> {
 /// #
-/// use http_types::{headers::Header, Response};
+/// use http_types::Response;
 /// use http_types::other::Date;
 ///
 /// use std::time::{Duration, SystemTime};

--- a/src/other/expect.rs
+++ b/src/other/expect.rs
@@ -17,7 +17,7 @@ use std::option;
 /// ```
 /// # fn main() -> http_types::Result<()> {
 /// #
-/// use http_types::{headers::Header, Response};
+/// use http_types::Response;
 /// use http_types::other::Expect;
 ///
 /// let expect = Expect::new();

--- a/src/other/expect.rs
+++ b/src/other/expect.rs
@@ -1,5 +1,5 @@
-use crate::ensure_eq_status;
 use crate::headers::{HeaderName, HeaderValue, Headers, ToHeaderValues, EXPECT};
+use crate::{ensure_eq_status, headers::Header};
 
 use std::fmt::Debug;
 use std::option;
@@ -23,7 +23,7 @@ use std::option;
 /// let expect = Expect::new();
 ///
 /// let mut res = Response::new(200);
-/// expect.apply(&mut res);
+/// expect.apply_header(&mut res);
 ///
 /// let expect = Expect::from_headers(res)?.unwrap();
 /// assert_eq!(expect, Expect::new());
@@ -58,7 +58,7 @@ impl Expect {
 
     /// Insert a `HeaderName` + `HeaderValue` pair into a `Headers` instance.
     pub fn apply(&self, mut headers: impl AsMut<Headers>) {
-        headers.as_mut().insert(EXPECT, self.value());
+        headers.as_mut().insert(EXPECT, self.header_value());
     }
 
     /// Get the `HeaderName`.
@@ -74,12 +74,12 @@ impl Expect {
     }
 }
 
-impl crate::headers::Header for Expect {
+impl Header for Expect {
     fn header_name(&self) -> HeaderName {
         EXPECT
     }
     fn header_value(&self) -> HeaderValue {
-        self.value()
+        self.header_value()
     }
 }
 
@@ -87,7 +87,7 @@ impl ToHeaderValues for Expect {
     type Iter = option::IntoIter<HeaderValue>;
     fn to_header_values(&self) -> crate::Result<Self::Iter> {
         // A HeaderValue will always convert into itself.
-        Ok(self.value().to_header_values().unwrap())
+        Ok(self.header_value().to_header_values().unwrap())
     }
 }
 
@@ -101,7 +101,7 @@ mod test {
         let expect = Expect::new();
 
         let mut headers = Headers::new();
-        expect.apply(&mut headers);
+        expect.apply_header(&mut headers);
 
         let expect = Expect::from_headers(headers)?.unwrap();
         assert_eq!(expect, Expect::new());

--- a/src/other/expect.rs
+++ b/src/other/expect.rs
@@ -3,7 +3,6 @@ use crate::{ensure_eq_status, headers::Header};
 
 use std::fmt::Debug;
 
-
 /// HTTP `Expect` header
 ///
 /// [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Expect)

--- a/src/other/expect.rs
+++ b/src/other/expect.rs
@@ -17,7 +17,7 @@ use std::option;
 /// ```
 /// # fn main() -> http_types::Result<()> {
 /// #
-/// use http_types::Response;
+/// use http_types::{headers::Header, Response};
 /// use http_types::other::Expect;
 ///
 /// let expect = Expect::new();

--- a/src/other/expect.rs
+++ b/src/other/expect.rs
@@ -23,7 +23,7 @@ use std::option;
 /// let expect = Expect::new();
 ///
 /// let mut res = Response::new(200);
-/// expect.apply_header(&mut res);
+/// res.insert_header(&expect, &expect);
 ///
 /// let expect = Expect::from_headers(res)?.unwrap();
 /// assert_eq!(expect, Expect::new());
@@ -65,14 +65,6 @@ impl Header for Expect {
         let value = "100-continue";
         // SAFETY: the internal string is validated to be ASCII.
         unsafe { HeaderValue::from_bytes_unchecked(value.into()) }
-    }
-}
-
-impl ToHeaderValues for Expect {
-    type Iter = option::IntoIter<HeaderValue>;
-    fn to_header_values(&self) -> crate::Result<Self::Iter> {
-        // A HeaderValue will always convert into itself.
-        Ok(self.header_value().to_header_values().unwrap())
     }
 }
 

--- a/src/other/expect.rs
+++ b/src/other/expect.rs
@@ -1,8 +1,8 @@
-use crate::headers::{HeaderName, HeaderValue, Headers, ToHeaderValues, EXPECT};
+use crate::headers::{HeaderName, HeaderValue, Headers, EXPECT};
 use crate::{ensure_eq_status, headers::Header};
 
 use std::fmt::Debug;
-use std::option;
+
 
 /// HTTP `Expect` header
 ///

--- a/src/other/expect.rs
+++ b/src/other/expect.rs
@@ -55,23 +55,6 @@ impl Expect {
 
         Ok(Some(Self { _priv: () }))
     }
-
-    /// Insert a `HeaderName` + `HeaderValue` pair into a `Headers` instance.
-    pub fn apply(&self, mut headers: impl AsMut<Headers>) {
-        headers.as_mut().insert(EXPECT, self.header_value());
-    }
-
-    /// Get the `HeaderName`.
-    pub fn name(&self) -> HeaderName {
-        EXPECT
-    }
-
-    /// Get the `HeaderValue`.
-    pub fn value(&self) -> HeaderValue {
-        let value = "100-continue";
-        // SAFETY: the internal string is validated to be ASCII.
-        unsafe { HeaderValue::from_bytes_unchecked(value.into()) }
-    }
 }
 
 impl Header for Expect {
@@ -79,7 +62,9 @@ impl Header for Expect {
         EXPECT
     }
     fn header_value(&self) -> HeaderValue {
-        self.header_value()
+        let value = "100-continue";
+        // SAFETY: the internal string is validated to be ASCII.
+        unsafe { HeaderValue::from_bytes_unchecked(value.into()) }
     }
 }
 

--- a/src/other/referer.rs
+++ b/src/other/referer.rs
@@ -19,7 +19,7 @@ use std::convert::TryInto;
 /// ```
 /// # fn main() -> http_types::Result<()> {
 /// #
-/// use http_types::{Response, Url};
+/// use http_types::{headers::Header, Response, Url};
 /// use http_types::other::Referer;
 ///
 /// let referer = Referer::new(Url::parse("https://example.net/")?);

--- a/src/other/referer.rs
+++ b/src/other/referer.rs
@@ -25,7 +25,7 @@ use std::convert::TryInto;
 /// let referer = Referer::new(Url::parse("https://example.net/")?);
 ///
 /// let mut res = Response::new(200);
-/// referer.apply_header(&mut res);
+/// res.insert_header(&referer, &referer);
 ///
 /// let base_url = Url::parse("https://example.net/")?;
 /// let referer = Referer::from_headers(base_url, res)?.unwrap();

--- a/src/other/referer.rs
+++ b/src/other/referer.rs
@@ -70,24 +70,6 @@ impl Referer {
         Ok(Some(Self { location: url }))
     }
 
-    /// Sets the header.
-    pub fn apply(&self, mut headers: impl AsMut<Headers>) {
-        headers.as_mut().insert(self.name(), self.header_value());
-    }
-
-    /// Get the `HeaderName`.
-    pub fn name(&self) -> HeaderName {
-        REFERER
-    }
-
-    /// Get the `HeaderValue`.
-    pub fn value(&self) -> HeaderValue {
-        let output = self.location.to_string();
-
-        // SAFETY: the internal string is validated to be ASCII.
-        unsafe { HeaderValue::from_bytes_unchecked(output.into()) }
-    }
-
     /// Get the url.
     pub fn location(&self) -> &Url {
         &self.location
@@ -108,8 +90,12 @@ impl Header for Referer {
     fn header_name(&self) -> HeaderName {
         REFERER
     }
+
     fn header_value(&self) -> HeaderValue {
-        self.header_value()
+        let output = self.location.to_string();
+
+        // SAFETY: the internal string is validated to be ASCII.
+        unsafe { HeaderValue::from_bytes_unchecked(output.into()) }
     }
 }
 

--- a/src/other/referer.rs
+++ b/src/other/referer.rs
@@ -19,7 +19,7 @@ use std::convert::TryInto;
 /// ```
 /// # fn main() -> http_types::Result<()> {
 /// #
-/// use http_types::{headers::Header, Response, Url};
+/// use http_types::{Response, Url};
 /// use http_types::other::Referer;
 ///
 /// let referer = Referer::new(Url::parse("https://example.net/")?);

--- a/src/other/referer.rs
+++ b/src/other/referer.rs
@@ -1,4 +1,4 @@
-use crate::headers::{HeaderName, HeaderValue, Headers, REFERER};
+use crate::headers::{Header, HeaderName, HeaderValue, Headers, REFERER};
 use crate::{bail_status as bail, Status, Url};
 
 use std::convert::TryInto;
@@ -25,7 +25,7 @@ use std::convert::TryInto;
 /// let referer = Referer::new(Url::parse("https://example.net/")?);
 ///
 /// let mut res = Response::new(200);
-/// referer.apply(&mut res);
+/// referer.apply_header(&mut res);
 ///
 /// let base_url = Url::parse("https://example.net/")?;
 /// let referer = Referer::from_headers(base_url, res)?.unwrap();
@@ -72,7 +72,7 @@ impl Referer {
 
     /// Sets the header.
     pub fn apply(&self, mut headers: impl AsMut<Headers>) {
-        headers.as_mut().insert(self.name(), self.value());
+        headers.as_mut().insert(self.name(), self.header_value());
     }
 
     /// Get the `HeaderName`.
@@ -104,12 +104,12 @@ impl Referer {
     }
 }
 
-impl crate::headers::Header for Referer {
+impl Header for Referer {
     fn header_name(&self) -> HeaderName {
         REFERER
     }
     fn header_value(&self) -> HeaderValue {
-        self.value()
+        self.header_value()
     }
 }
 
@@ -123,7 +123,7 @@ mod test {
         let referer = Referer::new(Url::parse("https://example.net/test.json")?);
 
         let mut headers = Headers::new();
-        referer.apply(&mut headers);
+        referer.apply_header(&mut headers);
 
         let base_url = Url::parse("https://example.net/")?;
         let referer = Referer::from_headers(base_url, headers)?.unwrap();

--- a/src/other/retry_after.rs
+++ b/src/other/retry_after.rs
@@ -17,7 +17,7 @@ use crate::utils::{fmt_http_date, parse_http_date};
 /// # fn main() -> http_types::Result<()> {
 /// #
 /// use http_types::other::RetryAfter;
-/// use http_types::{headers::Header, Response};
+/// use http_types::Response;
 /// use std::time::{SystemTime, Duration};
 /// use async_std::task;
 ///

--- a/src/other/retry_after.rs
+++ b/src/other/retry_after.rs
@@ -17,7 +17,7 @@ use crate::utils::{fmt_http_date, parse_http_date};
 /// # fn main() -> http_types::Result<()> {
 /// #
 /// use http_types::other::RetryAfter;
-/// use http_types::Response;
+/// use http_types::{headers::Header, Response};
 /// use std::time::{SystemTime, Duration};
 /// use async_std::task;
 ///

--- a/src/other/retry_after.rs
+++ b/src/other/retry_after.rs
@@ -24,7 +24,7 @@ use crate::utils::{fmt_http_date, parse_http_date};
 /// let retry = RetryAfter::new(Duration::from_secs(10));
 ///
 /// let mut headers = Response::new(429);
-/// retry.apply_header(&mut headers);
+/// headers.insert_header(&retry, &retry);
 ///
 /// // Sleep for the duration, then try the task again.
 /// let retry = RetryAfter::from_headers(headers)?.unwrap();

--- a/src/other/source_map.rs
+++ b/src/other/source_map.rs
@@ -67,24 +67,6 @@ impl SourceMap {
         Ok(Some(Self { location: url }))
     }
 
-    /// Sets the header.
-    pub fn apply(&self, mut headers: impl AsMut<Headers>) {
-        headers.as_mut().insert(self.name(), self.header_value());
-    }
-
-    /// Get the `HeaderName`.
-    pub fn name(&self) -> HeaderName {
-        SOURCE_MAP
-    }
-
-    /// Get the `HeaderValue`.
-    pub fn value(&self) -> HeaderValue {
-        let output = self.location.to_string();
-
-        // SAFETY: the internal string is validated to be ASCII.
-        unsafe { HeaderValue::from_bytes_unchecked(output.into()) }
-    }
-
     /// Get the url.
     pub fn location(&self) -> &Url {
         &self.location
@@ -105,8 +87,12 @@ impl Header for SourceMap {
     fn header_name(&self) -> HeaderName {
         SOURCE_MAP
     }
+
     fn header_value(&self) -> HeaderValue {
-        self.header_value()
+        let output = self.location.to_string();
+
+        // SAFETY: the internal string is validated to be ASCII.
+        unsafe { HeaderValue::from_bytes_unchecked(output.into()) }
     }
 }
 

--- a/src/other/source_map.rs
+++ b/src/other/source_map.rs
@@ -16,13 +16,13 @@ use std::convert::TryInto;
 /// ```
 /// # fn main() -> http_types::Result<()> {
 /// #
-/// use http_types::{headers::Header, Response, Url};
+/// use http_types::{Response, Url};
 /// use http_types::other::SourceMap;
 ///
 /// let source_map = SourceMap::new(Url::parse("https://example.net/")?);
 ///
 /// let mut res = Response::new(200);
-/// source_map.apply_header(&mut res);
+/// res.insert_header(&source_map, &source_map);
 ///
 /// let base_url = Url::parse("https://example.net/")?;
 /// let source_map = SourceMap::from_headers(base_url, res)?.unwrap();

--- a/src/other/source_map.rs
+++ b/src/other/source_map.rs
@@ -16,7 +16,7 @@ use std::convert::TryInto;
 /// ```
 /// # fn main() -> http_types::Result<()> {
 /// #
-/// use http_types::{Response, Url};
+/// use http_types::{headers::Header, Response, Url};
 /// use http_types::other::SourceMap;
 ///
 /// let source_map = SourceMap::new(Url::parse("https://example.net/")?);

--- a/src/other/source_map.rs
+++ b/src/other/source_map.rs
@@ -1,4 +1,4 @@
-use crate::headers::{HeaderName, HeaderValue, Headers, SOURCE_MAP};
+use crate::headers::{Header, HeaderName, HeaderValue, Headers, SOURCE_MAP};
 use crate::{bail_status as bail, Status, Url};
 
 use std::convert::TryInto;
@@ -22,7 +22,7 @@ use std::convert::TryInto;
 /// let source_map = SourceMap::new(Url::parse("https://example.net/")?);
 ///
 /// let mut res = Response::new(200);
-/// source_map.apply(&mut res);
+/// source_map.apply_header(&mut res);
 ///
 /// let base_url = Url::parse("https://example.net/")?;
 /// let source_map = SourceMap::from_headers(base_url, res)?.unwrap();
@@ -69,7 +69,7 @@ impl SourceMap {
 
     /// Sets the header.
     pub fn apply(&self, mut headers: impl AsMut<Headers>) {
-        headers.as_mut().insert(self.name(), self.value());
+        headers.as_mut().insert(self.name(), self.header_value());
     }
 
     /// Get the `HeaderName`.
@@ -101,12 +101,12 @@ impl SourceMap {
     }
 }
 
-impl crate::headers::Header for SourceMap {
+impl Header for SourceMap {
     fn header_name(&self) -> HeaderName {
         SOURCE_MAP
     }
     fn header_value(&self) -> HeaderValue {
-        self.value()
+        self.header_value()
     }
 }
 
@@ -120,7 +120,7 @@ mod test {
         let source_map = SourceMap::new(Url::parse("https://example.net/test.json")?);
 
         let mut headers = Headers::new();
-        source_map.apply(&mut headers);
+        source_map.apply_header(&mut headers);
 
         let base_url = Url::parse("https://example.net/")?;
         let source_map = SourceMap::from_headers(base_url, headers)?.unwrap();

--- a/src/proxies/forwarded.rs
+++ b/src/proxies/forwarded.rs
@@ -43,7 +43,7 @@ impl<'a> Forwarded<'a> {
     /// # Examples
     /// ```rust
     /// # fn main() -> http_types::Result<()> {
-    /// use http_types::{headers::Header, Request};
+    /// use http_types::{Request};
     /// use http_types::proxies::Forwarded;
     ///
     /// let mut request = Request::get("http://_/");

--- a/src/proxies/forwarded.rs
+++ b/src/proxies/forwarded.rs
@@ -1,5 +1,5 @@
 use crate::{
-    headers::{Header, HeaderName, HeaderValue, Headers, ToHeaderValues, FORWARDED},
+    headers::{Header, HeaderName, HeaderValue, Headers, FORWARDED},
     parse_utils::{parse_quoted_string, parse_token},
 };
 use std::{borrow::Cow, convert::TryFrom, fmt::Write, net::IpAddr};

--- a/src/proxies/forwarded.rs
+++ b/src/proxies/forwarded.rs
@@ -1,5 +1,5 @@
 use crate::{
-    headers::{HeaderName, HeaderValue, Headers, ToHeaderValues, FORWARDED},
+    headers::{Header, HeaderName, HeaderValue, Headers, ToHeaderValues, FORWARDED},
     parse_utils::{parse_quoted_string, parse_token},
 };
 use std::{borrow::Cow, convert::TryFrom, fmt::Write, net::IpAddr};
@@ -65,7 +65,7 @@ impl<'a> Forwarded<'a> {
     /// assert_eq!(forwarded.forwarded_for(), vec!["192.0.2.43", "[2001:db8:cafe::17]", "unknown"]);
     /// assert_eq!(forwarded.proto(), Some("https"));
     /// assert_eq!(
-    ///     forwarded.value()?,
+    ///     forwarded.header_value()?,
     ///     r#"for=192.0.2.43, for="[2001:db8:cafe::17]", for=unknown;proto=https"#
     /// );
     /// # Ok(()) }
@@ -188,7 +188,7 @@ impl<'a> Forwarded<'a> {
     /// )?;
     /// assert_eq!(forwarded.forwarded_for(), vec!["192.0.2.43", "[2001:db8:cafe::17]", "unknown"]);
     /// assert_eq!(
-    ///     forwarded.value()?,
+    ///     forwarded.header_value()?,
     ///     r#"for=192.0.2.43, for="[2001:db8:cafe::17]", for=unknown;proto=https"#
     /// );
     /// # Ok(()) }
@@ -301,67 +301,6 @@ impl<'a> Forwarded<'a> {
         }
     }
 
-    /// Insert a header that represents this Forwarded.
-    ///
-    /// # Example
-    ///
-    /// ```rust
-    /// let mut response = http_types::Response::new(200);
-    /// let mut forwarded = http_types::proxies::Forwarded::new();
-    /// forwarded.add_for("192.0.2.43");
-    /// forwarded.add_for("[2001:db8:cafe::17]");
-    /// forwarded.set_proto("https");
-    /// forwarded.apply(&mut response);
-    /// assert_eq!(response["Forwarded"], r#"for=192.0.2.43, for="[2001:db8:cafe::17]";proto=https"#);
-    /// ```
-    pub fn apply(&self, mut headers: impl AsMut<Headers>) {
-        headers.as_mut().insert(FORWARDED, self);
-    }
-
-    /// Builds a Forwarded header as a String.
-    ///
-    /// # Example
-    ///
-    /// ```rust
-    /// # fn main() -> http_types::Result<()> {
-    /// let mut forwarded = http_types::proxies::Forwarded::new();
-    /// forwarded.add_for("_haproxy");
-    /// forwarded.add_for("[2001:db8:cafe::17]");
-    /// forwarded.set_proto("https");
-    /// assert_eq!(forwarded.value()?, r#"for=_haproxy, for="[2001:db8:cafe::17]";proto=https"#);
-    /// # Ok(()) }
-    /// ```
-    pub fn value(&self) -> Result<String, std::fmt::Error> {
-        let mut buf = String::new();
-        if let Some(by) = self.by() {
-            write!(&mut buf, "by={};", by)?;
-        }
-
-        buf.push_str(
-            &self
-                .forwarded_for
-                .iter()
-                .map(|f| format!("for={}", format_value(f)))
-                .collect::<Vec<_>>()
-                .join(", "),
-        );
-
-        buf.push(';');
-
-        if let Some(host) = self.host() {
-            write!(&mut buf, "host={};", host)?;
-        }
-
-        if let Some(proto) = self.proto() {
-            write!(&mut buf, "proto={};", proto)?;
-        }
-
-        // remove a trailing semicolon
-        buf.pop();
-
-        Ok(buf)
-    }
-
     /// Builds a new empty Forwarded
     pub fn new() -> Self {
         Self::default()
@@ -408,13 +347,38 @@ impl<'a> Forwarded<'a> {
     }
 }
 
-impl<'a> crate::headers::Header for Forwarded<'a> {
+impl<'a> Header for Forwarded<'a> {
     fn header_name(&self) -> HeaderName {
         FORWARDED
     }
     fn header_value(&self) -> HeaderValue {
-        // NOTE(yosh): This will never panic because we always write into a string.
-        let output = self.value().unwrap();
+        let mut output = String::new();
+        if let Some(by) = self.by() {
+            write!(&mut output, "by={};", by).unwrap();
+        }
+
+        output.push_str(
+            &self
+                .forwarded_for
+                .iter()
+                .map(|f| format!("for={}", format_value(f)))
+                .collect::<Vec<_>>()
+                .join(", "),
+        );
+
+        output.push(';');
+
+        if let Some(host) = self.host() {
+            write!(&mut output, "host={};", host).unwrap();
+        }
+
+        if let Some(proto) = self.proto() {
+            write!(&mut output, "proto={};", proto).unwrap();
+        }
+
+        // remove a trailing semicolon
+        output.pop();
+
         // SAFETY: the internal string is validated to be ASCII.
         unsafe { HeaderValue::from_bytes_unchecked(output.into()) }
     }
@@ -460,21 +424,21 @@ fn starts_with_ignore_case(start: &'static str, input: &str) -> bool {
 
 impl std::fmt::Display for Forwarded<'_> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.write_str(&self.value()?)
+        f.write_str(&self.header_value().as_str())
     }
 }
 
 impl ToHeaderValues for Forwarded<'_> {
     type Iter = std::option::IntoIter<HeaderValue>;
     fn to_header_values(&self) -> crate::Result<Self::Iter> {
-        Ok(self.value()?.to_header_values()?)
+        Ok(self.header_value().to_header_values()?)
     }
 }
 
 impl ToHeaderValues for &Forwarded<'_> {
     type Iter = std::option::IntoIter<HeaderValue>;
     fn to_header_values(&self) -> crate::Result<Self::Iter> {
-        Ok(self.value()?.to_header_values()?)
+        Ok(self.header_value().to_header_values()?)
     }
 }
 

--- a/src/proxies/forwarded.rs
+++ b/src/proxies/forwarded.rs
@@ -434,20 +434,6 @@ impl std::fmt::Display for Forwarded<'_> {
     }
 }
 
-impl ToHeaderValues for Forwarded<'_> {
-    type Iter = std::option::IntoIter<HeaderValue>;
-    fn to_header_values(&self) -> crate::Result<Self::Iter> {
-        Ok(self.header_value().to_header_values()?)
-    }
-}
-
-impl ToHeaderValues for &Forwarded<'_> {
-    type Iter = std::option::IntoIter<HeaderValue>;
-    fn to_header_values(&self) -> crate::Result<Self::Iter> {
-        Ok(self.header_value().to_header_values()?)
-    }
-}
-
 #[derive(Debug, Clone)]
 pub struct ParseError(&'static str);
 impl ParseError {

--- a/src/proxies/forwarded.rs
+++ b/src/proxies/forwarded.rs
@@ -42,9 +42,11 @@ impl<'a> Forwarded<'a> {
     ///
     /// # Examples
     /// ```rust
-    /// # use http_types::{proxies::Forwarded, Method::Get, Request, Url, Result};
-    /// # fn main() -> Result<()> {
-    /// let mut request = Request::new(Get, Url::parse("http://_/")?);
+    /// # fn main() -> http_types::Result<()> {
+    /// use http_types::{headers::Header, Request};
+    /// use http_types::proxies::Forwarded;
+    ///
+    /// let mut request = Request::get("http://_/");
     /// request.insert_header(
     ///     "Forwarded",
     ///     r#"for=192.0.2.43, for="[2001:db8:cafe::17]", for=unknown;proto=https"#
@@ -56,16 +58,18 @@ impl<'a> Forwarded<'a> {
     /// ```
     ///
     /// ```rust
-    /// # use http_types::{proxies::Forwarded, Method::Get, Request, Url, Result};
-    /// # fn main() -> Result<()> {
-    /// let mut request = Request::new(Get, Url::parse("http://_/")?);
+    /// # fn main() -> http_types::Result<()> {
+    /// use http_types::{headers::Header, Request};
+    /// use http_types::proxies::Forwarded;
+    ///
+    /// let mut request = Request::get("http://_/");
     /// request.insert_header("X-Forwarded-For", "192.0.2.43, 2001:db8:cafe::17, unknown");
     /// request.insert_header("X-Forwarded-Proto", "https");
     /// let forwarded = Forwarded::from_headers(&request)?.unwrap();
     /// assert_eq!(forwarded.forwarded_for(), vec!["192.0.2.43", "[2001:db8:cafe::17]", "unknown"]);
     /// assert_eq!(forwarded.proto(), Some("https"));
     /// assert_eq!(
-    ///     forwarded.header_value()?,
+    ///     forwarded.header_value(),
     ///     r#"for=192.0.2.43, for="[2001:db8:cafe::17]", for=unknown;proto=https"#
     /// );
     /// # Ok(()) }
@@ -181,14 +185,16 @@ impl<'a> Forwarded<'a> {
     ///
     /// # Examples
     /// ```rust
-    /// # use http_types::{proxies::Forwarded, Method::Get, Request, Url, Result};
-    /// # fn main() -> Result<()> {
+    /// # fn main() -> http_types::Result<()> {
+    /// use http_types::headers::Header;
+    /// use http_types::proxies::Forwarded;
+    ///
     /// let forwarded = Forwarded::parse(
     ///     r#"for=192.0.2.43,         for="[2001:db8:cafe::17]", FOR=unknown;proto=https"#
     /// )?;
     /// assert_eq!(forwarded.forwarded_for(), vec!["192.0.2.43", "[2001:db8:cafe::17]", "unknown"]);
     /// assert_eq!(
-    ///     forwarded.header_value()?,
+    ///     forwarded.header_value(),
     ///     r#"for=192.0.2.43, for="[2001:db8:cafe::17]", for=unknown;proto=https"#
     /// );
     /// # Ok(()) }

--- a/src/security/csp.rs
+++ b/src/security/csp.rs
@@ -119,7 +119,7 @@ pub struct ReportToEndpoint {
 /// res.set_body("Hello, Chashu!");
 ///
 /// security::default(&mut res);
-/// policy.apply_header(&mut res);
+/// policy.apply(&mut res);
 ///
 /// assert_eq!(res["content-security-policy"], "base-uri 'none'; default-src 'self' areweasyncyet.rs; object-src 'none'; script-src 'self' 'unsafe-inline'; upgrade-insecure-requests");
 /// ```

--- a/src/security/csp.rs
+++ b/src/security/csp.rs
@@ -119,7 +119,7 @@ pub struct ReportToEndpoint {
 /// res.set_body("Hello, Chashu!");
 ///
 /// security::default(&mut res);
-/// policy.apply(&mut res);
+/// policy.apply_header(&mut res);
 ///
 /// assert_eq!(res["content-security-policy"], "base-uri 'none'; default-src 'self' areweasyncyet.rs; object-src 'none'; script-src 'self' 'unsafe-inline'; upgrade-insecure-requests");
 /// ```

--- a/src/security/mod.rs
+++ b/src/security/mod.rs
@@ -28,7 +28,7 @@ pub use timing_allow_origin::TimingAllowOrigin;
 ///
 // /// ## Examples
 // /// ```
-// /// use http_types::Response;
+// /// use http_types::{headers::Header, Response};
 // ///
 // /// let mut res = Response::new(StatusCode::Ok);
 // /// http_types::security::default(&mut headers);
@@ -50,7 +50,7 @@ pub fn default(mut headers: impl AsMut<Headers>) {
 ///
 // /// ## Examples
 // /// ```
-// /// use http_types::Response;
+// /// use http_types::{headers::Header, Response};
 // ///
 // /// let mut res = Response::new(StatusCode::Ok);
 // /// http_types::security::dns_prefetch_control(&mut headers);
@@ -76,7 +76,7 @@ pub enum FrameOptions {
 ///
 // /// ## Examples
 // /// ```
-// /// use http_types::Response;
+// /// use http_types::{headers::Header, Response};
 // ///
 // /// let mut res = Response::new(StatusCode::Ok);
 // /// http_types::security::frameguard(&mut headers, None);
@@ -98,7 +98,7 @@ pub fn frameguard(mut headers: impl AsMut<Headers>, guard: Option<FrameOptions>)
 ///
 // /// ## Examples
 // /// ```
-// /// use http_types::Response;
+// /// use http_types::{headers::Header, Response};
 // ///
 // /// let mut res = Response::new(StatusCode::Ok);
 // /// headers.as_mut().insert("X-Powered-By", "Tide/Rust".parse());
@@ -127,7 +127,7 @@ pub fn powered_by(mut headers: impl AsMut<Headers>, value: Option<HeaderValue>) 
 ///
 // /// ## Examples
 // /// ```
-// /// use http_types::Response;
+// /// use http_types::{headers::Header, Response};
 // ///
 // /// let mut res = Response::new(StatusCode::Ok);
 // /// http_types::security::hsts(&mut headers);
@@ -147,7 +147,7 @@ pub fn hsts(mut headers: impl AsMut<Headers>) {
 ///
 // /// ## Examples
 // /// ```
-// /// use http_types::Response;
+// /// use http_types::{headers::Header, Response};
 // ///
 // /// let mut res = Response::new(StatusCode::Ok);
 // /// http_types::security::nosniff(&mut headers);
@@ -164,7 +164,7 @@ pub fn nosniff(mut headers: impl AsMut<Headers>) {
 ///
 // /// ## Examples
 // /// ```
-// /// use http_types::Response;
+// /// use http_types::{headers::Header, Response};
 // ///
 // /// let mut res = Response::new(StatusCode::Ok);
 // /// http_types::security::xss_filter(&mut headers);
@@ -205,7 +205,7 @@ pub enum ReferrerOptions {
 ///
 // /// ## Examples
 // /// ```
-// /// use http_types::Response;
+// /// use http_types::{headers::Header, Response};
 // ///
 // /// let mut res = Response::new(StatusCode::Ok);
 // /// http_types::security::referrer_policy(&mut headers, Some(http_types::security::ReferrerOptions::UnsafeUrl));

--- a/src/security/mod.rs
+++ b/src/security/mod.rs
@@ -28,7 +28,7 @@ pub use timing_allow_origin::TimingAllowOrigin;
 ///
 // /// ## Examples
 // /// ```
-// /// use http_types::{headers::Header, Response};
+// /// use http_types::Response;
 // ///
 // /// let mut res = Response::new(StatusCode::Ok);
 // /// http_types::security::default(&mut headers);
@@ -50,7 +50,7 @@ pub fn default(mut headers: impl AsMut<Headers>) {
 ///
 // /// ## Examples
 // /// ```
-// /// use http_types::{headers::Header, Response};
+// /// use http_types::Response;
 // ///
 // /// let mut res = Response::new(StatusCode::Ok);
 // /// http_types::security::dns_prefetch_control(&mut headers);
@@ -76,7 +76,7 @@ pub enum FrameOptions {
 ///
 // /// ## Examples
 // /// ```
-// /// use http_types::{headers::Header, Response};
+// /// use http_types::Response;
 // ///
 // /// let mut res = Response::new(StatusCode::Ok);
 // /// http_types::security::frameguard(&mut headers, None);
@@ -98,7 +98,7 @@ pub fn frameguard(mut headers: impl AsMut<Headers>, guard: Option<FrameOptions>)
 ///
 // /// ## Examples
 // /// ```
-// /// use http_types::{headers::Header, Response};
+// /// use http_types::Response;
 // ///
 // /// let mut res = Response::new(StatusCode::Ok);
 // /// headers.as_mut().insert("X-Powered-By", "Tide/Rust".parse());
@@ -127,7 +127,7 @@ pub fn powered_by(mut headers: impl AsMut<Headers>, value: Option<HeaderValue>) 
 ///
 // /// ## Examples
 // /// ```
-// /// use http_types::{headers::Header, Response};
+// /// use http_types::Response;
 // ///
 // /// let mut res = Response::new(StatusCode::Ok);
 // /// http_types::security::hsts(&mut headers);
@@ -147,7 +147,7 @@ pub fn hsts(mut headers: impl AsMut<Headers>) {
 ///
 // /// ## Examples
 // /// ```
-// /// use http_types::{headers::Header, Response};
+// /// use http_types::Response;
 // ///
 // /// let mut res = Response::new(StatusCode::Ok);
 // /// http_types::security::nosniff(&mut headers);
@@ -164,7 +164,7 @@ pub fn nosniff(mut headers: impl AsMut<Headers>) {
 ///
 // /// ## Examples
 // /// ```
-// /// use http_types::{headers::Header, Response};
+// /// use http_types::Response;
 // ///
 // /// let mut res = Response::new(StatusCode::Ok);
 // /// http_types::security::xss_filter(&mut headers);
@@ -205,7 +205,7 @@ pub enum ReferrerOptions {
 ///
 // /// ## Examples
 // /// ```
-// /// use http_types::{headers::Header, Response};
+// /// use http_types::Response;
 // ///
 // /// let mut res = Response::new(StatusCode::Ok);
 // /// http_types::security::referrer_policy(&mut headers, Some(http_types::security::ReferrerOptions::UnsafeUrl));

--- a/src/security/timing_allow_origin.rs
+++ b/src/security/timing_allow_origin.rs
@@ -44,7 +44,7 @@ use std::slice;
 /// ```
 /// # fn main() -> http_types::Result<()> {
 /// #
-/// use http_types::{headers::Header, Response, Url};
+/// use http_types::{Response, Url};
 /// use http_types::security::TimingAllowOrigin;
 ///
 /// let mut origins = TimingAllowOrigin::new();

--- a/src/security/timing_allow_origin.rs
+++ b/src/security/timing_allow_origin.rs
@@ -27,14 +27,14 @@
 //! ```
 
 use crate::headers::{
-    Header, HeaderName, HeaderValue, Headers, ToHeaderValues, TIMING_ALLOW_ORIGIN,
+    Header, HeaderName, HeaderValue, Headers, TIMING_ALLOW_ORIGIN,
 };
 use crate::{Status, Url};
 
 use std::fmt::Write;
 use std::fmt::{self, Debug};
 use std::iter::Iterator;
-use std::option;
+
 use std::slice;
 
 /// Specify origins that are allowed to see values via the Resource Timing API.

--- a/src/security/timing_allow_origin.rs
+++ b/src/security/timing_allow_origin.rs
@@ -108,39 +108,6 @@ impl TimingAllowOrigin {
         self.origins.push(origin.into());
     }
 
-    /// Insert a `HeaderName` + `HeaderValue` pair into a `Headers` instance.
-    pub fn apply(&self, mut headers: impl AsMut<Headers>) {
-        headers
-            .as_mut()
-            .insert(TIMING_ALLOW_ORIGIN, self.header_value());
-    }
-
-    /// Get the `HeaderName`.
-    pub fn name(&self) -> HeaderName {
-        TIMING_ALLOW_ORIGIN
-    }
-
-    /// Get the `HeaderValue`.
-    pub fn value(&self) -> HeaderValue {
-        let mut output = String::new();
-        for (n, origin) in self.origins.iter().enumerate() {
-            match n {
-                0 => write!(output, "{}", origin).unwrap(),
-                _ => write!(output, ", {}", origin).unwrap(),
-            };
-        }
-
-        if self.wildcard {
-            match output.len() {
-                0 => write!(output, "*").unwrap(),
-                _ => write!(output, ", *").unwrap(),
-            };
-        }
-
-        // SAFETY: the internal string is validated to be ASCII.
-        unsafe { HeaderValue::from_bytes_unchecked(output.into()) }
-    }
-
     /// Returns `true` if a wildcard directive was set.
     pub fn wildcard(&self) -> bool {
         self.wildcard
@@ -171,7 +138,23 @@ impl Header for TimingAllowOrigin {
         TIMING_ALLOW_ORIGIN
     }
     fn header_value(&self) -> HeaderValue {
-        self.header_value()
+        let mut output = String::new();
+        for (n, origin) in self.origins.iter().enumerate() {
+            match n {
+                0 => write!(output, "{}", origin).unwrap(),
+                _ => write!(output, ", {}", origin).unwrap(),
+            };
+        }
+
+        if self.wildcard {
+            match output.len() {
+                0 => write!(output, "*").unwrap(),
+                _ => write!(output, ", *").unwrap(),
+            };
+        }
+
+        // SAFETY: the internal string is validated to be ASCII.
+        unsafe { HeaderValue::from_bytes_unchecked(output.into()) }
     }
 }
 

--- a/src/security/timing_allow_origin.rs
+++ b/src/security/timing_allow_origin.rs
@@ -10,7 +10,7 @@
 //! ```
 //! # fn main() -> http_types::Result<()> {
 //! #
-//! use http_types::{Response, Url};
+//! use http_types::{Response, Url, headers::Header};
 //! use http_types::security::TimingAllowOrigin;
 //!
 //! let mut origins = TimingAllowOrigin::new();
@@ -44,7 +44,7 @@ use std::slice;
 /// ```
 /// # fn main() -> http_types::Result<()> {
 /// #
-/// use http_types::{Response, Url};
+/// use http_types::{headers::Header, Response, Url};
 /// use http_types::security::TimingAllowOrigin;
 ///
 /// let mut origins = TimingAllowOrigin::new();

--- a/src/security/timing_allow_origin.rs
+++ b/src/security/timing_allow_origin.rs
@@ -51,7 +51,7 @@ use std::slice;
 /// origins.push(Url::parse("https://example.com")?);
 ///
 /// let mut res = Response::new(200);
-/// origins.apply_header(&mut res);
+/// res.insert_header(&origins, &origins);
 ///
 /// let origins = TimingAllowOrigin::from_headers(res)?.unwrap();
 /// let origin = origins.iter().next().unwrap();
@@ -244,14 +244,6 @@ impl<'a> Iterator for IterMut<'a> {
     #[inline]
     fn size_hint(&self) -> (usize, Option<usize>) {
         self.inner.size_hint()
-    }
-}
-
-// Conversion from `AllowOrigin` -> `HeaderValue`.
-impl ToHeaderValues for TimingAllowOrigin {
-    type Iter = option::IntoIter<HeaderValue>;
-    fn to_header_values(&self) -> crate::Result<Self::Iter> {
-        Ok(self.header_value().to_header_values().unwrap())
     }
 }
 

--- a/src/security/timing_allow_origin.rs
+++ b/src/security/timing_allow_origin.rs
@@ -26,9 +26,7 @@
 //! # Ok(()) }
 //! ```
 
-use crate::headers::{
-    Header, HeaderName, HeaderValue, Headers, TIMING_ALLOW_ORIGIN,
-};
+use crate::headers::{Header, HeaderName, HeaderValue, Headers, TIMING_ALLOW_ORIGIN};
 use crate::{Status, Url};
 
 use std::fmt::Write;

--- a/src/server/allow.rs
+++ b/src/server/allow.rs
@@ -20,7 +20,7 @@ use std::str::FromStr;
 /// ```
 /// # fn main() -> http_types::Result<()> {
 /// #
-/// use http_types::{Method, Response};
+/// use http_types::{headers::Header, Method, Response};
 /// use http_types::server::Allow;
 ///
 /// let mut allow = Allow::new();

--- a/src/server/allow.rs
+++ b/src/server/allow.rs
@@ -1,6 +1,6 @@
 //! List the set of methods supported by a resource.
 
-use crate::headers::{HeaderName, HeaderValue, Headers, ToHeaderValues, ALLOW};
+use crate::headers::{Header, HeaderName, HeaderValue, Headers, ToHeaderValues, ALLOW};
 use crate::Method;
 
 use std::collections::{hash_set, HashSet};
@@ -28,7 +28,7 @@ use std::str::FromStr;
 /// allow.insert(Method::Post);
 ///
 /// let mut res = Response::new(200);
-/// allow.apply(&mut res);
+/// allow.apply_header(&mut res);
 ///
 /// let allow = Allow::from_headers(res)?.unwrap();
 /// assert!(allow.contains(Method::Put));
@@ -68,7 +68,7 @@ impl Allow {
 
     /// Sets the `Allow` header.
     pub fn apply(&self, mut headers: impl AsMut<Headers>) {
-        headers.as_mut().insert(ALLOW, self.value());
+        headers.as_mut().insert(ALLOW, self.header_value());
     }
 
     /// Get the `HeaderName`.
@@ -108,12 +108,12 @@ impl Allow {
     }
 }
 
-impl crate::headers::Header for Allow {
+impl Header for Allow {
     fn header_name(&self) -> HeaderName {
         ALLOW
     }
     fn header_value(&self) -> HeaderValue {
-        self.value()
+        self.header_value()
     }
 }
 
@@ -181,7 +181,7 @@ impl ToHeaderValues for Allow {
     type Iter = option::IntoIter<HeaderValue>;
     fn to_header_values(&self) -> crate::Result<Self::Iter> {
         // A HeaderValue will always convert into itself.
-        Ok(self.value().to_header_values().unwrap())
+        Ok(self.header_value().to_header_values().unwrap())
     }
 }
 
@@ -207,7 +207,7 @@ mod test {
         allow.insert(Method::Post);
 
         let mut headers = Headers::new();
-        allow.apply(&mut headers);
+        allow.apply_header(&mut headers);
 
         let allow = Allow::from_headers(headers)?.unwrap();
         assert!(allow.contains(Method::Put));

--- a/src/server/allow.rs
+++ b/src/server/allow.rs
@@ -20,7 +20,7 @@ use std::str::FromStr;
 /// ```
 /// # fn main() -> http_types::Result<()> {
 /// #
-/// use http_types::{headers::Header, Method, Response};
+/// use http_types::{Method, Response};
 /// use http_types::server::Allow;
 ///
 /// let mut allow = Allow::new();

--- a/src/server/allow.rs
+++ b/src/server/allow.rs
@@ -28,7 +28,7 @@ use std::str::FromStr;
 /// allow.insert(Method::Post);
 ///
 /// let mut res = Response::new(200);
-/// allow.apply_header(&mut res);
+/// res.insert_header(&allow, &allow);
 ///
 /// let allow = Allow::from_headers(res)?.unwrap();
 /// assert!(allow.contains(Method::Put));
@@ -159,14 +159,6 @@ impl<'a> Iterator for Iter<'a> {
     #[inline]
     fn size_hint(&self) -> (usize, Option<usize>) {
         self.inner.size_hint()
-    }
-}
-
-impl ToHeaderValues for Allow {
-    type Iter = option::IntoIter<HeaderValue>;
-    fn to_header_values(&self) -> crate::Result<Self::Iter> {
-        // A HeaderValue will always convert into itself.
-        Ok(self.header_value().to_header_values().unwrap())
     }
 }
 

--- a/src/server/allow.rs
+++ b/src/server/allow.rs
@@ -66,30 +66,6 @@ impl Allow {
         Ok(Some(Self { entries }))
     }
 
-    /// Sets the `Allow` header.
-    pub fn apply(&self, mut headers: impl AsMut<Headers>) {
-        headers.as_mut().insert(ALLOW, self.header_value());
-    }
-
-    /// Get the `HeaderName`.
-    pub fn name(&self) -> HeaderName {
-        ALLOW
-    }
-
-    /// Get the `HeaderValue`.
-    pub fn value(&self) -> HeaderValue {
-        let mut output = String::new();
-        for (n, method) in self.entries.iter().enumerate() {
-            match n {
-                0 => write!(output, "{}", method).unwrap(),
-                _ => write!(output, ", {}", method).unwrap(),
-            };
-        }
-
-        // SAFETY: the internal string is validated to be ASCII.
-        unsafe { HeaderValue::from_bytes_unchecked(output.into()) }
-    }
-
     /// Push a method into the set of methods.
     pub fn insert(&mut self, method: Method) {
         self.entries.insert(method);
@@ -113,7 +89,16 @@ impl Header for Allow {
         ALLOW
     }
     fn header_value(&self) -> HeaderValue {
-        self.header_value()
+        let mut output = String::new();
+        for (n, method) in self.entries.iter().enumerate() {
+            match n {
+                0 => write!(output, "{}", method).unwrap(),
+                _ => write!(output, ", {}", method).unwrap(),
+            };
+        }
+
+        // SAFETY: the internal string is validated to be ASCII.
+        unsafe { HeaderValue::from_bytes_unchecked(output.into()) }
     }
 }
 

--- a/src/server/allow.rs
+++ b/src/server/allow.rs
@@ -1,12 +1,12 @@
 //! List the set of methods supported by a resource.
 
-use crate::headers::{Header, HeaderName, HeaderValue, Headers, ToHeaderValues, ALLOW};
+use crate::headers::{Header, HeaderName, HeaderValue, Headers, ALLOW};
 use crate::Method;
 
 use std::collections::{hash_set, HashSet};
 use std::fmt::{self, Debug, Write};
 use std::iter::Iterator;
-use std::option;
+
 use std::str::FromStr;
 
 /// List the set of methods supported by a resource.

--- a/src/trace/server_timing/mod.rs
+++ b/src/trace/server_timing/mod.rs
@@ -5,14 +5,14 @@
 //! ```
 //! # fn main() -> http_types::Result<()> {
 //! #
-//! use http_types::{headers::Header, Response};
+//! use http_types::Response;
 //! use http_types::trace::{ServerTiming, Metric};
 //!
 //! let mut timings = ServerTiming::new();
 //! timings.push(Metric::new("server".to_owned(), None, None)?);
 //!
 //! let mut res = Response::new(200);
-//! timings.apply_header(&mut res);
+//! res.insert_header(&timings, &timings);
 //!
 //! let timings = ServerTiming::from_headers(res)?.unwrap();
 //! let entry = timings.iter().next().unwrap();
@@ -45,7 +45,7 @@ use crate::headers::{Header, HeaderName, HeaderValue, Headers, ToHeaderValues, S
 /// ```
 /// # fn main() -> http_types::Result<()> {
 /// #
-/// use http_types::{headers::Header, Response};
+/// use http_types::Response;
 /// use http_types::trace::{ServerTiming, Metric};
 ///
 /// let mut timings = ServerTiming::new();

--- a/src/trace/server_timing/mod.rs
+++ b/src/trace/server_timing/mod.rs
@@ -52,7 +52,7 @@ use crate::headers::{Header, HeaderName, HeaderValue, Headers, ToHeaderValues, S
 /// timings.push(Metric::new("server".to_owned(), None, None)?);
 ///
 /// let mut res = Response::new(200);
-/// timings.apply_header(&mut res);
+/// res.insert_header(&timings, &timings);
 ///
 /// let timings = ServerTiming::from_headers(res)?.unwrap();
 /// let entry = timings.iter().next().unwrap();
@@ -211,14 +211,6 @@ impl<'a> Iterator for IterMut<'a> {
     #[inline]
     fn size_hint(&self) -> (usize, Option<usize>) {
         self.inner.size_hint()
-    }
-}
-
-impl ToHeaderValues for ServerTiming {
-    type Iter = option::IntoIter<HeaderValue>;
-    fn to_header_values(&self) -> crate::Result<Self::Iter> {
-        // A HeaderValue will always convert into itself.
-        Ok(self.header_value().to_header_values().unwrap())
     }
 }
 

--- a/src/trace/server_timing/mod.rs
+++ b/src/trace/server_timing/mod.rs
@@ -12,7 +12,7 @@
 //! timings.push(Metric::new("server".to_owned(), None, None)?);
 //!
 //! let mut res = Response::new(200);
-//! timings.apply(&mut res);
+//! timings.apply_header(&mut res);
 //!
 //! let timings = ServerTiming::from_headers(res)?.unwrap();
 //! let entry = timings.iter().next().unwrap();
@@ -33,7 +33,7 @@ use std::iter::Iterator;
 use std::option;
 use std::slice;
 
-use crate::headers::{HeaderName, HeaderValue, Headers, ToHeaderValues, SERVER_TIMING};
+use crate::headers::{Header, HeaderName, HeaderValue, Headers, ToHeaderValues, SERVER_TIMING};
 
 /// Metrics and descriptions for the given request-response cycle.
 ///
@@ -53,7 +53,7 @@ use crate::headers::{HeaderName, HeaderValue, Headers, ToHeaderValues, SERVER_TI
 /// timings.push(Metric::new("server".to_owned(), None, None)?);
 ///
 /// let mut res = Response::new(200);
-/// timings.apply(&mut res);
+/// timings.apply_header(&mut res);
 ///
 /// let timings = ServerTiming::from_headers(res)?.unwrap();
 /// let entry = timings.iter().next().unwrap();
@@ -88,7 +88,7 @@ impl ServerTiming {
 
     /// Sets the `Server-Timing` header.
     pub fn apply(&self, mut headers: impl AsMut<Headers>) {
-        headers.as_mut().insert(SERVER_TIMING, self.value());
+        headers.as_mut().insert(SERVER_TIMING, self.header_value());
     }
 
     /// Get the `HeaderName`.
@@ -131,12 +131,12 @@ impl ServerTiming {
     }
 }
 
-impl crate::headers::Header for ServerTiming {
+impl Header for ServerTiming {
     fn header_name(&self) -> HeaderName {
         SERVER_TIMING
     }
     fn header_value(&self) -> HeaderValue {
-        self.value()
+        self.header_value()
     }
 }
 
@@ -233,7 +233,7 @@ impl ToHeaderValues for ServerTiming {
     type Iter = option::IntoIter<HeaderValue>;
     fn to_header_values(&self) -> crate::Result<Self::Iter> {
         // A HeaderValue will always convert into itself.
-        Ok(self.value().to_header_values().unwrap())
+        Ok(self.header_value().to_header_values().unwrap())
     }
 }
 
@@ -248,7 +248,7 @@ mod test {
         timings.push(Metric::new("server".to_owned(), None, None)?);
 
         let mut headers = Headers::new();
-        timings.apply(&mut headers);
+        timings.apply_header(&mut headers);
 
         let timings = ServerTiming::from_headers(headers)?.unwrap();
         let entry = timings.iter().next().unwrap();
@@ -262,7 +262,7 @@ mod test {
         timings.push(Metric::new("server".to_owned(), None, None)?);
 
         let mut headers = Headers::new();
-        timings.apply(&mut headers);
+        timings.apply_header(&mut headers);
 
         let timings = ServerTiming::from_headers(headers)?.unwrap();
         let entry = timings.iter().next().unwrap();

--- a/src/trace/server_timing/mod.rs
+++ b/src/trace/server_timing/mod.rs
@@ -5,7 +5,7 @@
 //! ```
 //! # fn main() -> http_types::Result<()> {
 //! #
-//! use http_types::Response;
+//! use http_types::{headers::Header, Response};
 //! use http_types::trace::{ServerTiming, Metric};
 //!
 //! let mut timings = ServerTiming::new();
@@ -45,7 +45,7 @@ use crate::headers::{Header, HeaderName, HeaderValue, Headers, ToHeaderValues, S
 /// ```
 /// # fn main() -> http_types::Result<()> {
 /// #
-/// use http_types::Response;
+/// use http_types::{headers::Header, Response};
 /// use http_types::trace::{ServerTiming, Metric};
 ///
 /// let mut timings = ServerTiming::new();

--- a/src/trace/server_timing/mod.rs
+++ b/src/trace/server_timing/mod.rs
@@ -29,10 +29,10 @@ use parse::parse_header;
 
 use std::fmt::Write;
 use std::iter::Iterator;
-use std::option;
+
 use std::slice;
 
-use crate::headers::{Header, HeaderName, HeaderValue, Headers, ToHeaderValues, SERVER_TIMING};
+use crate::headers::{Header, HeaderName, HeaderValue, Headers, SERVER_TIMING};
 
 /// Metrics and descriptions for the given request-response cycle.
 ///

--- a/src/trace/trace_context.rs
+++ b/src/trace/trace_context.rs
@@ -170,7 +170,7 @@ impl TraceContext {
     /// # fn main() -> http_types::Result<()> {
     /// #
     /// use http_types::trace::TraceContext;
-    /// use http_types::Response;
+    /// use http_types::{headers::Header, Response};
     ///
     /// let mut res = Response::new(200);
     /// res.insert_header("traceparent", "00-00000000000000000000000000000001-0000000000000002-01");

--- a/src/trace/trace_context.rs
+++ b/src/trace/trace_context.rs
@@ -121,51 +121,6 @@ impl TraceContext {
         }))
     }
 
-    /// Add the traceparent header to the http headers
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// # fn main() -> http_types::Result<()> {
-    /// #
-    /// use http_types::trace::TraceContext;
-    /// use http_types::{Request, Response, Url, Method};
-    ///
-    /// let mut req = Request::new(Method::Get, Url::parse("https://example.com").unwrap());
-    /// req.insert_header(
-    ///   "traceparent",
-    ///   "00-0af7651916cd43dd8448eb211c80319c-00f067aa0ba902b7-01"
-    /// );
-    ///
-    /// let parent = TraceContext::from_headers(&req)?.unwrap();
-    ///
-    /// let mut res = Response::new(200);
-    /// parent.apply_header(&mut res);
-    ///
-    /// let child = TraceContext::from_headers(&res)?.unwrap();
-    ///
-    /// assert_eq!(child.version(), parent.version());
-    /// assert_eq!(child.trace_id(), parent.trace_id());
-    /// assert_eq!(child.parent_id(), Some(parent.id()));
-    /// #
-    /// # Ok(()) }
-    /// ```
-    pub fn apply(&self, mut headers: impl AsMut<Headers>) {
-        let headers = headers.as_mut();
-        headers.insert(TRACEPARENT, self.header_value());
-    }
-
-    /// Get the `HeaderName`.
-    pub fn name(&self) -> HeaderName {
-        TRACEPARENT
-    }
-
-    /// Get the `HeaderValue`.
-    pub fn value(&self) -> HeaderValue {
-        let output = format!("{}", self);
-        unsafe { HeaderValue::from_bytes_unchecked(output.into()) }
-    }
-
     /// Generate a child of the current TraceContext and return it.
     ///
     /// The child will have a new randomly genrated `id` and its `parent_id` will be set to the
@@ -250,8 +205,10 @@ impl Header for TraceContext {
     fn header_name(&self) -> HeaderName {
         TRACEPARENT
     }
+
     fn header_value(&self) -> HeaderValue {
-        self.header_value()
+        let output = format!("{}", self);
+        unsafe { HeaderValue::from_bytes_unchecked(output.into()) }
     }
 }
 

--- a/src/trace/trace_context.rs
+++ b/src/trace/trace_context.rs
@@ -1,7 +1,7 @@
 use rand::Rng;
 use std::fmt;
 
-use crate::headers::{HeaderName, HeaderValue, Headers, TRACEPARENT};
+use crate::headers::{Header, HeaderName, HeaderValue, Headers, TRACEPARENT};
 use crate::Status;
 
 /// Extract and apply [Trace-Context](https://w3c.github.io/trace-context/) headers.
@@ -140,7 +140,7 @@ impl TraceContext {
     /// let parent = TraceContext::from_headers(&req)?.unwrap();
     ///
     /// let mut res = Response::new(200);
-    /// parent.apply(&mut res);
+    /// parent.apply_header(&mut res);
     ///
     /// let child = TraceContext::from_headers(&res)?.unwrap();
     ///
@@ -152,7 +152,7 @@ impl TraceContext {
     /// ```
     pub fn apply(&self, mut headers: impl AsMut<Headers>) {
         let headers = headers.as_mut();
-        headers.insert(TRACEPARENT, self.value());
+        headers.insert(TRACEPARENT, self.header_value());
     }
 
     /// Get the `HeaderName`.
@@ -246,12 +246,12 @@ impl TraceContext {
     }
 }
 
-impl crate::headers::Header for TraceContext {
+impl Header for TraceContext {
     fn header_name(&self) -> HeaderName {
         TRACEPARENT
     }
     fn header_value(&self) -> HeaderValue {
-        self.value()
+        self.header_value()
     }
 }
 

--- a/src/trace/trace_context.rs
+++ b/src/trace/trace_context.rs
@@ -170,7 +170,7 @@ impl TraceContext {
     /// # fn main() -> http_types::Result<()> {
     /// #
     /// use http_types::trace::TraceContext;
-    /// use http_types::{headers::Header, Response};
+    /// use http_types::Response;
     ///
     /// let mut res = Response::new(200);
     /// res.insert_header("traceparent", "00-00000000000000000000000000000001-0000000000000002-01");

--- a/src/transfer/te.rs
+++ b/src/transfer/te.rs
@@ -31,7 +31,7 @@ use std::slice;
 ///
 /// let mut res = Response::new(200);
 /// let encoding = te.negotiate(&[Encoding::Brotli, Encoding::Gzip])?;
-/// encoding.apply_header(&mut res);
+/// res.insert_header(&encoding, &encoding);
 ///
 /// assert_eq!(res["Transfer-Encoding"], "br");
 /// #
@@ -264,14 +264,6 @@ impl<'a> Iterator for IterMut<'a> {
     #[inline]
     fn size_hint(&self) -> (usize, Option<usize>) {
         self.inner.size_hint()
-    }
-}
-
-impl ToHeaderValues for TE {
-    type Iter = option::IntoIter<HeaderValue>;
-    fn to_header_values(&self) -> crate::Result<Self::Iter> {
-        // A HeaderValue will always convert into itself.
-        Ok(self.header_value().to_header_values().unwrap())
     }
 }
 

--- a/src/transfer/te.rs
+++ b/src/transfer/te.rs
@@ -22,7 +22,7 @@ use std::slice;
 /// # fn main() -> http_types::Result<()> {
 /// #
 /// use http_types::transfer::{TE, TransferEncoding, Encoding, EncodingProposal};
-/// use http_types::{headers::Header, Response};
+/// use http_types::Response;
 ///
 /// let mut te = TE::new();
 /// te.push(EncodingProposal::new(Encoding::Brotli, Some(0.8))?);

--- a/src/transfer/te.rs
+++ b/src/transfer/te.rs
@@ -1,10 +1,10 @@
-use crate::headers::{self, Header, HeaderName, HeaderValue, Headers, ToHeaderValues};
+use crate::headers::{self, Header, HeaderName, HeaderValue, Headers};
 use crate::transfer::{Encoding, EncodingProposal, TransferEncoding};
 use crate::utils::sort_by_weight;
 use crate::{Error, StatusCode};
 
 use std::fmt::{self, Debug, Write};
-use std::option;
+
 use std::slice;
 
 /// Client header advertising the transfer encodings the user agent is willing to

--- a/src/transfer/te.rs
+++ b/src/transfer/te.rs
@@ -136,38 +136,6 @@ impl TE {
         Err(err)
     }
 
-    /// Sets the `Accept-Encoding` header.
-    pub fn apply(&self, mut headers: impl AsMut<Headers>) {
-        headers.as_mut().insert(headers::TE, self.header_value());
-    }
-
-    /// Get the `HeaderName`.
-    pub fn name(&self) -> HeaderName {
-        headers::TE
-    }
-
-    /// Get the `HeaderValue`.
-    pub fn value(&self) -> HeaderValue {
-        let mut output = String::new();
-        for (n, directive) in self.entries.iter().enumerate() {
-            let directive: HeaderValue = directive.clone().into();
-            match n {
-                0 => write!(output, "{}", directive).unwrap(),
-                _ => write!(output, ", {}", directive).unwrap(),
-            };
-        }
-
-        if self.wildcard {
-            match output.len() {
-                0 => write!(output, "*").unwrap(),
-                _ => write!(output, ", *").unwrap(),
-            }
-        }
-
-        // SAFETY: the internal string is validated to be ASCII.
-        unsafe { HeaderValue::from_bytes_unchecked(output.into()) }
-    }
-
     /// An iterator visiting all entries.
     pub fn iter(&self) -> Iter<'_> {
         Iter {
@@ -187,8 +155,26 @@ impl Header for TE {
     fn header_name(&self) -> HeaderName {
         headers::TE
     }
+
     fn header_value(&self) -> HeaderValue {
-        self.header_value()
+        let mut output = String::new();
+        for (n, directive) in self.entries.iter().enumerate() {
+            let directive: HeaderValue = directive.clone().into();
+            match n {
+                0 => write!(output, "{}", directive).unwrap(),
+                _ => write!(output, ", {}", directive).unwrap(),
+            };
+        }
+
+        if self.wildcard {
+            match output.len() {
+                0 => write!(output, "*").unwrap(),
+                _ => write!(output, ", *").unwrap(),
+            }
+        }
+
+        // SAFETY: the internal string is validated to be ASCII.
+        unsafe { HeaderValue::from_bytes_unchecked(output.into()) }
     }
 }
 

--- a/src/transfer/te.rs
+++ b/src/transfer/te.rs
@@ -22,7 +22,7 @@ use std::slice;
 /// # fn main() -> http_types::Result<()> {
 /// #
 /// use http_types::transfer::{TE, TransferEncoding, Encoding, EncodingProposal};
-/// use http_types::Response;
+/// use http_types::{headers::Header, Response};
 ///
 /// let mut te = TE::new();
 /// te.push(EncodingProposal::new(Encoding::Brotli, Some(0.8))?);

--- a/src/transfer/transfer_encoding.rs
+++ b/src/transfer/transfer_encoding.rs
@@ -4,7 +4,6 @@ use crate::transfer::{Encoding, EncodingProposal};
 use std::fmt::{self, Debug};
 use std::ops::{Deref, DerefMut};
 
-
 /// The form of encoding used to safely transfer the payload body to the user.
 ///
 /// [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Transfer-Encoding)

--- a/src/transfer/transfer_encoding.rs
+++ b/src/transfer/transfer_encoding.rs
@@ -59,23 +59,6 @@ impl TransferEncoding {
         Ok(Some(Self { inner }))
     }
 
-    /// Sets the `Content-Encoding` header.
-    pub fn apply(&self, mut headers: impl AsMut<Headers>) {
-        headers
-            .as_mut()
-            .insert(TRANSFER_ENCODING, self.header_value());
-    }
-
-    /// Get the `HeaderName`.
-    pub fn name(&self) -> HeaderName {
-        TRANSFER_ENCODING
-    }
-
-    /// Get the `HeaderValue`.
-    pub fn value(&self) -> HeaderValue {
-        self.inner.into()
-    }
-
     /// Access the encoding kind.
     pub fn encoding(&self) -> Encoding {
         self.inner
@@ -87,7 +70,7 @@ impl Header for TransferEncoding {
         TRANSFER_ENCODING
     }
     fn header_value(&self) -> HeaderValue {
-        self.header_value()
+        self.inner.into()
     }
 }
 

--- a/src/transfer/transfer_encoding.rs
+++ b/src/transfer/transfer_encoding.rs
@@ -1,4 +1,4 @@
-use crate::headers::{HeaderName, HeaderValue, Headers, ToHeaderValues, TRANSFER_ENCODING};
+use crate::headers::{Header, HeaderName, HeaderValue, Headers, ToHeaderValues, TRANSFER_ENCODING};
 use crate::transfer::{Encoding, EncodingProposal};
 
 use std::fmt::{self, Debug};
@@ -23,7 +23,7 @@ use std::option;
 /// let mut encoding = TransferEncoding::new(Encoding::Chunked);
 ///
 /// let mut res = Response::new(200);
-/// encoding.apply(&mut res);
+/// encoding.apply_header(&mut res);
 ///
 /// let encoding = TransferEncoding::from_headers(res)?.unwrap();
 /// assert_eq!(encoding, &Encoding::Chunked);
@@ -61,7 +61,9 @@ impl TransferEncoding {
 
     /// Sets the `Content-Encoding` header.
     pub fn apply(&self, mut headers: impl AsMut<Headers>) {
-        headers.as_mut().insert(TRANSFER_ENCODING, self.value());
+        headers
+            .as_mut()
+            .insert(TRANSFER_ENCODING, self.header_value());
     }
 
     /// Get the `HeaderName`.
@@ -80,12 +82,12 @@ impl TransferEncoding {
     }
 }
 
-impl crate::headers::Header for TransferEncoding {
+impl Header for TransferEncoding {
     fn header_name(&self) -> HeaderName {
         TRANSFER_ENCODING
     }
     fn header_value(&self) -> HeaderValue {
-        self.value()
+        self.header_value()
     }
 }
 
@@ -93,7 +95,7 @@ impl ToHeaderValues for TransferEncoding {
     type Iter = option::IntoIter<HeaderValue>;
     fn to_header_values(&self) -> crate::Result<Self::Iter> {
         // A HeaderValue will always convert into itself.
-        Ok(self.value().to_header_values().unwrap())
+        Ok(self.header_value().to_header_values().unwrap())
     }
 }
 

--- a/src/transfer/transfer_encoding.rs
+++ b/src/transfer/transfer_encoding.rs
@@ -18,7 +18,7 @@ use std::option;
 /// ```
 /// # fn main() -> http_types::Result<()> {
 /// #
-/// use http_types::{headers::Header, Response};
+/// use http_types::Response;
 /// use http_types::transfer::{TransferEncoding, Encoding};
 /// let mut encoding = TransferEncoding::new(Encoding::Chunked);
 ///

--- a/src/transfer/transfer_encoding.rs
+++ b/src/transfer/transfer_encoding.rs
@@ -23,7 +23,7 @@ use std::option;
 /// let mut encoding = TransferEncoding::new(Encoding::Chunked);
 ///
 /// let mut res = Response::new(200);
-/// encoding.apply_header(&mut res);
+/// res.insert_header(&encoding, &encoding);
 ///
 /// let encoding = TransferEncoding::from_headers(res)?.unwrap();
 /// assert_eq!(encoding, &Encoding::Chunked);
@@ -71,14 +71,6 @@ impl Header for TransferEncoding {
     }
     fn header_value(&self) -> HeaderValue {
         self.inner.into()
-    }
-}
-
-impl ToHeaderValues for TransferEncoding {
-    type Iter = option::IntoIter<HeaderValue>;
-    fn to_header_values(&self) -> crate::Result<Self::Iter> {
-        // A HeaderValue will always convert into itself.
-        Ok(self.header_value().to_header_values().unwrap())
     }
 }
 

--- a/src/transfer/transfer_encoding.rs
+++ b/src/transfer/transfer_encoding.rs
@@ -1,9 +1,9 @@
-use crate::headers::{Header, HeaderName, HeaderValue, Headers, ToHeaderValues, TRANSFER_ENCODING};
+use crate::headers::{Header, HeaderName, HeaderValue, Headers, TRANSFER_ENCODING};
 use crate::transfer::{Encoding, EncodingProposal};
 
 use std::fmt::{self, Debug};
 use std::ops::{Deref, DerefMut};
-use std::option;
+
 
 /// The form of encoding used to safely transfer the payload body to the user.
 ///

--- a/src/transfer/transfer_encoding.rs
+++ b/src/transfer/transfer_encoding.rs
@@ -18,7 +18,7 @@ use std::option;
 /// ```
 /// # fn main() -> http_types::Result<()> {
 /// #
-/// use http_types::Response;
+/// use http_types::{headers::Header, Response};
 /// use http_types::transfer::{TransferEncoding, Encoding};
 /// let mut encoding = TransferEncoding::new(Encoding::Chunked);
 ///


### PR DESCRIPTION
Precursor to https://github.com/http-rs/http-types/pull/335, follow-up to #315. This removes all the manual `name`, `value`, and `apply` methods defined on the typed headers in favor of the `Header` trait. This also adds conversions to easily go from `&impl Header` -> `HeaderName` / `HeaderValue`, which allows for more convenient use. Which also enabled us to remove a fair amount of code from the manual `IntoHeaderValues` implementations on various typed headers.

## Example
**before**
```rust
let authz = BasicAuth::new(username, password);

let mut res = Response::new(200);
authz.apply(&mut res);                                         // variant 1, inverted logic
res.insert_header(authz.header_name(), authz.header_value());  // variant 2, clearer but verbose
```
**after**
```rust
let authz = BasicAuth::new(username, password);

let mut res = Response::new(200);
res.insert_header(&authz, &authz); // enabled by this PR
```

## Future directions

This doesn't preclude changing `Header::insert_header` to take one `Header` argument rather than two separate ones. But at least under the current API it significantly simplifies usage patterns and removes lots of duplicates.