### PR TITLE
Change MIME-Type of javascript

### DIFF
--- a/src/mime/constants.rs
+++ b/src/mime/constants.rs
@@ -52,7 +52,7 @@ macro_rules! mime_const {
     };
 }
 
-utf8_mime_const!(JAVASCRIPT, "JavaScript", "application", "javascript");
+utf8_mime_const!(JAVASCRIPT, "JavaScript", "text", "javascript");
 utf8_mime_const!(CSS, "CSS", "text", "css");
 utf8_mime_const!(HTML, "HTML", "text", "html");
 utf8_mime_const!(PLAIN, "Plain text", "text", "plain");


### PR DESCRIPTION
* it recommends MIME Type for javascript is `text/javascript`
* see RFC 9239

update mime-type for .js to text/javascript align with [RFC9239](https://www.rfc-editor.org/rfc/rfc9239#section-6.2.1-3.6)

`The current implementations should use text/javascript as the only JavaScript/ECMAScript media type`