### PR TITLE
Propose v2.11.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "http-types"
-version = "2.11.0"
+version = "2.11.1"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/http-rs/http-types"
 documentation = "https://docs.rs/http-types"

--- a/src/hyperium_http.rs
+++ b/src/hyperium_http.rs
@@ -61,7 +61,7 @@ fn hyperium_headers_to_headers(hyperium_headers: http::HeaderMap, headers: &mut 
         if let Some(name) = name {
             let name = name.as_str().as_bytes().to_owned();
             let name = unsafe { HeaderName::from_bytes_unchecked(name) };
-            headers.insert(name, value).unwrap();
+            headers.append(name, value);
         }
     }
 }


### PR DESCRIPTION
Proposed changelog:

----

*`http-types` provides shared types for HTTP operations. It combines a performant, streaming interface with convenient methods for creating headers, urls, and other standard HTTP types. This is part of the `http-rs` project and powers the `tide` framework and `surf` client. Check out [the docs](https://docs.rs/http-types) or [join us on Zulip](https://http-rs.zulipchat.com/join/5phy5kfzfh6quhnlvtdspzrm/).*

## Highlights

This release fixes an unconditional panic in the `hyperium_http` compatibility feature.

The `http-types` 3.0 merge window remains open, and you can see the nominated items for the next major version [as part of the `Semver-Major` issue on GitHub](https://github.com/http-rs/http-types/labels/semver-major).

## Fixed
- `hyperium_http`: Avoids unconditional panic when translating headers from hyperium. #359
