### PR TITLE
fix: append from hyperium translation

### DIFF
--- a/src/hyperium_http.rs
+++ b/src/hyperium_http.rs
@@ -61,7 +61,7 @@ fn hyperium_headers_to_headers(hyperium_headers: http::HeaderMap, headers: &mut 
         if let Some(name) = name {
             let name = name.as_str().as_bytes().to_owned();
             let name = unsafe { HeaderName::from_bytes_unchecked(name) };
-            headers.insert(name, value).unwrap();
+            headers.append(name, value);
         }
     }
 }


### PR DESCRIPTION
The opposite direction also uses hyperium's append, but (I think) this was written before that same functionality existed in http-types.

This is somewhat important for my use and I intend to make a 2.11.1 release with this.