### PR TITLE
Implement `Status` for `Result<T, http_types::Error>`

### DIFF
--- a/src/cache/age.rs
+++ b/src/cache/age.rs
@@ -62,7 +62,7 @@ impl Age {
         // entry. We want the last entry.
         let header = headers.iter().last().unwrap();
 
-        let num: u64 = header.as_str().parse().status(400)?;
+        let num: u64 = header.as_str().parse::<u64>().status(400)?;
         let dur = Duration::from_secs_f64(num as f64);
 
         Ok(Some(Self { dur }))

--- a/src/cache/cache_control/cache_directive.rs
+++ b/src/cache/cache_control/cache_directive.rs
@@ -94,7 +94,7 @@ impl CacheDirective {
 
         let mut get_dur = || -> crate::Result<Duration> {
             let dur = parts.next().status(400)?;
-            let dur: u64 = dur.parse().status(400)?;
+            let dur: u64 = dur.parse::<u64>().status(400)?;
             Ok(Duration::new(dur, 0))
         };
 
@@ -112,7 +112,7 @@ impl CacheDirective {
             "max-age" => Some(MaxAge(get_dur()?)),
             "max-stale" => match parts.next() {
                 Some(secs) => {
-                    let dur: u64 = secs.parse().status(400)?;
+                    let dur: u64 = secs.parse::<u64>().status(400)?;
                     Some(MaxStale(Some(Duration::new(dur, 0))))
                 }
                 None => Some(MaxStale(None)),

--- a/src/content/content_length.rs
+++ b/src/content/content_length.rs
@@ -47,7 +47,7 @@ impl ContentLength {
         // If we successfully parsed the header then there's always at least one
         // entry. We want the last entry.
         let value = headers.iter().last().unwrap();
-        let length = value.as_str().trim().parse().status(400)?;
+        let length = value.as_str().trim().parse::<u64>().status(400)?;
         Ok(Some(Self { length }))
     }
 

--- a/src/status.rs
+++ b/src/status.rs
@@ -71,6 +71,48 @@ where
     }
 }
 
+impl<T> Status<T, Error> for Result<T, Error> {
+    /// Wrap the error value with an additional status code.
+    ///
+    /// # Panics
+    ///
+    /// Panics if [`Status`][status] is not a valid [`StatusCode`][statuscode].
+    ///
+    /// [status]: crate::Status
+    /// [statuscode]: crate::StatusCode
+    fn status<S>(self, status: S) -> Result<T, Error>
+    where
+        S: TryInto<StatusCode>,
+        S::Error: Debug,
+    {
+        self.map_err(|mut error| {
+            error.set_status(status);
+            error
+        })
+    }
+
+    /// Wrap the error value with an additional status code that is evaluated
+    /// lazily only once an error does occur.
+    ///
+    /// # Panics
+    ///
+    /// Panics if [`Status`][status] is not a valid [`StatusCode`][statuscode].
+    ///
+    /// [status]: crate::Status
+    /// [statuscode]: crate::StatusCode
+    fn with_status<S, F>(self, f: F) -> Result<T, Error>
+    where
+        S: TryInto<StatusCode>,
+        S::Error: Debug,
+        F: FnOnce() -> S,
+    {
+        self.map_err(|mut error| {
+            error.set_status(f());
+            error
+        })
+    }
+}
+
 impl<T> Status<T, Infallible> for Option<T> {
     /// Wrap the error value with an additional status code.
     ///


### PR DESCRIPTION
It will be very convenient if I can use `Status` trait for `Result<T, http_types::Error>` to replace StatusCode.

For example, (in tide)

```rust
let body = request.body_json().await.map_err(|mut e| {e.set_status(StatusCode::BadRequest); e})?;
let data = some_function(body).status(StatusCode::NotFound)?;
```

...will become:

```rust
let body = request.body_json().await.status(StatusCode::BadRequest)?;
let data = some_function(body).status(StatusCode::NotFound)?;
```