### PR TITLE
Fix correct default weight in media_type_propose

### DIFF
--- a/src/content/accept.rs
+++ b/src/content/accept.rs
@@ -362,9 +362,9 @@ mod test {
         let mut accept = Accept::from_headers(headers)?.unwrap();
         accept.sort();
         let mut accept = accept.iter();
+        assert_eq!(accept.next().unwrap(), mime::XML);
         assert_eq!(accept.next().unwrap(), mime::PLAIN);
         assert_eq!(accept.next().unwrap(), mime::HTML);
-        assert_eq!(accept.next().unwrap(), mime::XML);
         Ok(())
     }
 
@@ -381,9 +381,9 @@ mod test {
         let mut accept = Accept::from_headers(res)?.unwrap();
         accept.sort();
         let mut accept = accept.iter();
-        assert_eq!(accept.next().unwrap(), mime::PLAIN);
         assert_eq!(accept.next().unwrap(), mime::XML);
         assert_eq!(accept.next().unwrap(), mime::HTML);
+        assert_eq!(accept.next().unwrap(), mime::PLAIN);
         Ok(())
     }
 
@@ -394,7 +394,7 @@ mod test {
         accept.push(MediaTypeProposal::new(mime::PLAIN, Some(0.8))?);
         accept.push(MediaTypeProposal::new(mime::XML, None)?);
 
-        assert_eq!(accept.negotiate(&[mime::HTML, mime::XML])?, mime::HTML);
+        assert_eq!(accept.negotiate(&[mime::HTML, mime::XML])?, mime::XML);
         Ok(())
     }
 

--- a/src/content/media_type_proposal.rs
+++ b/src/content/media_type_proposal.rs
@@ -29,6 +29,12 @@ impl MediaTypeProposal {
                 "MediaTypeProposal should have a weight between 0.0 and 1.0"
             )
         }
+        if weight.is_none() {
+            return Ok(Self {
+                media_type: media_type.into(),
+                weight: Some(1.0),
+            });
+        }
 
         Ok(Self {
             media_type: media_type.into(),


### PR DESCRIPTION
Fixes #362 
https://tools.ietf.org/html/rfc7231#section-5.3.1
refers that default weight value is 1.0. So, I fixed if weight in media_type_propose is None, it applies default value.