### PR TITLE
Expose reference of inner anyhow error

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -238,3 +238,9 @@ impl From<Error> for Box<dyn StdError + 'static> {
         Box::<dyn StdError + Send + Sync>::from(error.error)
     }
 }
+
+impl AsRef<anyhow::Error> for Error {
+    fn as_ref(&self) -> &anyhow::Error {
+        &self.error
+    }
+}


### PR DESCRIPTION
It would be great if `http_types::Error` exposes the reference of inner `anyhow::Error`.

Especially, when using `backtrace` feature of `anyhow` in stable rust, I cannot get backtraces without losing status and `type_name` information. But if I can get the reference of `anyhow::Error`, I can without losing information.