### PR TITLE
feat: add TryFrom impl for HeaderName, HeaderValue, and Headers

### DIFF
--- a/src/headers/header_values.rs
+++ b/src/headers/header_values.rs
@@ -146,6 +146,7 @@ impl AsMut<HeaderValue> for HeaderValues {
         &mut self.inner[0]
     }
 }
+
 impl Deref for HeaderValues {
     type Target = HeaderValue;
 
@@ -167,6 +168,22 @@ impl<'a> IntoIterator for &'a HeaderValues {
     #[inline]
     fn into_iter(self) -> Self::IntoIter {
         self.iter()
+    }
+}
+
+impl From<Vec<HeaderValue>> for HeaderValues {
+    fn from(headers: Vec<HeaderValue>) -> Self {
+        Self { inner: headers }
+    }
+}
+
+impl IntoIterator for HeaderValues {
+    type Item = HeaderValue;
+    type IntoIter = std::vec::IntoIter<HeaderValue>;
+
+    #[inline]
+    fn into_iter(self) -> Self::IntoIter {
+        self.inner.into_iter()
     }
 }
 

--- a/src/hyperium_http.rs
+++ b/src/hyperium_http.rs
@@ -1,8 +1,8 @@
 // This is the compat file for the "hyperium/http" crate.
 
 use crate::headers::{HeaderName, HeaderValue, Headers};
-use crate::{Body, Method, Request, Response, StatusCode, Url, Version};
-use std::convert::TryFrom;
+use crate::{Body, Error, Method, Request, Response, StatusCode, Url, Version};
+use std::convert::{TryFrom, TryInto};
 use std::str::FromStr;
 
 impl From<http::Method> for Method {
@@ -51,6 +51,92 @@ impl From<Version> for http::Version {
             Version::Http2_0 => http::Version::HTTP_2,
             Version::Http3_0 => http::Version::HTTP_3,
         }
+    }
+}
+
+impl TryFrom<http::header::HeaderName> for HeaderName {
+    type Error = Error;
+
+    fn try_from(name: http::header::HeaderName) -> Result<Self, Self::Error> {
+        let name = name.as_str().as_bytes().to_owned();
+        HeaderName::from_bytes(name)
+    }
+}
+
+impl TryFrom<HeaderName> for http::header::HeaderName {
+    type Error = Error;
+
+    fn try_from(name: HeaderName) -> Result<Self, Self::Error> {
+        let name = name.as_str().as_bytes();
+        http::header::HeaderName::from_bytes(name).map_err(|e| Error::new_adhoc(e))
+    }
+}
+
+impl TryFrom<http::header::HeaderValue> for HeaderValue {
+    type Error = Error;
+
+    fn try_from(value: http::header::HeaderValue) -> Result<Self, Self::Error> {
+        let value = value.as_bytes().to_owned();
+        HeaderValue::from_bytes(value)
+    }
+}
+
+impl TryFrom<HeaderValue> for http::header::HeaderValue {
+    type Error = Error;
+
+    fn try_from(value: HeaderValue) -> Result<Self, Self::Error> {
+        let value = value.as_str().as_bytes();
+        http::header::HeaderValue::from_bytes(value).map_err(|e| Error::new_adhoc(e))
+    }
+}
+
+impl TryFrom<http::HeaderMap> for Headers {
+    type Error = Error;
+
+    fn try_from(hyperium_headers: http::HeaderMap) -> Result<Self, Self::Error> {
+        let mut headers = Headers::new();
+
+        hyperium_headers
+            .into_iter()
+            .map(|(name, value)| {
+                if let Some(name) = name {
+                    let value: HeaderValue = value.try_into()?;
+                    let name: HeaderName = name.try_into()?;
+                    headers.append(name, value);
+                }
+                Ok(())
+            })
+            .collect::<Result<Vec<()>, Error>>()?;
+
+        Ok(headers)
+    }
+}
+
+impl TryFrom<Headers> for http::HeaderMap {
+    type Error = Error;
+
+    fn try_from(headers: Headers) -> Result<Self, Self::Error> {
+        let mut hyperium_headers = http::HeaderMap::new();
+
+        headers
+            .into_iter()
+            .map(|(name, values)| {
+                let name: http::header::HeaderName = name.try_into()?;
+
+                values
+                    .into_iter()
+                    .map(|value| {
+                        let value: http::header::HeaderValue = value.try_into()?;
+                        hyperium_headers.append(&name, value);
+                        Ok(())
+                    })
+                    .collect::<Result<Vec<()>, Error>>()?;
+
+                Ok(())
+            })
+            .collect::<Result<Vec<()>, Error>>()?;
+
+        Ok(hyperium_headers)
     }
 }
 


### PR DESCRIPTION
This PR includes additional utilities for converting between this lib's types and hyperium/http. Since `hyperium_headers_to_headers` and `headers_to_hyperium_headers` both use references rather than values, I've left them as-is instead of using the TryFrom impl.

closes #356 