### PR TITLE
Fix canonical reason for 304 Not Modified

### DIFF
--- a/src/status_code.rs
+++ b/src/status_code.rs
@@ -484,7 +484,7 @@ impl StatusCode {
             StatusCode::MovedPermanently => "Moved Permanently",
             StatusCode::Found => "Found",
             StatusCode::SeeOther => "See Other",
-            StatusCode::NotModified => "Modified",
+            StatusCode::NotModified => "Not Modified",
             StatusCode::TemporaryRedirect => "Temporary Redirect",
             StatusCode::PermanentRedirect => "Permanent Redirect",
             StatusCode::BadRequest => "Bad Request",


### PR DESCRIPTION
Saw it in a Tide log.