### PR TITLE
Update serde-qs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,7 +49,7 @@ cookie = { version = "0.14.0", features = ["percent-encode"], optional = true }
 serde_json = { version = "1.0.51", optional = true }
 serde_crate = { version = "1.0.106", features = ["derive"], optional = true, package = "serde" }
 serde_urlencoded = { version = "0.7.0", optional = true}
-serde_qs = { version = "0.7.0", optional = true }
+serde_qs = { version = "0.8.3", optional = true }
 
 
 [dev-dependencies]


### PR DESCRIPTION
`serde-qs` is updated to `0.8`, so it would be great if `http-types` use latest `serde-qs`.

For my case, I needed [https://github.com/samscott89/serde_qs/commit/b7b2520107ecfca77520151c6dc3002442bf0f0b](this commit) to encode query correctly.

Currently, I'm using this workaround:

```
pub fn set_query<Req>(req: Req, query: &impl serde::Serialize) -> http_types::Result<Req>
where
    Req: Into<http_types::Request> + From<http_types::Request>,
{
    let mut req: Request = req.into();
    let query = serde_qs::to_string(query)
        .map_err(|e| http_types::Error::from_str(StatusCode::BadRequest, format!("{}", e)))?;
    req.url_mut().set_query(Some(&query));
    Ok(req.into())
}
```