### PR TITLE
propose v2.11.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "http-types"
-version = "2.10.0"
+version = "2.11.0"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/http-rs/http-types"
 documentation = "https://docs.rs/http-types"

--- a/src/auth/authorization.rs
+++ b/src/auth/authorization.rs
@@ -132,11 +132,10 @@ mod test {
     }
 
     #[test]
-    fn bad_request_on_parse_error() -> crate::Result<()> {
+    fn bad_request_on_parse_error() {
         let mut headers = Headers::new();
         headers.insert(AUTHORIZATION, "<nori ate the tag. yum.>");
         let err = Authorization::from_headers(headers).unwrap_err();
         assert_eq!(err.status(), 400);
-        Ok(())
     }
 }

--- a/src/auth/basic_auth.rs
+++ b/src/auth/basic_auth.rs
@@ -135,11 +135,10 @@ mod test {
     }
 
     #[test]
-    fn bad_request_on_parse_error() -> crate::Result<()> {
+    fn bad_request_on_parse_error() {
         let mut headers = Headers::new();
         headers.insert(AUTHORIZATION, "<nori ate the tag. yum.>");
         let err = BasicAuth::from_headers(headers).unwrap_err();
         assert_eq!(err.status(), 400);
-        Ok(())
     }
 }

--- a/src/auth/www_authenticate.rs
+++ b/src/auth/www_authenticate.rs
@@ -159,11 +159,10 @@ mod test {
     }
 
     #[test]
-    fn bad_request_on_parse_error() -> crate::Result<()> {
+    fn bad_request_on_parse_error() {
         let mut headers = Headers::new();
         headers.insert(WWW_AUTHENTICATE, "<nori ate the tag. yum.>");
         let err = WwwAuthenticate::from_headers(headers).unwrap_err();
         assert_eq!(err.status(), 400);
-        Ok(())
     }
 }

--- a/src/body.rs
+++ b/src/body.rs
@@ -441,7 +441,6 @@ impl Body {
     /// assert_eq!(&body.into_string().await.unwrap(), "Hello Nori");
     /// # Ok(()) }) }
     /// ```
-    #[cfg(feature = "async-std")]
     pub fn chain(self, other: Body) -> Self {
         let mime = if self.mime == other.mime {
             self.mime.clone()
@@ -455,7 +454,7 @@ impl Body {
         Self {
             mime,
             length,
-            reader: Box::new(async_std::io::ReadExt::chain(self, other)),
+            reader: Box::new(futures_lite::io::AsyncReadExt::chain(self, other)),
             bytes_read: 0,
         }
     }

--- a/src/cache/age.rs
+++ b/src/cache/age.rs
@@ -113,11 +113,10 @@ mod test {
     }
 
     #[test]
-    fn bad_request_on_parse_error() -> crate::Result<()> {
+    fn bad_request_on_parse_error() {
         let mut headers = Headers::new();
         headers.insert(AGE, "<nori ate the tag. yum.>");
         let err = Age::from_headers(headers).unwrap_err();
         assert_eq!(err.status(), 400);
-        Ok(())
     }
 }

--- a/src/cache/cache_control/cache_directive.rs
+++ b/src/cache/cache_control/cache_directive.rs
@@ -47,26 +47,29 @@ impl CacheDirective {
     /// Check whether this directive is valid in an HTTP request.
     pub fn valid_in_req(&self) -> bool {
         use CacheDirective::*;
-        matches!(self,
-            MaxAge(_) | MaxStale(_) | MinFresh(_) | NoCache | NoStore | NoTransform
-            | OnlyIfCached)
+        matches!(
+            self,
+            MaxAge(_) | MaxStale(_) | MinFresh(_) | NoCache | NoStore | NoTransform | OnlyIfCached
+        )
     }
 
     /// Check whether this directive is valid in an HTTP response.
     pub fn valid_in_res(&self) -> bool {
         use CacheDirective::*;
-        matches!(self,
+        matches!(
+            self,
             MustRevalidate
-            | NoCache
-            | NoStore
-            | NoTransform
-            | Public
-            | Private
-            | ProxyRevalidate
-            | MaxAge(_)
-            | SMaxAge(_)
-            | StaleIfError(_)
-            | StaleWhileRevalidate(_))
+                | NoCache
+                | NoStore
+                | NoTransform
+                | Public
+                | Private
+                | ProxyRevalidate
+                | MaxAge(_)
+                | SMaxAge(_)
+                | StaleIfError(_)
+                | StaleWhileRevalidate(_)
+        )
     }
 
     /// Create an instance from a string slice.

--- a/src/cache/cache_control/mod.rs
+++ b/src/cache/cache_control/mod.rs
@@ -45,11 +45,10 @@ mod test {
     }
 
     #[test]
-    fn bad_request_on_parse_error() -> crate::Result<()> {
+    fn bad_request_on_parse_error() {
         let mut headers = Headers::new();
         headers.insert(CACHE_CONTROL, "min-fresh=0.9"); // floats are not supported
         let err = CacheControl::from_headers(headers).unwrap_err();
         assert_eq!(err.status(), 400);
-        Ok(())
     }
 }

--- a/src/cache/expires.rs
+++ b/src/cache/expires.rs
@@ -120,11 +120,10 @@ mod test {
     }
 
     #[test]
-    fn bad_request_on_parse_error() -> crate::Result<()> {
+    fn bad_request_on_parse_error() {
         let mut headers = Headers::new();
         headers.insert(EXPIRES, "<nori ate the tag. yum.>");
         let err = Expires::from_headers(headers).unwrap_err();
         assert_eq!(err.status(), 400);
-        Ok(())
     }
 }

--- a/src/conditional/etag.rs
+++ b/src/conditional/etag.rs
@@ -177,21 +177,19 @@ mod test {
     }
 
     #[test]
-    fn bad_request_on_parse_error() -> crate::Result<()> {
+    fn bad_request_on_parse_error() {
         let mut headers = Headers::new();
         headers.insert(ETAG, "<nori ate the tag. yum.>");
         let err = ETag::from_headers(headers).unwrap_err();
         assert_eq!(err.status(), 400);
-        Ok(())
     }
 
     #[test]
-    fn validate_quotes() -> crate::Result<()> {
+    fn validate_quotes() {
         assert_entry_err(r#""hello"#, "Invalid ETag header");
         assert_entry_err(r#"hello""#, "Invalid ETag header");
         assert_entry_err(r#"/O"valid content""#, "Invalid ETag header");
         assert_entry_err(r#"/Wvalid content""#, "Invalid ETag header");
-        Ok(())
     }
 
     fn assert_entry_err(s: &str, msg: &str) {
@@ -202,9 +200,8 @@ mod test {
     }
 
     #[test]
-    fn validate_characters() -> crate::Result<()> {
+    fn validate_characters() {
         assert_entry_err(r#"""hello""#, "Invalid ETag header");
         assert_entry_err("\"hello\x7F\"", "Invalid ETag header");
-        Ok(())
     }
 }

--- a/src/conditional/if_modified_since.rs
+++ b/src/conditional/if_modified_since.rs
@@ -116,11 +116,10 @@ mod test {
     }
 
     #[test]
-    fn bad_request_on_parse_error() -> crate::Result<()> {
+    fn bad_request_on_parse_error() {
         let mut headers = Headers::new();
         headers.insert(IF_MODIFIED_SINCE, "<nori ate the tag. yum.>");
         let err = IfModifiedSince::from_headers(headers).unwrap_err();
         assert_eq!(err.status(), 400);
-        Ok(())
     }
 }

--- a/src/conditional/if_unmodified_since.rs
+++ b/src/conditional/if_unmodified_since.rs
@@ -116,11 +116,10 @@ mod test {
     }
 
     #[test]
-    fn bad_request_on_parse_error() -> crate::Result<()> {
+    fn bad_request_on_parse_error() {
         let mut headers = Headers::new();
         headers.insert(IF_UNMODIFIED_SINCE, "<nori ate the tag. yum.>");
         let err = IfUnmodifiedSince::from_headers(headers).unwrap_err();
         assert_eq!(err.status(), 400);
-        Ok(())
     }
 }

--- a/src/conditional/last_modified.rs
+++ b/src/conditional/last_modified.rs
@@ -115,11 +115,10 @@ mod test {
     }
 
     #[test]
-    fn bad_request_on_parse_error() -> crate::Result<()> {
+    fn bad_request_on_parse_error() {
         let mut headers = Headers::new();
         headers.insert(LAST_MODIFIED, "<nori ate the tag. yum.>");
         let err = LastModified::from_headers(headers).unwrap_err();
         assert_eq!(err.status(), 400);
-        Ok(())
     }
 }

--- a/src/content/accept.rs
+++ b/src/content/accept.rs
@@ -137,7 +137,7 @@ impl Accept {
             }
         }
 
-        let mut err = Error::new_adhoc("No suitable ContentEncoding found");
+        let mut err = Error::new_adhoc("No suitable Content-Type found");
         err.set_status(StatusCode::NotAcceptable);
         Err(err)
     }

--- a/src/content/accept_encoding.rs
+++ b/src/content/accept_encoding.rs
@@ -107,7 +107,7 @@ impl AcceptEncoding {
         sort_by_weight(&mut self.entries);
     }
 
-    /// Determine the most suitable `Content-Type` encoding.
+    /// Determine the most suitable `Content-Encoding` encoding.
     ///
     /// # Errors
     ///
@@ -130,7 +130,7 @@ impl AcceptEncoding {
             }
         }
 
-        let mut err = Error::new_adhoc("No suitable ContentEncoding found");
+        let mut err = Error::new_adhoc("No suitable Content-Encoding found");
         err.set_status(StatusCode::NotAcceptable);
         Err(err)
     }

--- a/src/content/content_length.rs
+++ b/src/content/content_length.rs
@@ -98,11 +98,10 @@ mod test {
     }
 
     #[test]
-    fn bad_request_on_parse_error() -> crate::Result<()> {
+    fn bad_request_on_parse_error() {
         let mut headers = Headers::new();
         headers.insert(CONTENT_LENGTH, "<nori ate the tag. yum.>");
         let err = ContentLength::from_headers(headers).unwrap_err();
         assert_eq!(err.status(), 400);
-        Ok(())
     }
 }

--- a/src/content/content_location.rs
+++ b/src/content/content_location.rs
@@ -122,13 +122,12 @@ mod test {
     }
 
     #[test]
-    fn bad_request_on_parse_error() -> crate::Result<()> {
+    fn bad_request_on_parse_error() {
         let mut headers = Headers::new();
         headers.insert(CONTENT_LOCATION, "htt://<nori ate the tag. yum.>");
         let err =
             ContentLocation::from_headers(Url::parse("https://example.net").unwrap(), headers)
                 .unwrap_err();
         assert_eq!(err.status(), 400);
-        Ok(())
     }
 }

--- a/src/content/content_type.rs
+++ b/src/content/content_type.rs
@@ -130,11 +130,10 @@ mod test {
     }
 
     #[test]
-    fn bad_request_on_parse_error() -> crate::Result<()> {
+    fn bad_request_on_parse_error() {
         let mut headers = Headers::new();
         headers.insert(CONTENT_TYPE, "<nori ate the tag. yum.>");
         let err = ContentType::from_headers(headers).unwrap_err();
         assert_eq!(err.status(), 400);
-        Ok(())
     }
 }

--- a/src/content/encoding_proposal.rs
+++ b/src/content/encoding_proposal.rs
@@ -123,15 +123,14 @@ mod test {
     use super::*;
 
     #[test]
-    fn smoke() -> crate::Result<()> {
+    fn smoke() {
         let _ = EncodingProposal::new(Encoding::Gzip, Some(0.0)).unwrap();
         let _ = EncodingProposal::new(Encoding::Gzip, Some(0.5)).unwrap();
         let _ = EncodingProposal::new(Encoding::Gzip, Some(1.0)).unwrap();
-        Ok(())
     }
 
     #[test]
-    fn error_code_500() -> crate::Result<()> {
+    fn error_code_500() {
         let err = EncodingProposal::new(Encoding::Gzip, Some(1.1)).unwrap_err();
         assert_eq!(err.status(), 500);
 
@@ -140,6 +139,5 @@ mod test {
 
         let err = EncodingProposal::new(Encoding::Gzip, Some(-0.0)).unwrap_err();
         assert_eq!(err.status(), 500);
-        Ok(())
     }
 }

--- a/src/content/media_type_proposal.rs
+++ b/src/content/media_type_proposal.rs
@@ -57,7 +57,7 @@ impl MediaTypeProposal {
             .remove_param("q")
             .map(|param| param.as_str().parse())
             .transpose()?;
-        Ok(Self::new(media_type, weight)?)
+        Self::new(media_type, weight)
     }
 }
 
@@ -135,15 +135,14 @@ mod test {
     use crate::mime;
 
     #[test]
-    fn smoke() -> crate::Result<()> {
+    fn smoke() {
         let _ = MediaTypeProposal::new(mime::JSON, Some(0.0)).unwrap();
         let _ = MediaTypeProposal::new(mime::XML, Some(0.5)).unwrap();
         let _ = MediaTypeProposal::new(mime::HTML, Some(1.0)).unwrap();
-        Ok(())
     }
 
     #[test]
-    fn error_code_500() -> crate::Result<()> {
+    fn error_code_500() {
         let err = MediaTypeProposal::new(mime::JSON, Some(1.1)).unwrap_err();
         assert_eq!(err.status(), 500);
 
@@ -152,6 +151,5 @@ mod test {
 
         let err = MediaTypeProposal::new(mime::HTML, Some(-0.0)).unwrap_err();
         assert_eq!(err.status(), 500);
-        Ok(())
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,9 +8,9 @@
 //! ```
 //! # fn main() -> Result<(), http_types::url::ParseError> {
 //! #
-//! use http_types::{Url, Method, Request, Response, StatusCode};
+//! use http_types::{Method, Request, Response, StatusCode};
 //!
-//! let mut req = Request::new(Method::Get, Url::parse("https://example.com")?);
+//! let mut req = Request::new(Method::Get, "https://example.com");
 //! req.set_body("Hello, Nori!");
 //!
 //! let mut res = Response::new(StatusCode::Ok);

--- a/src/method.rs
+++ b/src/method.rs
@@ -518,9 +518,8 @@ mod test {
     }
 
     #[test]
-    fn serde_fail() -> Result<(), serde_json::Error> {
+    fn serde_fail() {
         serde_json::from_str::<Method>("\"ABC\"").expect_err("Did deserialize from invalid string");
-        Ok(())
     }
 
     #[test]

--- a/src/method.rs
+++ b/src/method.rs
@@ -5,49 +5,354 @@ use std::str::FromStr;
 
 /// HTTP request methods.
 ///
-/// [Read more](https://developer.mozilla.org/en-US/docs/Web/HTTP/Methods)
+/// See also [Mozilla's documentation][Mozilla docs], the [RFC7231, Section 4][] and
+/// [IANA's Hypertext Transfer Protocol (HTTP) Method Registry][HTTP Method Registry].
+///
+/// [Mozilla docs]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Methods
+/// [RFC7231, Section 4]: https://tools.ietf.org/html/rfc7231#section-4
+/// [HTTP Method Registry]: https://www.iana.org/assignments/http-methods/http-methods.xhtml
 #[derive(Debug, Clone, Copy, Eq, PartialEq, Hash)]
 pub enum Method {
-    /// The GET method requests a representation of the specified resource. Requests using GET
-    /// should only retrieve data.
-    Get,
+    /// The ACL method modifies the access control list (which can be read via the DAV:acl
+    /// property) of a resource.
+    ///
+    /// See [RFC3744, Section 8.1][].
+    ///
+    /// [RFC3744, Section 8.1]: https://tools.ietf.org/html/rfc3744#section-8.1
+    Acl,
 
-    /// The HEAD method asks for a response identical to that of a GET request, but without the response body.
-    Head,
+    /// A collection can be placed under baseline control with a BASELINE-CONTROL request.
+    ///
+    /// See [RFC3253, Section 12.6][].
+    ///
+    /// [RFC3253, Section 12.6]: https://tools.ietf.org/html/rfc3253#section-12.6
+    BaselineControl,
 
-    /// The POST method is used to submit an entity to the specified resource, often causing a
-    /// change in state or side effects on the server.
-    Post,
+    /// The BIND method modifies the collection identified by the Request- URI, by adding a new
+    /// binding from the segment specified in the BIND body to the resource identified in the BIND
+    /// body.
+    ///
+    /// See [RFC5842, Section 4][].
+    ///
+    /// [RFC5842, Section 4]: https://tools.ietf.org/html/rfc5842#section-4
+    Bind,
 
-    /// The PUT method replaces all current representations of the target resource with the request
-    /// payload.
-    Put,
+    /// A CHECKIN request can be applied to a checked-out version-controlled resource to produce a
+    /// new version whose content and dead properties are copied from the checked-out resource.
+    ///
+    /// See [RFC3253, Section 4.4][] and [RFC3253, Section 9.4][].
+    ///
+    /// [RFC3253, Section 4.4]: https://tools.ietf.org/html/rfc3253#section-4.4
+    /// [RFC3253, Section 9.4]: https://tools.ietf.org/html/rfc3253#section-9.4
+    Checkin,
 
-    /// The DELETE method deletes the specified resource.
-    Delete,
+    /// A CHECKOUT request can be applied to a checked-in version-controlled resource to allow
+    /// modifications to the content and dead properties of that version-controlled resource.
+    ///
+    /// See [RFC3253, Section 4.3][] and [RFC3253, Section 8.8][].
+    ///
+    /// [RFC3253, Section 4.3]: https://tools.ietf.org/html/rfc3253#section-4.3
+    /// [RFC3253, Section 8.8]: https://tools.ietf.org/html/rfc3253#section-8.8
+    Checkout,
 
-    /// The CONNECT method establishes a tunnel to the server identified by the target resource.
+    /// The CONNECT method requests that the recipient establish a tunnel to the destination origin
+    /// server identified by the request-target and, if successful, thereafter restrict its
+    /// behavior to blind forwarding of packets, in both directions, until the tunnel is closed.
+    ///
+    /// See [RFC7231, Section 4.3.6][].
+    ///
+    /// [RFC7231, Section 4.3.6]: https://tools.ietf.org/html/rfc7231#section-4.3.6
     Connect,
 
-    /// The OPTIONS method is used to describe the communication options for the target resource.
+    /// The COPY method creates a duplicate of the source resource identified by the Request-URI,
+    /// in the destination resource identified by the URI in the Destination header.
+    ///
+    /// See [RFC4918, Section 9.8][].
+    ///
+    /// [RFC4918, Section 9.8]: https://tools.ietf.org/html/rfc4918#section-9.8
+    Copy,
+
+    /// The DELETE method requests that the origin server remove the association between the target
+    /// resource and its current functionality.
+    ///
+    /// See [RFC7231, Section 4.3.5][].
+    ///
+    /// [RFC7231, Section 4.3.5]: https://tools.ietf.org/html/rfc7231#section-4.3.5
+    Delete,
+
+    /// The GET method requests transfer of a current selected representation for the target
+    /// resource.
+    ///
+    /// See [RFC7231, Section 4.3.1][].
+    ///
+    /// [RFC7231, Section 4.3.1]: https://tools.ietf.org/html/rfc7231#section-4.3.1
+    Get,
+
+    /// The HEAD method is identical to GET except that the server MUST NOT send a message body in
+    /// the response.
+    ///
+    /// See [RFC7231, Section 4.3.2][].
+    ///
+    /// [RFC7231, Section 4.3.2]: https://tools.ietf.org/html/rfc7231#section-4.3.2
+    Head,
+
+    /// A LABEL request can be applied to a version to modify the labels that select that version.
+    ///
+    /// See [RFC3253, Section 8.2][].
+    ///
+    /// [RFC3253, Section 8.2]: https://tools.ietf.org/html/rfc3253#section-8.2
+    Label,
+
+    /// The LINK method establishes one or more Link relationships between the existing resource
+    /// identified by the Request-URI and other existing resources.
+    ///
+    /// See [RFC2068, Section 19.6.1.2][].
+    ///
+    /// [RFC2068, Section 19.6.1.2]: https://tools.ietf.org/html/rfc2068#section-19.6.1.2
+    Link,
+
+    /// The LOCK method is used to take out a lock of any access type and to refresh an existing
+    /// lock.
+    ///
+    /// See [RFC4918, Section 9.10][].
+    ///
+    /// [RFC4918, Section 9.10]: https://tools.ietf.org/html/rfc4918#section-9.10
+    Lock,
+
+    /// The MERGE method performs the logical merge of a specified version (the "merge source")
+    /// into a specified version-controlled resource (the "merge target").
+    ///
+    /// See [RFC3253, Section 11.2][].
+    ///
+    /// [RFC3253, Section 11.2]: https://tools.ietf.org/html/rfc3253#section-11.2
+    Merge,
+
+    /// A MKACTIVITY request creates a new activity resource.
+    ///
+    /// See [RFC3253, Section 13.5].
+    ///
+    /// [RFC3253, Section 13.5]: https://tools.ietf.org/html/rfc3253#section-13.5
+    MkActivity,
+
+    /// An HTTP request using the MKCALENDAR method creates a new calendar collection resource.
+    ///
+    /// See [RFC4791, Section 5.3.1][] and [RFC8144, Section 2.3][].
+    ///
+    /// [RFC4791, Section 5.3.1]: https://tools.ietf.org/html/rfc4791#section-5.3.1
+    /// [RFC8144, Section 2.3]: https://tools.ietf.org/html/rfc8144#section-2.3
+    MkCalendar,
+
+    /// MKCOL creates a new collection resource at the location specified by the Request-URI.
+    ///
+    /// See [RFC4918, Section 9.3][], [RFC5689, Section 3][] and [RFC8144, Section 2.3][].
+    ///
+    /// [RFC4918, Section 9.3]: https://tools.ietf.org/html/rfc4918#section-9.3
+    /// [RFC5689, Section 3]: https://tools.ietf.org/html/rfc5689#section-3
+    /// [RFC8144, Section 2.3]: https://tools.ietf.org/html/rfc5689#section-3
+    MkCol,
+
+    /// The MKREDIRECTREF method requests the creation of a redirect reference resource.
+    ///
+    /// See [RFC4437, Section 6][].
+    ///
+    /// [RFC4437, Section 6]: https://tools.ietf.org/html/rfc4437#section-6
+    MkRedirectRef,
+
+    /// A MKWORKSPACE request creates a new workspace resource.
+    ///
+    /// See [RFC3253, Section 6.3][].
+    ///
+    /// [RFC3253, Section 6.3]: https://tools.ietf.org/html/rfc3253#section-6.3
+    MkWorkspace,
+
+    /// The MOVE operation on a non-collection resource is the logical equivalent of a copy (COPY),
+    /// followed by consistency maintenance processing, followed by a delete of the source, where
+    /// all three actions are performed in a single operation.
+    ///
+    /// See [RFC4918, Section 9.9][].
+    ///
+    /// [RFC4918, Section 9.9]: https://tools.ietf.org/html/rfc4918#section-9.9
+    Move,
+
+    /// The OPTIONS method requests information about the communication options available for the
+    /// target resource, at either the origin server or an intervening intermediary.
+    ///
+    /// See [RFC7231, Section 4.3.7][].
+    ///
+    /// [RFC7231, Section 4.3.7]: https://tools.ietf.org/html/rfc7231#section-4.3.7
     Options,
 
-    /// The TRACE method performs a message loop-back test along the path to the target resource.
+    /// The ORDERPATCH method is used to change the ordering semantics of a collection, to change
+    /// the order of the collection's members in the ordering, or both.
+    ///
+    /// See [RFC3648, Section 7][].
+    ///
+    /// [RFC3648, Section 7]: https://tools.ietf.org/html/rfc3648#section-7
+    OrderPatch,
+
+    /// The PATCH method requests that a set of changes described in the request entity be applied
+    /// to the resource identified by the Request- URI.
+    ///
+    /// See [RFC5789, Section 2][].
+    ///
+    /// [RFC5789, Section 2]: https://tools.ietf.org/html/rfc5789#section-2
+    Patch,
+
+    /// The POST method requests that the target resource process the representation enclosed in
+    /// the request according to the resource's own specific semantics.
+    ///
+    /// For example, POST is used for the following functions (among others):
+    ///
+    ///   - Providing a block of data, such as the fields entered into an HTML form, to a
+    ///     data-handling process;
+    ///   - Posting a message to a bulletin board, newsgroup, mailing list, blog, or similar group
+    ///     of articles;
+    ///   - Creating a new resource that has yet to be identified by the origin server; and
+    ///   - Appending data to a resource's existing representation(s).
+    ///
+    /// See [RFC7231, Section 4.3.3][].
+    ///
+    /// [RFC7231, Section 4.3.3]: https://tools.ietf.org/html/rfc7231#section-4.3.3
+    Post,
+
+    /// This method is never used by an actual client. This method will appear to be used when an
+    /// HTTP/1.1 server or intermediary attempts to parse an HTTP/2 connection preface.
+    ///
+    /// See [RFC7540, Section 3.5][] and [RFC7540, Section 11.6][]
+    ///
+    /// [RFC7540, Section 3.5]: https://tools.ietf.org/html/rfc7540#section-3.5
+    /// [RFC7540, Section 11.6]: https://tools.ietf.org/html/rfc7540#section-11.6
+    Pri,
+
+    /// The PROPFIND method retrieves properties defined on the resource identified by the
+    /// Request-URI.
+    ///
+    /// See [RFC4918, Section 9.1][] and [RFC8144, Section 2.1][].
+    ///
+    /// [RFC4918, Section 9.1]: https://tools.ietf.org/html/rfc4918#section-9.1
+    /// [RFC8144, Section 2.1]: https://tools.ietf.org/html/rfc8144#section-2.1
+    PropFind,
+
+    /// The PROPPATCH method processes instructions specified in the request body to set and/or
+    /// remove properties defined on the resource identified by the Request-URI.
+    ///
+    /// See [RFC4918, Section 9.2][] and [RFC8144, Section 2.2][].
+    ///
+    /// [RFC4918, Section 9.2]: https://tools.ietf.org/html/rfc4918#section-9.2
+    /// [RFC8144, Section 2.2]: https://tools.ietf.org/html/rfc8144#section-2.2
+    PropPatch,
+
+    /// The PUT method requests that the state of the target resource be created or replaced with
+    /// the state defined by the representation enclosed in the request message payload.
+    ///
+    /// See [RFC7231, Section 4.3.4][].
+    ///
+    /// [RFC7231, Section 4.3.4]: https://tools.ietf.org/html/rfc7231#section-4.3.4
+    Put,
+
+    /// The REBIND method removes a binding to a resource from a collection, and adds a binding to
+    /// that resource into the collection identified by the Request-URI.
+    ///
+    /// See [RFC5842, Section 6][].
+    ///
+    /// [RFC5842, Section 6]: https://tools.ietf.org/html/rfc5842#section-6
+    Rebind,
+
+    /// A REPORT request is an extensible mechanism for obtaining information about a resource.
+    ///
+    /// See [RFC3253, Section 3.6][] and [RFC8144, Section 2.1][].
+    ///
+    /// [RFC3253, Section 3.6]: https://tools.ietf.org/html/rfc3253#section-3.6
+    /// [RFC8144, Section 2.1]: https://tools.ietf.org/html/rfc8144#section-2.1
+    Report,
+
+    /// The client invokes the SEARCH method to initiate a server-side search. The body of the
+    /// request defines the query.
+    ///
+    /// See [RFC5323, Section 2][].
+    ///
+    /// [RFC5323, Section 2]: https://tools.ietf.org/html/rfc5323#section-2
+    Search,
+
+    /// The TRACE method requests a remote, application-level loop-back of the request message.
+    ///
+    /// See [RFC7231, Section 4.3.8][].
+    ///
+    /// [RFC7231, Section 4.3.8]: https://tools.ietf.org/html/rfc7231#section-4.3.8
     Trace,
 
-    /// The PATCH method is used to apply partial modifications to a resource.
-    Patch,
+    /// The UNBIND method modifies the collection identified by the Request- URI by removing the
+    /// binding identified by the segment specified in the UNBIND body.
+    ///
+    /// See [RFC5842, Section 5][].
+    ///
+    /// [RFC5842, Section 5]: https://tools.ietf.org/html/rfc5842#section-5
+    Unbind,
+
+    /// An UNCHECKOUT request can be applied to a checked-out version-controlled resource to cancel
+    /// the CHECKOUT and restore the pre-CHECKOUT state of the version-controlled resource.
+    ///
+    /// See [RFC3253, Section 4.5][].
+    ///
+    /// [RFC3253, Section 4.5]: https://tools.ietf.org/html/rfc3253#section-4.5
+    Uncheckout,
+
+    /// The UNLINK method removes one or more Link relationships from the existing resource
+    /// identified by the Request-URI.
+    ///
+    /// See [RFC2068, Section 19.6.1.3][].
+    ///
+    /// [RFC2068, Section 19.6.1.3]: https://tools.ietf.org/html/rfc2068#section-19.6.1.3
+    Unlink,
+
+    /// The UNLOCK method removes the lock identified by the lock token in the Lock-Token request
+    /// header.
+    ///
+    /// See [RFC4918, Section 9.11][].
+    ///
+    /// [RFC4918, Section 9.11]: https://tools.ietf.org/html/rfc4918#section-9.11
+    Unlock,
+
+    /// The UPDATE method modifies the content and dead properties of a checked-in
+    /// version-controlled resource (the "update target") to be those of a specified version (the
+    /// "update source") from the version history of that version-controlled resource.
+    ///
+    /// See [RFC3253, Section 7.1][].
+    ///
+    /// [RFC3253, Section 7.1]: https://tools.ietf.org/html/rfc3253#section-7.1
+    Update,
+
+    /// The UPDATEREDIRECTREF method requests the update of a redirect reference resource.
+    ///
+    /// See [RFC4437, Section 7][].
+    ///
+    /// [RFC4437, Section 7]: https://tools.ietf.org/html/rfc4437#section-7
+    UpdateRedirectRef,
+
+    /// A VERSION-CONTROL request can be used to create a version-controlled resource at the
+    /// request-URL.
+    ///
+    /// See [RFC3253, Section 3.5].
+    ///
+    /// [RFC3253, Section 3.5]: https://tools.ietf.org/html/rfc3253#section-3.5
+    VersionControl,
 }
 
 impl Method {
-    /// Whether a method is considered "safe", meaning the request is
-    /// essentially read-only.
+    /// Whether a method is considered "safe", meaning the request is essentially read-only.
     ///
     /// See [the spec](https://tools.ietf.org/html/rfc7231#section-4.2.1) for more details.
     pub fn is_safe(&self) -> bool {
         matches!(
             self,
-            Method::Get | Method::Head | Method::Options | Method::Trace
+            Method::Get
+                | Method::Head
+                | Method::Options
+                | Method::Pri
+                | Method::PropFind
+                | Method::Report
+                | Method::Search
+                | Method::Trace
         )
     }
 }
@@ -92,17 +397,7 @@ impl Serialize for Method {
 
 impl Display for Method {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            Self::Get => write!(f, "GET"),
-            Self::Head => write!(f, "HEAD"),
-            Self::Post => write!(f, "POST"),
-            Self::Put => write!(f, "PUT"),
-            Self::Delete => write!(f, "DELETE"),
-            Self::Connect => write!(f, "CONNECT"),
-            Self::Options => write!(f, "OPTIONS"),
-            Self::Trace => write!(f, "TRACE"),
-            Self::Patch => write!(f, "PATCH"),
-        }
+        f.write_str(AsRef::<str>::as_ref(self))
     }
 }
 
@@ -111,15 +406,45 @@ impl FromStr for Method {
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         match &*s.to_ascii_uppercase() {
+            "ACL" => Ok(Self::Acl),
+            "BASELINE-CONTROL" => Ok(Self::BaselineControl),
+            "BIND" => Ok(Self::Bind),
+            "CHECKIN" => Ok(Self::Checkin),
+            "CHECKOUT" => Ok(Self::Checkout),
+            "CONNECT" => Ok(Self::Connect),
+            "COPY" => Ok(Self::Copy),
+            "DELETE" => Ok(Self::Delete),
             "GET" => Ok(Self::Get),
             "HEAD" => Ok(Self::Head),
-            "POST" => Ok(Self::Post),
-            "PUT" => Ok(Self::Put),
-            "DELETE" => Ok(Self::Delete),
-            "CONNECT" => Ok(Self::Connect),
+            "LABEL" => Ok(Self::Label),
+            "LINK" => Ok(Self::Link),
+            "LOCK" => Ok(Self::Lock),
+            "MERGE" => Ok(Self::Merge),
+            "MKACTIVITY" => Ok(Self::MkActivity),
+            "MKCALENDAR" => Ok(Self::MkCalendar),
+            "MKCOL" => Ok(Self::MkCol),
+            "MKREDIRECTREF" => Ok(Self::MkRedirectRef),
+            "MKWORKSPACE" => Ok(Self::MkWorkspace),
+            "MOVE" => Ok(Self::Move),
             "OPTIONS" => Ok(Self::Options),
-            "TRACE" => Ok(Self::Trace),
+            "ORDERPATCH" => Ok(Self::OrderPatch),
             "PATCH" => Ok(Self::Patch),
+            "POST" => Ok(Self::Post),
+            "PRI" => Ok(Self::Pri),
+            "PROPFIND" => Ok(Self::PropFind),
+            "PROPPATCH" => Ok(Self::PropPatch),
+            "PUT" => Ok(Self::Put),
+            "REBIND" => Ok(Self::Rebind),
+            "REPORT" => Ok(Self::Report),
+            "SEARCH" => Ok(Self::Search),
+            "TRACE" => Ok(Self::Trace),
+            "UNBIND" => Ok(Self::Unbind),
+            "UNCHECKOUT" => Ok(Self::Uncheckout),
+            "UNLINK" => Ok(Self::Unlink),
+            "UNLOCK" => Ok(Self::Unlock),
+            "UPDATE" => Ok(Self::Update),
+            "UPDATEREDIRECTREF" => Ok(Self::UpdateRedirectRef),
+            "VERSION-CONTROL" => Ok(Self::VersionControl),
             _ => crate::bail!("Invalid HTTP method"),
         }
     }
@@ -136,21 +461,53 @@ impl<'a> std::convert::TryFrom<&'a str> for Method {
 impl AsRef<str> for Method {
     fn as_ref(&self) -> &str {
         match self {
+            Self::Acl => "ACL",
+            Self::BaselineControl => "BASELINE-CONTROL",
+            Self::Bind => "BIND",
+            Self::Checkin => "CHECKIN",
+            Self::Checkout => "CHECKOUT",
+            Self::Connect => "CONNECT",
+            Self::Copy => "COPY",
+            Self::Delete => "DELETE",
             Self::Get => "GET",
             Self::Head => "HEAD",
-            Self::Post => "POST",
-            Self::Put => "PUT",
-            Self::Delete => "DELETE",
-            Self::Connect => "CONNECT",
+            Self::Label => "LABEL",
+            Self::Link => "LINK",
+            Self::Lock => "LOCK",
+            Self::Merge => "MERGE",
+            Self::MkActivity => "MKACTIVITY",
+            Self::MkCalendar => "MKCALENDAR",
+            Self::MkCol => "MKCOL",
+            Self::MkRedirectRef => "MKREDIRECTREF",
+            Self::MkWorkspace => "MKWORKSPACE",
+            Self::Move => "MOVE",
             Self::Options => "OPTIONS",
-            Self::Trace => "TRACE",
+            Self::OrderPatch => "ORDERPATCH",
             Self::Patch => "PATCH",
+            Self::Post => "POST",
+            Self::Pri => "PRI",
+            Self::PropFind => "PROPFIND",
+            Self::PropPatch => "PROPPATCH",
+            Self::Put => "PUT",
+            Self::Rebind => "REBIND",
+            Self::Report => "REPORT",
+            Self::Search => "SEARCH",
+            Self::Trace => "TRACE",
+            Self::Unbind => "UNBIND",
+            Self::Uncheckout => "UNCHECKOUT",
+            Self::Unlink => "UNLINK",
+            Self::Unlock => "UNLOCK",
+            Self::Update => "UPDATE",
+            Self::UpdateRedirectRef => "UPDATEREDIRECTREF",
+            Self::VersionControl => "VERSION-CONTROL",
         }
     }
 }
 
 #[cfg(test)]
 mod test {
+    use std::collections::HashSet;
+
     use super::Method;
 
     #[test]
@@ -159,9 +516,70 @@ mod test {
         assert_eq!(Some("PATCH"), serde_json::to_value(Method::Patch)?.as_str());
         Ok(())
     }
+
     #[test]
     fn serde_fail() -> Result<(), serde_json::Error> {
         serde_json::from_str::<Method>("\"ABC\"").expect_err("Did deserialize from invalid string");
+        Ok(())
+    }
+
+    #[test]
+    fn names() -> Result<(), crate::Error> {
+        let method_names = [
+            "ACL",
+            "BASELINE-CONTROL",
+            "BIND",
+            "CHECKIN",
+            "CHECKOUT",
+            "CONNECT",
+            "COPY",
+            "DELETE",
+            "GET",
+            "HEAD",
+            "LABEL",
+            "LINK",
+            "LOCK",
+            "MERGE",
+            "MKACTIVITY",
+            "MKCALENDAR",
+            "MKCOL",
+            "MKREDIRECTREF",
+            "MKWORKSPACE",
+            "MOVE",
+            "OPTIONS",
+            "ORDERPATCH",
+            "PATCH",
+            "POST",
+            "PRI",
+            "PROPFIND",
+            "PROPPATCH",
+            "PUT",
+            "REBIND",
+            "REPORT",
+            "SEARCH",
+            "TRACE",
+            "UNBIND",
+            "UNCHECKOUT",
+            "UNLINK",
+            "UNLOCK",
+            "UPDATE",
+            "UPDATEREDIRECTREF",
+            "VERSION-CONTROL",
+        ];
+
+        let methods = method_names
+            .iter()
+            .map(|s| s.parse::<Method>())
+            .collect::<Result<HashSet<_>, _>>()?;
+
+        // check that we didn't accidentally map two methods to the same variant
+        assert_eq!(methods.len(), method_names.len());
+
+        // check that a method's name and the name it is parsed from match
+        for method in methods {
+            assert_eq!(method.as_ref().parse::<Method>()?, method);
+        }
+
         Ok(())
     }
 }

--- a/src/mime/constants.rs
+++ b/src/mime/constants.rs
@@ -20,12 +20,23 @@ macro_rules! mime_const {
     };
 
     (with_params, $name:ident, $desc:expr, $base:expr, $sub:expr, $is_utf8:expr, $doccomment:expr) => {
-        mime_const!(doc_expanded, $name, $desc, $base, $sub, $is_utf8,
-             concat!(
+        mime_const!(
+            doc_expanded,
+            $name,
+            $desc,
+            $base,
+            $sub,
+            $is_utf8,
+            concat!(
                 "Content-Type for ",
                 $desc,
                 ".\n\n# Mime Type\n\n```text\n",
-                $base, "/", $sub, $doccomment, "\n```")
+                $base,
+                "/",
+                $sub,
+                $doccomment,
+                "\n```"
+            )
         );
     };
 

--- a/src/other/date.rs
+++ b/src/other/date.rs
@@ -132,11 +132,10 @@ mod test {
     }
 
     #[test]
-    fn bad_request_on_parse_error() -> crate::Result<()> {
+    fn bad_request_on_parse_error() {
         let mut headers = Headers::new();
         headers.insert(DATE, "<nori ate the tag. yum.>");
         let err = Date::from_headers(headers).unwrap_err();
         assert_eq!(err.status(), 400);
-        Ok(())
     }
 }

--- a/src/other/expect.rs
+++ b/src/other/expect.rs
@@ -100,11 +100,10 @@ mod test {
     }
 
     #[test]
-    fn bad_request_on_parse_error() -> crate::Result<()> {
+    fn bad_request_on_parse_error() {
         let mut headers = Headers::new();
         headers.insert(EXPECT, "<nori ate the tag. yum.>");
         let err = Expect::from_headers(headers).unwrap_err();
         assert_eq!(err.status(), 400);
-        Ok(())
     }
 }

--- a/src/other/referer.rs
+++ b/src/other/referer.rs
@@ -126,13 +126,12 @@ mod test {
     }
 
     #[test]
-    fn bad_request_on_parse_error() -> crate::Result<()> {
+    fn bad_request_on_parse_error() {
         let mut headers = Headers::new();
         headers.insert(REFERER, "htt://<nori ate the tag. yum.>");
         let err =
             Referer::from_headers(Url::parse("https://example.net").unwrap(), headers).unwrap_err();
         assert_eq!(err.status(), 500);
-        Ok(())
     }
 
     #[test]

--- a/src/other/source_map.rs
+++ b/src/other/source_map.rs
@@ -123,13 +123,12 @@ mod test {
     }
 
     #[test]
-    fn bad_request_on_parse_error() -> crate::Result<()> {
+    fn bad_request_on_parse_error() {
         let mut headers = Headers::new();
         headers.insert(SOURCE_MAP, "htt://<nori ate the tag. yum.>");
         let err = SourceMap::from_headers(Url::parse("https://example.net").unwrap(), headers)
             .unwrap_err();
         assert_eq!(err.status(), 500);
-        Ok(())
     }
 
     #[test]

--- a/src/proxies/forwarded.rs
+++ b/src/proxies/forwarded.rs
@@ -545,7 +545,7 @@ mod tests {
         assert_eq!(forwarded.forwarded_for(), vec!["client.com"]);
         assert_eq!(forwarded.host(), Some("host.com"));
         assert_eq!(forwarded.proto(), Some("https"));
-        assert!(matches!(forwarded, Forwarded{..}));
+        assert!(matches!(forwarded, Forwarded { .. }));
         Ok(())
     }
 
@@ -644,7 +644,7 @@ mod tests {
         assert_eq!(forwarded.forwarded_for(), vec!["client"]);
         assert_eq!(forwarded.host(), Some("example.com"));
         assert_eq!(forwarded.proto(), Some("https"));
-        assert!(matches!(forwarded, Forwarded{..}));
+        assert!(matches!(forwarded, Forwarded { .. }));
         Ok(())
     }
 

--- a/src/proxies/forwarded.rs
+++ b/src/proxies/forwarded.rs
@@ -455,14 +455,14 @@ impl std::fmt::Display for Forwarded<'_> {
 impl ToHeaderValues for Forwarded<'_> {
     type Iter = std::option::IntoIter<HeaderValue>;
     fn to_header_values(&self) -> crate::Result<Self::Iter> {
-        Ok(self.value()?.to_header_values()?)
+        self.value()?.to_header_values()
     }
 }
 
 impl ToHeaderValues for &Forwarded<'_> {
     type Iter = std::option::IntoIter<HeaderValue>;
     fn to_header_values(&self) -> crate::Result<Self::Iter> {
-        Ok(self.value()?.to_header_values()?)
+        self.value()?.to_header_values()
     }
 }
 
@@ -550,7 +550,7 @@ mod tests {
     }
 
     #[test]
-    fn bad_parse() -> Result<()> {
+    fn bad_parse() {
         let err = Forwarded::parse("by=proxy.com;for=client;host=example.com;host").unwrap_err();
         assert_eq!(
             err.to_string(),
@@ -580,7 +580,6 @@ mod tests {
             err.to_string(),
             "unable to parse forwarded header: for= without valid value"
         );
-        Ok(())
     }
 
     #[test]
@@ -611,7 +610,7 @@ mod tests {
     }
 
     #[test]
-    fn formatting_edge_cases() -> Result<()> {
+    fn formatting_edge_cases() {
         let mut forwarded = Forwarded::new();
         forwarded.add_for(r#"quote: " backslash: \"#);
         forwarded.add_for(";proto=https");
@@ -619,7 +618,6 @@ mod tests {
             forwarded.to_string(),
             r#"for="quote: \" backslash: \\", for=";proto=https""#
         );
-        Ok(())
     }
 
     #[test]

--- a/src/request.rs
+++ b/src/request.rs
@@ -21,9 +21,9 @@ pin_project_lite::pin_project! {
     /// # Examples
     ///
     /// ```
-    /// use http_types::{Url, Method, Request};
+    /// use http_types::Request;
     ///
-    /// let mut req = Request::new(Method::Get, Url::parse("https://example.com").unwrap());
+    /// let mut req = Request::get("https://example.com");
     /// req.set_body("Hello, Nori!");
     /// ```
     #[derive(Debug)]
@@ -157,8 +157,8 @@ impl Request {
     /// ```
     /// # fn main() -> Result<(), http_types::Error> {
     /// #
-    /// use http_types::{Method, Request, Response, StatusCode, Url};
-    /// let mut req = Request::new(Method::Get, Url::parse("https://example.com")?);
+    /// use http_types::{Request, Response, StatusCode};
+    /// let mut req = Request::get("https://example.com");
     /// assert_eq!(req.url().scheme(), "https");
     /// #
     /// # Ok(()) }
@@ -175,7 +175,7 @@ impl Request {
     /// # fn main() -> Result<(), http_types::Error> {
     /// #
     /// use http_types::{Method, Request, Response, StatusCode, Url};
-    /// let mut req = Request::new(Method::Get, Url::parse("https://example.com")?);
+    /// let mut req = Request::get("https://example.com");
     /// req.url_mut().set_scheme("http");
     /// assert_eq!(req.url().scheme(), "http");
     /// #
@@ -190,9 +190,9 @@ impl Request {
     /// # Examples
     ///
     /// ```
-    /// use http_types::{Method, Request, Url};
+    /// use http_types::{Method, Request};
     ///
-    /// let mut req = Request::new(Method::Get, Url::parse("https://example.com").unwrap());
+    /// let mut req = Request::get("https://example.com");
     /// req.set_body("Hello, Nori!");
     /// ```
     pub fn set_body(&mut self, body: impl Into<Body>) {
@@ -208,9 +208,9 @@ impl Request {
     /// # use async_std::io::prelude::*;
     /// # fn main() -> http_types::Result<()> { async_std::task::block_on(async {
     /// #
-    /// use http_types::{Body, Method, Request, Url};
+    /// use http_types::{Body, Method, Request};
     ///
-    /// let mut req = Request::new(Method::Get, Url::parse("https://example.com").unwrap());
+    /// let mut req = Request::get("https://example.com");
     /// req.set_body("Hello, Nori!");
     /// let mut body: Body = req.replace_body("Hello, Chashu!");
     ///
@@ -234,9 +234,9 @@ impl Request {
     /// # use async_std::io::prelude::*;
     /// # fn main() -> http_types::Result<()> { async_std::task::block_on(async {
     /// #
-    /// use http_types::{Body, Method, Request, Url};
+    /// use http_types::{Body, Request};
     ///
-    /// let mut req = Request::new(Method::Get, Url::parse("https://example.com").unwrap());
+    /// let mut req = Request::get("https://example.com");
     /// req.set_body("Hello, Nori!");
     /// let mut body = "Hello, Chashu!".into();
     /// req.swap_body(&mut body);
@@ -260,9 +260,9 @@ impl Request {
     /// # use async_std::io::prelude::*;
     /// # fn main() -> http_types::Result<()> { async_std::task::block_on(async {
     /// #
-    /// use http_types::{Body, Method, Request, Url};
+    /// use http_types::{Body, Request};
     ///
-    /// let mut req = Request::new(Method::Get, Url::parse("https://example.com").unwrap());
+    /// let mut req = Request::get("https://example.com");
     /// req.set_body("Hello, Nori!");
     /// let mut body: Body = req.take_body();
     ///
@@ -293,9 +293,9 @@ impl Request {
     /// # use std::io::prelude::*;
     /// # fn main() -> http_types::Result<()> { async_std::task::block_on(async {
     /// use async_std::io::Cursor;
-    /// use http_types::{Body, Method, Request, Url};
+    /// use http_types::{Body, Request};
     ///
-    /// let mut req = Request::new(Method::Get, Url::parse("https://example.com").unwrap());
+    /// let mut req = Request::get("https://example.com");
     ///
     /// let cursor = Cursor::new("Hello Nori");
     /// let body = Body::from_reader(cursor, None);
@@ -319,10 +319,10 @@ impl Request {
     ///
     /// ```
     /// # fn main() -> http_types::Result<()> { async_std::task::block_on(async {
-    /// use http_types::{Body, Method, Request, Url};
+    /// use http_types::{Body, Request};
     ///
     /// let bytes = vec![1, 2, 3];
-    /// let mut req = Request::new(Method::Get, Url::parse("https://example.com").unwrap());
+    /// let mut req = Request::get("https://example.com");
     /// req.set_body(Body::from_bytes(bytes));
     ///
     /// let bytes = req.body_bytes().await?;
@@ -346,7 +346,7 @@ impl Request {
     /// ```
     /// # fn main() -> http_types::Result<()> { async_std::task::block_on(async {
     /// use http_types::convert::{Deserialize, Serialize};
-    /// use http_types::{Body, Method, Request, Url};
+    /// use http_types::{Body, Request};
     ///
     /// #[derive(Debug, Serialize, Deserialize)]
     /// struct Cat {
@@ -356,7 +356,7 @@ impl Request {
     /// let cat = Cat {
     ///     name: String::from("chashu"),
     /// };
-    /// let mut req = Request::new(Method::Get, Url::parse("https://example.com").unwrap());
+    /// let mut req = Request::get("https://example.com");
     /// req.set_body(Body::from_json(&cat)?);
     ///
     /// let cat: Cat = req.body_json().await?;
@@ -380,7 +380,7 @@ impl Request {
     /// ```
     /// # fn main() -> http_types::Result<()> { async_std::task::block_on(async {
     /// use http_types::convert::{Deserialize, Serialize};
-    /// use http_types::{Body, Method, Request, Url};
+    /// use http_types::{Body, Request};
     ///
     /// #[derive(Debug, Serialize, Deserialize)]
     /// struct Cat {
@@ -390,7 +390,7 @@ impl Request {
     /// let cat = Cat {
     ///     name: String::from("chashu"),
     /// };
-    /// let mut req = Request::new(Method::Get, Url::parse("https://example.com").unwrap());
+    /// let mut req = Request::get("https://example.com");
     /// req.set_body(Body::from_form(&cat)?);
     ///
     /// let cat: Cat = req.body_form().await?;
@@ -424,9 +424,9 @@ impl Request {
     /// ```
     /// # fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync + 'static>> {
     /// #
-    /// use http_types::{Method, Request, Url};
+    /// use http_types::Request;
     ///
-    /// let mut req = Request::new(Method::Get, Url::parse("https://example.com")?);
+    /// let mut req = Request::get("https://example.com");
     /// req.insert_header("Content-Type", "text/plain");
     /// #
     /// # Ok(()) }
@@ -450,9 +450,9 @@ impl Request {
     /// ```
     /// # fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync + 'static>> {
     /// #
-    /// use http_types::{Method, Request, Url};
+    /// use http_types::Request;
     ///
-    /// let mut req = Request::new(Method::Get, Url::parse("https://example.com")?);
+    /// let mut req = Request::get("https://example.com");
     /// req.append_header("Content-Type", "text/plain");
     /// #
     /// # Ok(()) }
@@ -503,11 +503,11 @@ impl Request {
     /// # Examples
     ///
     /// ```
-    /// use http_types::{Method, Request, Url, Version};
+    /// use http_types::{Request, Version};
     ///
     /// # fn main() -> Result<(), http_types::Error> {
     /// #
-    /// let mut req = Request::new(Method::Get, Url::parse("https://example.com")?);
+    /// let mut req = Request::get("https://example.com");
     /// assert_eq!(req.version(), None);
     ///
     /// req.set_version(Some(Version::Http2_0));
@@ -524,11 +524,11 @@ impl Request {
     /// # Examples
     ///
     /// ```
-    /// use http_types::{Method, Request, Url, Version};
+    /// use http_types::{Request, Version};
     ///
     /// # fn main() -> Result<(), http_types::Error> {
     /// #
-    /// let mut req = Request::new(Method::Get, Url::parse("https://example.com")?);
+    /// let mut req = Request::get("https://example.com");
     /// req.set_version(Some(Version::Http2_0));
     /// #
     /// # Ok(()) }
@@ -594,9 +594,9 @@ impl Request {
     /// ```
     /// # fn main() -> Result<(), http_types::Error> {
     /// #
-    /// use http_types::{Method, Request, Url, Version};
+    /// use http_types::{Request, Version};
     ///
-    /// let mut req = Request::new(Method::Get, Url::parse("https://example.com")?);
+    /// let mut req = Request::get("https://example.com");
     /// req.ext_mut().insert("hello from the extension");
     /// assert_eq!(req.ext().get(), Some(&"hello from the extension"));
     /// #
@@ -612,7 +612,7 @@ impl Request {
     ///
     /// ```
     /// use http_types::convert::Deserialize;
-    /// use http_types::{Method, Request, Url};
+    /// use http_types::Request;
     /// use std::collections::HashMap;
     ///
     /// #[derive(Deserialize)]
@@ -621,10 +621,7 @@ impl Request {
     ///     selections: HashMap<String, String>,
     /// }
     ///
-    /// let req = Request::new(
-    ///     Method::Get,
-    ///     Url::parse("https://httpbin.org/get?page=2&selections[width]=narrow&selections[height]=tall").unwrap(),
-    /// );
+    /// let mut req = Request::get("https://httpbin.org/get?page=2&selections[width]=narrow&selections[height]=tall");
     /// let Index { page, selections } = req.query().unwrap();
     /// assert_eq!(page, 2);
     /// assert_eq!(selections["width"], "narrow");
@@ -648,7 +645,7 @@ impl Request {
     ///
     /// ```
     /// use http_types::convert::Serialize;
-    /// use http_types::{Method, Request, Url};
+    /// use http_types::{Method, Request};
     /// use std::collections::HashMap;
     ///
     /// #[derive(Serialize)]
@@ -658,10 +655,7 @@ impl Request {
     /// }
     ///
     /// let query = Index { page: 2, topics: vec!["rust", "crabs", "crustaceans"] };
-    /// let mut req = Request::new(
-    ///     Method::Get,
-    ///     Url::parse("https://httpbin.org/get").unwrap(),
-    /// );
+    /// let mut req = Request::get("https://httpbin.org/get");
     /// req.set_query(&query).unwrap();
     /// assert_eq!(req.url().query(), Some("page=2&topics[0]=rust&topics[1]=crabs&topics[2]=crustaceans"));
     /// ```
@@ -680,7 +674,7 @@ impl Request {
     /// # Examples
     ///
     /// ```
-    /// use http_types::{Method, Request, Url};
+    /// use http_types::{Method, Request};
     ///
     /// let mut req = Request::get("https://example.com");
     /// req.set_body("Hello, Nori!");
@@ -702,7 +696,7 @@ impl Request {
     /// # Examples
     ///
     /// ```
-    /// use http_types::{Method, Request, Url};
+    /// use http_types::{Method, Request};
     ///
     /// let mut req = Request::head("https://example.com");
     /// assert_eq!(req.method(), Method::Head);
@@ -723,7 +717,7 @@ impl Request {
     /// # Examples
     ///
     /// ```
-    /// use http_types::{Method, Request, Url};
+    /// use http_types::{Method, Request};
     ///
     /// let mut req = Request::post("https://example.com");
     /// assert_eq!(req.method(), Method::Post);
@@ -744,7 +738,7 @@ impl Request {
     /// # Examples
     ///
     /// ```
-    /// use http_types::{Method, Request, Url};
+    /// use http_types::{Method, Request};
     ///
     /// let mut req = Request::put("https://example.com");
     /// assert_eq!(req.method(), Method::Put);
@@ -764,7 +758,7 @@ impl Request {
     /// # Examples
     ///
     /// ```
-    /// use http_types::{Method, Request, Url};
+    /// use http_types::{Method, Request};
     ///
     /// let mut req = Request::delete("https://example.com");
     /// assert_eq!(req.method(), Method::Delete);
@@ -785,7 +779,7 @@ impl Request {
     /// # Examples
     ///
     /// ```
-    /// use http_types::{Method, Request, Url};
+    /// use http_types::{Method, Request};
     ///
     /// let mut req = Request::connect("https://example.com");
     /// assert_eq!(req.method(), Method::Connect);
@@ -806,7 +800,7 @@ impl Request {
     /// # Examples
     ///
     /// ```
-    /// use http_types::{Method, Request, Url};
+    /// use http_types::{Method, Request};
     ///
     /// let mut req = Request::options("https://example.com");
     /// assert_eq!(req.method(), Method::Options);
@@ -827,7 +821,7 @@ impl Request {
     /// # Examples
     ///
     /// ```
-    /// use http_types::{Method, Request, Url};
+    /// use http_types::{Method, Request};
     ///
     /// let mut req = Request::trace("https://example.com");
     /// assert_eq!(req.method(), Method::Trace);
@@ -847,7 +841,7 @@ impl Request {
     /// # Examples
     ///
     /// ```
-    /// use http_types::{Method, Request, Url};
+    /// use http_types::{Method, Request};
     ///
     /// let mut req = Request::patch("https://example.com");
     /// assert_eq!(req.method(), Method::Patch);

--- a/src/security/timing_allow_origin.rs
+++ b/src/security/timing_allow_origin.rs
@@ -308,12 +308,11 @@ mod test {
     }
 
     #[test]
-    fn bad_request_on_parse_error() -> crate::Result<()> {
+    fn bad_request_on_parse_error() {
         let mut headers = Headers::new();
         headers.insert(TIMING_ALLOW_ORIGIN, "server; <nori ate your param omnom>");
         let err = TimingAllowOrigin::from_headers(headers).unwrap_err();
         assert_eq!(err.status(), 400);
-        Ok(())
     }
 
     #[test]

--- a/src/status_code.rs
+++ b/src/status_code.rs
@@ -149,38 +149,32 @@ pub enum StatusCode {
     /// 400 Bad Request
     ///
     /// The server could not understand the request due to invalid syntax.
+    BadRequest = 400,
+
+    /// 401 Unauthorized
     ///
     /// Although the HTTP standard specifies "unauthorized", semantically this
     /// response means "unauthenticated". That is, the client must
     /// authenticate itself to get the requested response.
-    BadRequest = 400,
+    Unauthorized = 401,
 
-    /// 401 Unauthorized
+    /// 402 Payment Required
     ///
     /// This response code is reserved for future use. The initial aim for
     /// creating this code was using it for digital payment systems, however
     /// this status code is used very rarely and no standard convention
     /// exists.
-    Unauthorized = 401,
-
-    /// 402 Payment Required
-    ///
-    /// The client does not have access rights to the content; that is, it is
-    /// unauthorized, so the server is refusing to give the requested
-    /// resource. Unlike 401, the client's identity is known to the server.
     PaymentRequired = 402,
 
     /// 403 Forbidden
     ///
-    /// The server can not find requested resource. In the browser, this means
-    /// the URL is not recognized. In an API, this can also mean that the
-    /// endpoint is valid but the resource itself does not exist. Servers
-    /// may also send this response instead of 403 to hide the existence of
-    /// a resource from an unauthorized client. This response code is probably
-    /// the most famous one due to its frequent occurrence on the web.
+    /// The client does not have access rights to the content; that is, it is
+    /// unauthorized, so the server is refusing to give the requested
+    /// resource. Unlike 401, the client's identity is known to the server.
     Forbidden = 403,
 
     /// 404 Not Found
+    ///
     /// The server can not find requested resource. In the browser, this means
     /// the URL is not recognized. In an API, this can also mean that the
     /// endpoint is valid but the resource itself does not exist. Servers

--- a/src/trace/server_timing/mod.rs
+++ b/src/trace/server_timing/mod.rs
@@ -262,11 +262,10 @@ mod test {
     }
 
     #[test]
-    fn bad_request_on_parse_error() -> crate::Result<()> {
+    fn bad_request_on_parse_error() {
         let mut headers = Headers::new();
         headers.insert(SERVER_TIMING, "server; <nori ate your param omnom>");
         let err = ServerTiming::from_headers(headers).unwrap_err();
         assert_eq!(err.status(), 400);
-        Ok(())
     }
 }

--- a/src/trace/trace_context.rs
+++ b/src/trace/trace_context.rs
@@ -274,13 +274,12 @@ mod test {
     }
 
     #[test]
-    fn no_header() -> crate::Result<()> {
+    fn no_header() {
         let context = TraceContext::new();
         assert_eq!(context.version(), 0);
         assert_eq!(context.parent_id(), None);
         assert_eq!(context.flags, 1);
         assert_eq!(context.sampled(), true);
-        Ok(())
     }
 
     #[test]

--- a/src/transfer/encoding_proposal.rs
+++ b/src/transfer/encoding_proposal.rs
@@ -125,15 +125,14 @@ mod test {
     use super::*;
 
     #[test]
-    fn smoke() -> crate::Result<()> {
+    fn smoke() {
         let _ = EncodingProposal::new(Encoding::Gzip, Some(0.0)).unwrap();
         let _ = EncodingProposal::new(Encoding::Gzip, Some(0.5)).unwrap();
         let _ = EncodingProposal::new(Encoding::Gzip, Some(1.0)).unwrap();
-        Ok(())
     }
 
     #[test]
-    fn error_code_500() -> crate::Result<()> {
+    fn error_code_500() {
         let err = EncodingProposal::new(Encoding::Gzip, Some(1.1)).unwrap_err();
         assert_eq!(err.status(), 500);
 
@@ -142,6 +141,5 @@ mod test {
 
         let err = EncodingProposal::new(Encoding::Gzip, Some(-0.0)).unwrap_err();
         assert_eq!(err.status(), 500);
-        Ok(())
     }
 }

--- a/src/transfer/te.rs
+++ b/src/transfer/te.rs
@@ -109,7 +109,7 @@ impl TE {
         sort_by_weight(&mut self.entries);
     }
 
-    /// Determine the most suitable `Content-Type` encoding.
+    /// Determine the most suitable `Transfer-Encoding` encoding.
     ///
     /// # Errors
     ///
@@ -132,7 +132,7 @@ impl TE {
             }
         }
 
-        let mut err = Error::new_adhoc("No suitable ContentEncoding found");
+        let mut err = Error::new_adhoc("No suitable Transfer-Encoding found");
         err.set_status(StatusCode::NotAcceptable);
         Err(err)
     }

--- a/src/transfer/te.rs
+++ b/src/transfer/te.rs
@@ -37,6 +37,7 @@ use std::slice;
 /// #
 /// # Ok(()) }
 /// ```
+#[allow(clippy::upper_case_acronyms)]
 pub struct TE {
     wildcard: bool,
     entries: Vec<EncodingProposal>,

--- a/src/version.rs
+++ b/src/version.rs
@@ -68,21 +68,37 @@ impl<'de> Deserialize<'de> for Version {
     }
 }
 
-impl std::fmt::Display for Version {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.write_str(match self {
+impl AsRef<str> for Version {
+    fn as_ref(&self) -> &'static str {
+        match self {
             Version::Http0_9 => "HTTP/0.9",
             Version::Http1_0 => "HTTP/1.0",
             Version::Http1_1 => "HTTP/1.1",
             Version::Http2_0 => "HTTP/2",
             Version::Http3_0 => "HTTP/3",
-        })
+        }
+    }
+}
+
+impl std::fmt::Display for Version {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.as_ref())
     }
 }
 
 #[cfg(test)]
 mod test {
     use super::*;
+
+    #[test]
+    fn as_ref() {
+        assert_eq!(Version::Http0_9.as_ref(), "HTTP/0.9");
+        assert_eq!(Version::Http1_0.as_ref(), "HTTP/1.0");
+        assert_eq!(Version::Http1_1.as_ref(), "HTTP/1.1");
+        assert_eq!(Version::Http2_0.as_ref(), "HTTP/2");
+        assert_eq!(Version::Http3_0.as_ref(), "HTTP/3");
+    }
+
     #[test]
     fn to_string() {
         let output = format!(


### PR DESCRIPTION
Proposed changelog:

----

*`http-types` provides shared types for HTTP operations. It combines a performant, streaming interface with convenient methods for creating headers, urls, and other standard HTTP types. This is part of the `http-rs` project and powers the `tide` framework and `surf` client. Check out [the docs](https://docs.rs/http-types) or [join us on Zulip](https://http-rs.zulipchat.com/join/5phy5kfzfh6quhnlvtdspzrm/).*

## Highlights

This release represents continued support of the `http-types` 2.x release line due to delays in the development of `http-types` 3.0.0. This release comes with several convenience features, listed below.

The `http-types` 3.0 merge window remains open, and you can see the nominated items for the next major version [as part of the `Semver-Major` issue on GitHub](https://github.com/http-rs/http-types/labels/semver-major).

## Changed
- Allowed `Request.query()` to deserialize into a borrowed `Deserialize<'de>` rather than just `DeserializeOwned`. #333
    - This is a looser restriction and is not a breaking change. See [serde's documentation on the subject](https://serde.rs/lifetimes.html).

## Added
- More HTTP Methods from [the IANA registry](https://www.iana.org/assignments/http-methods/http-methods.xhtml). #332
- `Body::chain()` for merge multiple `Body` instances. #342, #346
- `AsRef<str> for Version`, returning `'static str`. #351
- `Error::from_debug()`, a helper for converting from `std::error::Error`s. #345
- `Error::from_display`, a helper for converting from `std::error::Error`s.  #345

## Fixed
- Corrected error messages for `Content-Encoding` and `Transfer-Encoding`. #354

## Docs
- Improved request examples with the `url`'s crate new `TryFrom<&str>`. #324
- 4xx status codes now have the right descriptions. #341
- Fixed for `Content-Encoding` and `Transfer-Encoding` docs. #354
