### PR TITLE
Update serde_qs to 0.9.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,7 +49,7 @@ cookie = { version = "0.16.0", features = ["percent-encode"], optional = true }
 serde_json = { version = "1.0.51", optional = true }
 serde_crate = { version = "1.0.106", features = ["derive"], optional = true, package = "serde" }
 serde_urlencoded = { version = "0.7.0", optional = true}
-serde_qs = { version = "0.8.3", optional = true }
+serde_qs = { version = "0.9.1", optional = true }
 
 
 [dev-dependencies]

--- a/tests/querystring.rs
+++ b/tests/querystring.rs
@@ -32,10 +32,7 @@ fn unsuccessfully_deserialize_query() {
 
     let params = req.query::<Params>();
     assert!(params.is_err());
-    assert_eq!(
-        params.err().unwrap().to_string(),
-        "failed with reason: missing field `msg`"
-    );
+    assert_eq!(params.err().unwrap().to_string(), "missing field `msg`");
 }
 
 #[test]
@@ -47,10 +44,7 @@ fn malformatted_query() {
 
     let params = req.query::<Params>();
     assert!(params.is_err());
-    assert_eq!(
-        params.err().unwrap().to_string(),
-        "failed with reason: missing field `msg`"
-    );
+    assert_eq!(params.err().unwrap().to_string(), "missing field `msg`");
 }
 
 #[test]


### PR DESCRIPTION
I am trying to package this crate for Fedora and came across the slightly outdated version of `serde_qs`.