### PR TITLE
attempt to fix duration parsing

### DIFF
--- a/src/trace/server_timing/parse.rs
+++ b/src/trace/server_timing/parse.rs
@@ -65,7 +65,7 @@ fn parse_entry(s: &str) -> crate::Result<Metric> {
                 let millis: f64 = value.parse().map_err(|_| {
                         format_err!("Server timing duration params must be a valid double-precision floating-point number.")
                     })?;
-                dur = Some(Duration::from_secs_f64(millis / 1000.0));
+                dur = Some(Duration::from_secs_f64(millis) / 1000);
             }
             "desc" => {
                 // Ensure quotes line up, and strip them from the resulting output


### PR DESCRIPTION
I haven't been able to reproduce the CI failure locally, but trying this to see if it helps fix the number rounding issue.