### PR TITLE
Make 'mime' field in Body optional

### DIFF
--- a/src/body.rs
+++ b/src/body.rs
@@ -483,11 +483,11 @@ impl Body {
     /// # Examples
     /// ```
     /// use http_types::Body;
-    /// use http_types::mime::self;
+    /// use http_types::mime;
     ///
-    /// let mut body = Body::default();
-    /// body.set_mime(Some(mime::CSS));
-    /// assert_eq!(*body.mime(), mime::CSS);
+    /// let mut body = Body::empty();
+    /// body.set_mime(mime::CSS);
+    /// assert_eq!(body.mime(), Some(&mime::CSS));
     /// ```
     pub fn set_mime(&mut self, mime: impl Into<Mime>) {
         self.mime = Some(mime.into());
@@ -500,7 +500,7 @@ impl Body {
     /// use http_types::Body;
     /// use http_types::mime;
     ///
-    /// let mut body = Body::default();
+    /// let mut body = Body::empty();
     /// assert!(body.mime().is_some());
     ///
     /// body.unset_mime();

--- a/src/body.rs
+++ b/src/body.rs
@@ -486,29 +486,14 @@ impl Body {
     /// use http_types::mime;
     ///
     /// let mut body = Body::empty();
-    /// body.set_mime(mime::CSS);
+    /// body.set_mime(Some(mime::CSS));
     /// assert_eq!(body.mime(), Some(&mime::CSS));
+    ///
+    /// body.set_mime(None);
+    /// assert_eq!(body.mime(), None);
     /// ```
-    pub fn set_mime(&mut self, mime: impl Into<Mime>) {
-        self.mime = Some(mime.into());
-    }
-
-    /// Unsets the mime type of this Body.
-    ///
-    /// # Examples
-    /// ```
-    /// use http_types::Body;
-    /// use http_types::mime;
-    ///
-    /// let mut body = Body::empty();
-    /// assert!(body.mime().is_some());
-    ///
-    /// body.unset_mime();
-    /// assert!(body.mime().is_none());
-    /// ```
-    ///
-    pub fn unset_mime(&mut self) {
-        self.mime = None
+    pub fn set_mime(&mut self, mime: Option<Mime>) {
+        self.mime = mime;
     }
 
     /// Create a Body by chaining another Body after this one, consuming both.

--- a/src/request.rs
+++ b/src/request.rs
@@ -478,7 +478,9 @@ impl Request {
     /// Copy MIME data from the body.
     fn copy_content_type_from_body(&mut self) {
         if self.header(CONTENT_TYPE).is_none() {
-            self.set_content_type(self.body.mime().clone());
+            if let Some(mime) = self.body.mime().cloned() {
+                self.set_content_type(mime);
+            }
         }
     }
 

--- a/src/response.rs
+++ b/src/response.rs
@@ -383,7 +383,9 @@ impl Response {
     /// Copy MIME data from the body.
     fn copy_content_type_from_body(&mut self) {
         if self.header(CONTENT_TYPE).is_none() {
-            self.set_content_type(self.body.mime().clone());
+            if let Some(mime) = self.body.mime().cloned() {
+                self.set_content_type(mime);
+            }
         }
     }
 


### PR DESCRIPTION
This does not seem like the ideal way to do this since Option have to be
parameterized with a type, see the introduced example code for specific
example.

I see a couple of alternatives:
 - Add a method for unsetting the mime type
 - Clearly document what mime type is the "no mime type". This should
   possibly be part of an example above set_mime

The first as a semver minor change, and the second is a semver patch
change.

A solution to #381 